### PR TITLE
feat: add config init prompt on startup

### DIFF
--- a/cmd/mimi/cmd/start.go
+++ b/cmd/mimi/cmd/start.go
@@ -7,6 +7,7 @@ import (
 	"github.com/y3owk1n/mimi/internal/daemon"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/logging"
+	"github.com/y3owk1n/mimi/internal/permissions"
 )
 
 var startCmd = &cobra.Command{
@@ -14,10 +15,17 @@ var startCmd = &cobra.Command{
 	Short: "Start the mimi daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !config.Exists(configPath) {
-			cmd.Printf("No config found at %s — creating with defaults.\n", configPath)
-			cmd.Println("Edit it to customize hooks, then run 'mimi start' again.")
+			choice := permissions.ShowConfigOnboardingAlert(configPath)
+			if choice == permissions.ConfigOnboardingQuit {
+				return nil
+			}
 
-			return config.WriteDefault(configPath)
+			err := config.WriteDefault(configPath)
+			if err != nil {
+				return err
+			}
+
+			cmd.Printf("Default config written to %s\n", configPath)
 		}
 
 		cfg, err := config.Load(configPath)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -30,7 +30,7 @@ Mimi provides a command-line interface for controlling the daemon, testing hooks
 
 ### `mimi start`
 
-Start the mimi daemon. If no config file exists, creates one with sensible defaults.
+Start the mimi daemon. If no config file exists, prompts to create one with sensible defaults or quit.
 
 ```bash
 mimi start                             # Start with auto-resolved config

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # Configuration Guide
 
-Mimi uses TOML for configuration. No config file is required — Mimi creates a sensible default on first `mimi start`. Only define the options you want to change.
+Mimi uses TOML for configuration. On first `mimi start`, Mimi prompts you to create a sensible default config or quit. Only define the options you want to change.
 
 ---
 
@@ -48,8 +48,8 @@ Config is resolved in this priority order (first match wins):
 2. `$XDG_CONFIG_HOME/mimi/config.toml` (if `$XDG_CONFIG_HOME` is set and file exists)
 3. `~/.config/mimi/config.toml` (if file exists)
 4. `./mimi.toml` (current directory)
-5. Falls back to `$XDG_CONFIG_HOME/mimi/config.toml` (creates if missing)
-6. Falls back to `~/.config/mimi/config.toml` (creates if missing)
+5. Falls back to `$XDG_CONFIG_HOME/mimi/config.toml` (prompts to create if missing)
+6. Falls back to `~/.config/mimi/config.toml` (prompts to create if missing)
 
 ---
 

--- a/internal/permissions/check.go
+++ b/internal/permissions/check.go
@@ -5,6 +5,7 @@ package permissions
 #cgo LDFLAGS: -framework Cocoa -framework ApplicationServices
 #import <Cocoa/Cocoa.h>
 #include <ApplicationServices/ApplicationServices.h>
+#include <stdlib.h>
 
 static int MimiCheckAccessibilityPermissions(void) {
 	Boolean trusted = AXIsProcessTrusted();
@@ -91,17 +92,62 @@ static int MimiShowAccessibilityPermissionStartupAlert(void) {
 		return 1;
 	}
 }
+
+static int MimiShowConfigOnboardingAlert(const char *configPath) {
+	@autoreleasepool {
+		[NSApplication sharedApplication];
+
+		NSString *path = configPath ? [NSString stringWithUTF8String:configPath] : @"~/.config/mimi/config.toml";
+
+		NSAlert *alert = [[NSAlert alloc] init];
+		alert.messageText = @"Welcome to Mimi";
+		alert.informativeText =
+			[NSString stringWithFormat:@"No configuration file found.\n\nCreate a starter config at:\n%@",
+			                           path];
+		alert.alertStyle = NSAlertStyleInformational;
+
+		[alert addButtonWithTitle:@"Create Config"];
+		[alert addButtonWithTitle:@"Quit"];
+
+		[[alert window] setLevel:NSFloatingWindowLevel];
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+		[[alert window] center];
+		[[alert window] makeKeyAndOrderFront:nil];
+		[NSApp activateIgnoringOtherApps:YES];
+
+		NSModalResponse response = [alert runModal];
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+		if (response == NSAlertFirstButtonReturn) {
+			return 1;
+		} else if (response == NSAlertSecondButtonReturn) {
+			return 2;
+		}
+
+		return 2;
+	}
+}
 */
 import "C"
 
 import (
+	"unsafe"
+
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
+
+// ConfigOnboardingChoice represents the user's choice in the config onboarding alert.
+type ConfigOnboardingChoice int
 
 // AccessibilityStartupChoice represents the user's choice in the startup permission alert.
 type AccessibilityStartupChoice int
 
 const (
+	// ConfigOnboardingCreate indicates the user chose to create a config file.
+	ConfigOnboardingCreate ConfigOnboardingChoice = 1
+	// ConfigOnboardingQuit indicates the user chose to quit.
+	ConfigOnboardingQuit ConfigOnboardingChoice = 2
+
 	// AccessibilityStartupGranted indicates accessibility permission is granted.
 	AccessibilityStartupGranted AccessibilityStartupChoice = 1
 	// AccessibilityStartupQuit indicates the user chose to quit.
@@ -135,6 +181,14 @@ func Check() CheckResult {
 // RequestAccessibility asks macOS to start the accessibility permission flow.
 func RequestAccessibility() bool {
 	return C.MimiRequestAccessibilityPermissions() != 0
+}
+
+// ShowConfigOnboardingAlert displays startup guidance for creating the first config file.
+func ShowConfigOnboardingAlert(configPath string) ConfigOnboardingChoice {
+	cPath := C.CString(configPath)
+	defer C.free(unsafe.Pointer(cPath)) //nolint:nlreturn
+
+	return ConfigOnboardingChoice(C.MimiShowConfigOnboardingAlert(cPath))
 }
 
 // ShowAccessibilityStartupAlert displays startup guidance for granting accessibility permission.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a configuration init prompt if there's no config file found on startup.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
