### PR TITLE
feat: add accesibility prompt flow with tcc reset

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -35,11 +35,24 @@ func Run(cfg *config.Config, logger *zap.SugaredLogger, configPath string) error
 	defer removePID(cfg.Settings.PIDFile)
 
 	perm := permissions.Check()
+
+	var accessibilityPrompt func() bool
+	if !perm.Accessibility {
+		accessibilityPrompt = func() bool {
+			choice := permissions.ShowAccessibilityStartupAlert()
+
+			return choice != permissions.AccessibilityStartupQuit
+		}
+	}
+
+	if !cgo_bridge.Start(accessibilityPrompt) {
+		return nil
+	}
+
+	perm = permissions.Check()
 	if !perm.Accessibility {
 		logger.Warn("accessibility permission not granted — window events disabled")
 	}
-
-	cgo_bridge.Start()
 
 	bus := events.NewBus()
 	axMgr := observers.NewAccessibilityManager(perm.Accessibility)

--- a/internal/observers/cgo_bridge/bridge.go
+++ b/internal/observers/cgo_bridge/bridge.go
@@ -28,17 +28,26 @@ var eventCh = make(chan events.Event, eventChBufSize)
 func EventCh() <-chan events.Event { return eventCh }
 
 // Start initializes and starts all macOS event observers.
-func Start() {
+func Start(beforeRunLoop func() bool) bool {
 	// Lock to main OS thread to initialize NSApplication properly.
 	// NSWorkspace notifications require proper Cocoa initialization.
-	mainThread := make(chan struct{})
+	mainThread := make(chan bool)
 	go func() {
 		runtime.LockOSThread()
 		C.InitCocoaApp()
-		close(mainThread)
+
+		if beforeRunLoop != nil && !beforeRunLoop() {
+			mainThread <- false
+
+			return
+		}
+
+		mainThread <- true
 		C.WorkspaceObserverStart()
 	}()
-	<-mainThread
+	if !<-mainThread {
+		return false
+	}
 
 	// Start system observers
 	C.PowerObserverStart()
@@ -56,6 +65,8 @@ func Start() {
 		AppName: "mimi",
 		At:      time.Now(),
 	}
+
+	return true
 }
 
 // Stop stops all macOS event observers.

--- a/internal/permissions/check.go
+++ b/internal/permissions/check.go
@@ -1,13 +1,111 @@
 package permissions
 
 /*
-#cgo LDFLAGS: -framework ApplicationServices
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa -framework ApplicationServices
+#import <Cocoa/Cocoa.h>
 #include <ApplicationServices/ApplicationServices.h>
+
+static int MimiCheckAccessibilityPermissions(void) {
+	Boolean trusted = AXIsProcessTrusted();
+	return trusted ? 1 : 0;
+}
+
+static BOOL MimiResetAccessibilityPermissionDecision(void) {
+	NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+	if (bundleID == nil || [bundleID length] == 0) {
+		bundleID = @"com.y3owk1n.mimi";
+	}
+
+	NSTask *task = [[NSTask alloc] init];
+	task.launchPath = @"/usr/bin/tccutil";
+	task.arguments = @[ @"reset", @"Accessibility", bundleID ];
+
+	@try {
+		[task launch];
+		[task waitUntilExit];
+
+		int status = [task terminationStatus];
+		if (status != 0) {
+			NSLog(
+				@"Mimi: tccutil reset Accessibility %@ exited with status %d; system permission dialog may not appear",
+				bundleID, status);
+			return NO;
+		}
+	} @catch (NSException *exception) {
+		NSLog(@"Mimi: failed to reset Accessibility permission decision: %@", exception);
+		return NO;
+	}
+
+	return YES;
+}
+
+static int MimiRequestAccessibilityPermissions(void) {
+	@autoreleasepool {
+		if (!MimiResetAccessibilityPermissionDecision()) {
+			NSLog(@"Mimi: continuing with Accessibility permission request after reset failure");
+		}
+
+		NSDictionary *options = @{(__bridge id)kAXTrustedCheckOptionPrompt : @YES};
+		Boolean trusted = AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)options);
+		return trusted ? 1 : 0;
+	}
+}
+
+static int MimiShowAccessibilityPermissionStartupAlert(void) {
+	@autoreleasepool {
+		[NSApplication sharedApplication];
+
+		while (MimiCheckAccessibilityPermissions() != 1) {
+			NSAlert *alert = [[NSAlert alloc] init];
+			alert.messageText = @"Accessibility Permission Needed";
+			alert.informativeText =
+				@"Mimi needs Accessibility permission to receive window focus and title change events. "
+				@"Click Request Permission to open the macOS permission flow, grant access in System Settings, "
+				@"then return here and click Granted, Start Mimi.";
+			alert.alertStyle = NSAlertStyleWarning;
+			alert.icon = [NSImage imageNamed:NSImageNameCaution];
+
+			[alert addButtonWithTitle:@"Request Permission"];
+			[alert addButtonWithTitle:@"Granted, Start Mimi"];
+			[alert addButtonWithTitle:@"Quit"];
+
+			[[alert window] setLevel:NSFloatingWindowLevel];
+			[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+			[[alert window] center];
+			[[alert window] makeKeyAndOrderFront:nil];
+			[NSApp activateIgnoringOtherApps:YES];
+
+			NSModalResponse response = [alert runModal];
+			[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+			if (response == NSAlertFirstButtonReturn) {
+				MimiRequestAccessibilityPermissions();
+			} else if (response == NSAlertSecondButtonReturn) {
+				return 1;
+			} else if (response == NSAlertThirdButtonReturn) {
+				return 2;
+			}
+		}
+
+		return 1;
+	}
+}
 */
 import "C"
 
 import (
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// AccessibilityStartupChoice represents the user's choice in the startup permission alert.
+type AccessibilityStartupChoice int
+
+const (
+	// AccessibilityStartupGranted indicates accessibility permission is granted.
+	AccessibilityStartupGranted AccessibilityStartupChoice = 1
+	// AccessibilityStartupQuit indicates the user chose to quit.
+	AccessibilityStartupQuit AccessibilityStartupChoice = 2
 )
 
 // CheckResult holds the results of a permissions check.
@@ -18,7 +116,7 @@ type CheckResult struct {
 
 // Check verifies macOS accessibility permissions.
 func Check() CheckResult {
-	trusted := C.AXIsProcessTrusted() != 0
+	trusted := C.MimiCheckAccessibilityPermissions() != 0
 	res := CheckResult{Accessibility: trusted}
 	if !trusted {
 		res.AccessibilityMsg = `Accessibility permission is required for window focus events.
@@ -32,6 +130,16 @@ func Check() CheckResult {
 	}
 
 	return res
+}
+
+// RequestAccessibility asks macOS to start the accessibility permission flow.
+func RequestAccessibility() bool {
+	return C.MimiRequestAccessibilityPermissions() != 0
+}
+
+// ShowAccessibilityStartupAlert displays startup guidance for granting accessibility permission.
+func ShowAccessibilityStartupAlert() AccessibilityStartupChoice {
+	return AccessibilityStartupChoice(C.MimiShowAccessibilityPermissionStartupAlert())
 }
 
 // FriendlyError returns an error if accessibility permission is denied.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a prettier accessibility prompt request during startup.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
