### PR TITLE
fix: run permission alerts on main thread + headless Cocoa loop without systray

### DIFF
--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -19,20 +19,12 @@ func runWithHost(
 	configPath string,
 	version string,
 ) error {
-	if !cfg.Systray.Enabled {
-		return runCore(cfg, logger, configPath, nil)
-	}
+	var (
+		quitCh    <-chan struct{}
+		component *systray.Component
+	)
 
-	quitCh := make(chan struct{})
 	runDone := make(chan error, 1)
-
-	requestQuit := func() {
-		select {
-		case <-quitCh:
-		default:
-			close(quitCh)
-		}
-	}
 
 	reload := func(ctx context.Context, path string) error {
 		process, err := os.FindProcess(os.Getpid())
@@ -43,7 +35,20 @@ func runWithHost(
 		return process.Signal(syscall.SIGHUP)
 	}
 
-	component := systray.NewComponent(version, configPath, reload, requestQuit, logger)
+	if cfg.Systray.Enabled {
+		quitChWritable := make(chan struct{})
+		quitCh = quitChWritable
+
+		requestQuit := func() {
+			select {
+			case <-quitChWritable:
+			default:
+				close(quitChWritable)
+			}
+		}
+
+		component = systray.NewComponent(version, configPath, reload, requestQuit, logger)
+	}
 
 	go func() {
 		err := runCore(cfg, logger, configPath, quitCh)
@@ -53,8 +58,12 @@ func runWithHost(
 		runDone <- err
 	}()
 
-	systray.Run(component.OnReady, component.OnExit)
-	component.Close()
+	if cfg.Systray.Enabled {
+		systray.Run(component.OnReady, component.OnExit)
+		component.Close()
+	} else {
+		systray.RunHeadless(func() {}, func() {})
+	}
 
 	return <-runDone
 }

--- a/internal/permissions/permissions.m
+++ b/internal/permissions/permissions.m
@@ -3,6 +3,17 @@
 #import <ApplicationServices/ApplicationServices.h>
 #import <Cocoa/Cocoa.h>
 
+static int MimiRunOnMainThreadSync(int (^block)(void)) {
+	if ([NSThread isMainThread]) {
+		return block();
+	}
+	__block int result = 0;
+	dispatch_sync(dispatch_get_main_queue(), ^{
+		result = block();
+	});
+	return result;
+}
+
 static int MimiResetAccessibilityPermissionDecision(void) {
 	NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
 	if (bundleID == nil || [bundleID length] == 0) {
@@ -50,21 +61,63 @@ int MimiRequestAccessibilityPermissions(void) {
 }
 
 int MimiShowAccessibilityPermissionStartupAlert(void) {
-	@autoreleasepool {
-		[NSApplication sharedApplication];
+	return MimiRunOnMainThreadSync(^int{
+		@autoreleasepool {
+			[NSApplication sharedApplication];
 
-		while (MimiCheckAccessibilityPermissions() != 1) {
+			while (MimiCheckAccessibilityPermissions() != 1) {
+				NSAlert *alert = [[NSAlert alloc] init];
+				alert.messageText = @"Accessibility Permission Needed";
+				alert.informativeText =
+				    @"Mimi needs Accessibility permission to receive window focus and title change events. "
+				    @"Click Request Permission to open the macOS permission flow, grant access in System Settings, "
+				    @"then return here and click Granted, Start Mimi.";
+				alert.alertStyle = NSAlertStyleWarning;
+				alert.icon = [NSImage imageNamed:NSImageNameCaution];
+
+				[alert addButtonWithTitle:@"Request Permission"];
+				[alert addButtonWithTitle:@"Granted, Start Mimi"];
+				[alert addButtonWithTitle:@"Quit"];
+
+				[[alert window] setLevel:NSFloatingWindowLevel];
+				[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+				[[alert window] center];
+				[[alert window] makeKeyAndOrderFront:nil];
+				[NSApp activateIgnoringOtherApps:YES];
+
+				NSModalResponse response = [alert runModal];
+				[[alert window] orderOut:nil];
+				[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+				if (response == NSAlertFirstButtonReturn) {
+					MimiRequestAccessibilityPermissions();
+				} else if (response == NSAlertSecondButtonReturn) {
+					return 1;
+				} else if (response == NSAlertThirdButtonReturn) {
+					return 2;
+				}
+			}
+
+			return 1;
+		}
+	});
+}
+
+int MimiShowConfigOnboardingAlert(const char *configPath) {
+	return MimiRunOnMainThreadSync(^int{
+		@autoreleasepool {
+			[NSApplication sharedApplication];
+
+			NSString *path =
+			    configPath ? [NSString stringWithUTF8String:configPath] : @"~/.config/mimi/config.toml";
+
 			NSAlert *alert = [[NSAlert alloc] init];
-			alert.messageText = @"Accessibility Permission Needed";
+			alert.messageText = @"Welcome to Mimi";
 			alert.informativeText =
-			    @"Mimi needs Accessibility permission to receive window focus and title change events. "
-			    @"Click Request Permission to open the macOS permission flow, grant access in System Settings, "
-			    @"then return here and click Granted, Start Mimi.";
-			alert.alertStyle = NSAlertStyleWarning;
-			alert.icon = [NSImage imageNamed:NSImageNameCaution];
+			    [NSString stringWithFormat:@"No configuration file found.\n\nCreate a starter config at:\n%@", path];
+			alert.alertStyle = NSAlertStyleInformational;
 
-			[alert addButtonWithTitle:@"Request Permission"];
-			[alert addButtonWithTitle:@"Granted, Start Mimi"];
+			[alert addButtonWithTitle:@"Create Config"];
 			[alert addButtonWithTitle:@"Quit"];
 
 			[[alert window] setLevel:NSFloatingWindowLevel];
@@ -74,51 +127,16 @@ int MimiShowAccessibilityPermissionStartupAlert(void) {
 			[NSApp activateIgnoringOtherApps:YES];
 
 			NSModalResponse response = [alert runModal];
+			[[alert window] orderOut:nil];
 			[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
 
 			if (response == NSAlertFirstButtonReturn) {
-				MimiRequestAccessibilityPermissions();
-			} else if (response == NSAlertSecondButtonReturn) {
 				return 1;
-			} else if (response == NSAlertThirdButtonReturn) {
+			} else if (response == NSAlertSecondButtonReturn) {
 				return 2;
 			}
-		}
 
-		return 1;
-	}
-}
-
-int MimiShowConfigOnboardingAlert(const char *configPath) {
-	@autoreleasepool {
-		[NSApplication sharedApplication];
-
-		NSString *path = configPath ? [NSString stringWithUTF8String:configPath] : @"~/.config/mimi/config.toml";
-
-		NSAlert *alert = [[NSAlert alloc] init];
-		alert.messageText = @"Welcome to Mimi";
-		alert.informativeText =
-		    [NSString stringWithFormat:@"No configuration file found.\n\nCreate a starter config at:\n%@", path];
-		alert.alertStyle = NSAlertStyleInformational;
-
-		[alert addButtonWithTitle:@"Create Config"];
-		[alert addButtonWithTitle:@"Quit"];
-
-		[[alert window] setLevel:NSFloatingWindowLevel];
-		[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-		[[alert window] center];
-		[[alert window] makeKeyAndOrderFront:nil];
-		[NSApp activateIgnoringOtherApps:YES];
-
-		NSModalResponse response = [alert runModal];
-		[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-
-		if (response == NSAlertFirstButtonReturn) {
-			return 1;
-		} else if (response == NSAlertSecondButtonReturn) {
 			return 2;
 		}
-
-		return 2;
-	}
+	});
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes a macOS crash when launching the bundled app due to AppKit UI (NSAlert/NSWindow) being instantiated off the main thread (NSInternalInconsistencyException: NSWindow should only be instantiated on the main thread!).

Also fixes a hang when systray is disabled and the user clicks “Granted, Start Mimi” in the accessibility prompt. In systray-disabled mode, Mimi now runs a headless Cocoa event loop on the main thread so modal alerts and main-queue UI work complete reliably, while the daemon continues running silently in the background.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
