### PR TITLE
fix: optimise memory allocation and prevent leak

### DIFF
--- a/internal/observers/cgo_bridge/bridge.go
+++ b/internal/observers/cgo_bridge/bridge.go
@@ -1,7 +1,7 @@
 package cgo_bridge
 
 /*
-#cgo CFLAGS: -x objective-c
+#cgo CFLAGS: -x objective-c -fobjc-arc
 #cgo LDFLAGS: -framework Cocoa -framework ApplicationServices -framework IOKit -framework CoreAudio -framework SystemConfiguration
 
 #include "workspace.h"
@@ -42,20 +42,22 @@ func Start(beforeRunLoop func() bool) bool {
 			return
 		}
 
+		C.InitBridgeRunLoop()
+		// Run-loop-backed observers must be created on the same locked thread
+		// that owns the Cocoa run loop below.
+		C.PowerObserverStart()
+		C.AudioObserverStart()
+		C.ClipboardObserverStart()
+		C.USBObserverStart()
+		C.NetworkObserverStart()
+		C.DisplayObserverStart()
+
 		mainThread <- true
 		C.WorkspaceObserverStart()
 	}()
 	if !<-mainThread {
 		return false
 	}
-
-	// Start system observers
-	C.PowerObserverStart()
-	C.AudioObserverStart()
-	C.ClipboardObserverStart()
-	C.USBObserverStart()
-	C.NetworkObserverStart()
-	C.DisplayObserverStart()
 
 	// Push a synthetic startup event as a proof-of-life for the pipeline.
 	// Its kind ("_startup_") won't match any user hook.

--- a/internal/observers/cgo_bridge/system_events.m
+++ b/internal/observers/cgo_bridge/system_events.m
@@ -1,6 +1,7 @@
 #import "system_events.h"
 
 #include "_cgo_export.h"
+#import "workspace.h"
 
 #import <Cocoa/Cocoa.h>
 #import <CoreAudio/CoreAudio.h>
@@ -9,6 +10,22 @@
 #import <IOKit/ps/IOPowerSources.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 #import <netinet/in.h>
+
+static void runOnBridgeRunLoopSync(void (^block)(void)) {
+	CFRunLoopRef rl = GetRunLoop();
+	if (!rl || CFRunLoopGetCurrent() == rl) {
+		block();
+		return;
+	}
+
+	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+	CFRunLoopPerformBlock(rl, kCFRunLoopDefaultMode, ^{
+		block();
+		dispatch_semaphore_signal(sem);
+	});
+	CFRunLoopWakeUp(rl);
+	dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+}
 
 #pragma mark - Power/Battery Observer
 
@@ -130,10 +147,12 @@ void PowerObserverStart(void) {
 }
 
 void PowerObserverStop(void) {
-	if (gPowerObserver) {
-		[gPowerObserver stopObserving];
-		gPowerObserver = nil;
-	}
+	runOnBridgeRunLoopSync(^{
+		if (gPowerObserver) {
+			[gPowerObserver stopObserving];
+			gPowerObserver = nil;
+		}
+	});
 }
 
 #pragma mark - Audio Device Observer
@@ -218,10 +237,12 @@ void ClipboardObserverStart(void) {
 }
 
 void ClipboardObserverStop(void) {
-	if (gClipboardObserver) {
-		[gClipboardObserver stopObserving];
-		gClipboardObserver = nil;
-	}
+	runOnBridgeRunLoopSync(^{
+		if (gClipboardObserver) {
+			[gClipboardObserver stopObserving];
+			gClipboardObserver = nil;
+		}
+	});
 }
 
 #pragma mark - USB/Peripheral Observer
@@ -316,10 +337,12 @@ void USBObserverStart(void) {
 }
 
 void USBObserverStop(void) {
-	if (gUSBObserver) {
-		[gUSBObserver stopObserving];
-		gUSBObserver = nil;
-	}
+	runOnBridgeRunLoopSync(^{
+		if (gUSBObserver) {
+			[gUSBObserver stopObserving];
+			gUSBObserver = nil;
+		}
+	});
 }
 
 #pragma mark - Network Observer
@@ -400,10 +423,12 @@ void NetworkObserverStart(void) {
 }
 
 void NetworkObserverStop(void) {
-	if (gNetworkObserver) {
-		[gNetworkObserver stopObserving];
-		gNetworkObserver = nil;
-	}
+	runOnBridgeRunLoopSync(^{
+		if (gNetworkObserver) {
+			[gNetworkObserver stopObserving];
+			gNetworkObserver = nil;
+		}
+	});
 }
 
 #pragma mark - Display Observer

--- a/internal/observers/cgo_bridge/workspace.h
+++ b/internal/observers/cgo_bridge/workspace.h
@@ -6,6 +6,8 @@
 // NSWorkspace notifications.
 void InitCocoaApp(void);
 
+void InitBridgeRunLoop(void);
+
 void WorkspaceObserverStart(void);
 
 void WorkspaceObserverStop(void);

--- a/internal/observers/cgo_bridge/workspace.m
+++ b/internal/observers/cgo_bridge/workspace.m
@@ -24,6 +24,9 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 - (NSSet *)currentWindowIDs {
 	CFArrayRef windowList = CGWindowListCopyWindowInfo(
 	    kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+	if (!windowList)
+		return [NSSet set];
+
 	NSMutableSet *ids = [NSMutableSet setWithCapacity:CFArrayGetCount(windowList)];
 	for (NSDictionary *info in (__bridge NSArray *)windowList) {
 		NSNumber *winID = info[(__bridge NSString *)kCGWindowNumber];
@@ -37,11 +40,17 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 - (NSArray *)currentWindowList {
 	CFArrayRef windowList = CGWindowListCopyWindowInfo(
 	    kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
-	return (NSArray *)windowList;
+	if (!windowList)
+		return nil;
+
+	return CFBridgingRelease(windowList);
 }
 
 - (NSString *)windowInfoJSON {
 	NSArray *windows = [self currentWindowList];
+	if (!windows)
+		return @"";
+
 	NSInteger totalCount = [windows count];
 	NSMutableArray *items = [NSMutableArray arrayWithCapacity:totalCount];
 	NSInteger realCount = 0;
@@ -71,7 +80,6 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 			@"h" : @(h),
 		}];
 	}
-	CFRelease((CFArrayRef)windows);
 
 	NSDictionary *payload = @{
 		@"total_count" : @(totalCount),
@@ -174,9 +182,11 @@ void InitCocoaApp(void) {
 	}
 }
 
+void InitBridgeRunLoop(void) { atomic_store(&gRunLoop, CFRunLoopGetCurrent()); }
+
 void WorkspaceObserverStart(void) {
 	@autoreleasepool {
-		atomic_store(&gRunLoop, CFRunLoopGetCurrent());
+		InitBridgeRunLoop();
 		gObserver = [[WorkspaceObserver alloc] init];
 		[gObserver startObserving];
 
@@ -192,12 +202,36 @@ void WorkspaceObserverStart(void) {
 }
 
 void WorkspaceObserverStop(void) {
-	if (gObserver) {
-		[gObserver.spacePollTimer invalidate];
-		gObserver.spacePollTimer = nil;
-		NSNotificationCenter *wsnc = [[NSWorkspace sharedWorkspace] notificationCenter];
-		[wsnc removeObserver:gObserver];
-		[[NSDistributedNotificationCenter defaultCenter] removeObserver:gObserver];
+	CFRunLoopRef rl = GetRunLoop();
+	if (!rl)
+		return;
+
+	if (CFRunLoopGetCurrent() == rl) {
+		if (gObserver) {
+			[gObserver.spacePollTimer invalidate];
+			gObserver.spacePollTimer = nil;
+			NSNotificationCenter *wsnc = [[NSWorkspace sharedWorkspace] notificationCenter];
+			[wsnc removeObserver:gObserver];
+			[[NSDistributedNotificationCenter defaultCenter] removeObserver:gObserver];
+			gObserver = nil;
+		}
+		CFRunLoopStop(rl);
+		return;
 	}
-	CFRunLoopStop(CFRunLoopGetCurrent());
+
+	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+	CFRunLoopPerformBlock(rl, kCFRunLoopDefaultMode, ^{
+		if (gObserver) {
+			[gObserver.spacePollTimer invalidate];
+			gObserver.spacePollTimer = nil;
+			NSNotificationCenter *wsnc = [[NSWorkspace sharedWorkspace] notificationCenter];
+			[wsnc removeObserver:gObserver];
+			[[NSDistributedNotificationCenter defaultCenter] removeObserver:gObserver];
+			gObserver = nil;
+		}
+		CFRunLoopStop(rl);
+		dispatch_semaphore_signal(sem);
+	});
+	CFRunLoopWakeUp(rl);
+	dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR slightly improves the memory performance of mimi:

- Enabled ARC for the permissions and observer cgo packages to avoid Objective-C object lifetime leaks.
- Fixed observer threading so run-loop-backed observers start on the locked Cocoa thread in `bridge.go`.
- Fixed shutdown to cleanup observers on the bridge run loop before stopping it in `workspace.m` and `system_events.m`.
- Tightened CoreFoundation ownership around window-list handling.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
