### PR TITLE
feat: add simple workspace number for systray

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -41,6 +41,7 @@ pid_file = "~/.local/share/mimi/mimi.pid"
 [systray]
 # Show the Mimi menu bar item while the daemon is running.
 enabled = true
+show_workspace_number = false
 
 # =============================================================================
 # Hooks

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -88,13 +88,15 @@ pid_file = "~/.local/share/mimi/mimi.pid"
 
 ## [systray]
 
-| Key       | Type | Default | Description                          |
-| --------- | ---- | ------- | ------------------------------------ |
-| `enabled` | bool | `true`  | Show the Mimi menu bar item on macOS |
+| Key                    | Type | Default | Description                                                   |
+| ---------------------- | ---- | ------- | ------------------------------------------------------------- |
+| `enabled`              | bool | `true`  | Show the Mimi menu bar item on macOS                          |
+| `show_workspace_number` | bool | `false` | Show the current macOS Space number in the menu bar (opt-in) |
 
 ```toml
 [systray]
 enabled = true
+show_workspace_number = false
 ```
 
 The tray menu includes links to Mimi docs/source, a config reload action, and Quit Mimi.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,8 @@ type SettingsConfig struct {
 
 // SystrayConfig holds the [systray] section of the config.
 type SystrayConfig struct {
-	Enabled bool `json:"enabled" toml:"enabled"`
+	Enabled             bool `json:"enabled"             toml:"enabled"`
+	ShowWorkspaceNumber bool `json:"showWorkspaceNumber" toml:"show_workspace_number"`
 }
 
 // HooksConfig holds all hook entries grouped by event kind.
@@ -118,7 +119,8 @@ type rawConfig struct {
 }
 
 type rawSystrayConfig struct {
-	Enabled *bool `json:"enabled" toml:"enabled"`
+	Enabled             *bool `json:"enabled"             toml:"enabled"`
+	ShowWorkspaceNumber *bool `json:"showWorkspaceNumber" toml:"show_workspace_number"`
 }
 
 func decodeHooks(raw rawHooksConfig) (HooksConfig, error) {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -116,6 +116,10 @@ func Load(path string) (*Config, error) {
 		cfg.Systray.Enabled = *raw.Systray.Enabled
 	}
 
+	if raw.Systray.ShowWorkspaceNumber != nil {
+		cfg.Systray.ShowWorkspaceNumber = *raw.Systray.ShowWorkspaceNumber
+	}
+
 	applyDefaults(cfg, systrayEnabledSet)
 
 	err = validate(cfg)

--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -47,7 +47,14 @@ func runWithHost(
 			}
 		}
 
-		component = systray.NewComponent(version, configPath, reload, requestQuit, logger)
+		component = systray.NewComponent(
+			version,
+			configPath,
+			reload,
+			requestQuit,
+			cfg.Systray.ShowWorkspaceNumber,
+			logger,
+		)
 	}
 
 	go func() {

--- a/internal/systray/component.go
+++ b/internal/systray/component.go
@@ -3,17 +3,20 @@ package systray
 import (
 	"context"
 	"os/exec"
+	"strconv"
+	"time"
 
 	"go.uber.org/zap"
 )
 
 // Component owns Mimi's system tray menu.
 type Component struct {
-	version    string
-	configPath string
-	reload     func(context.Context, string) error
-	quit       func()
-	logger     *zap.SugaredLogger
+	version             string
+	configPath          string
+	reload              func(context.Context, string) error
+	quit                func()
+	logger              *zap.SugaredLogger
+	showWorkspaceNumber bool
 
 	ctx    context.Context //nolint:containedctx // Ties menu event goroutine to tray lifecycle.
 	cancel context.CancelFunc
@@ -33,18 +36,20 @@ func NewComponent(
 	configPath string,
 	reload func(context.Context, string) error,
 	quit func(),
+	showWorkspaceNumber bool,
 	logger *zap.SugaredLogger,
 ) *Component {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Component{
-		version:    version,
-		configPath: configPath,
-		reload:     reload,
-		quit:       quit,
-		logger:     logger,
-		ctx:        ctx,
-		cancel:     cancel,
+		version:             version,
+		configPath:          configPath,
+		reload:              reload,
+		quit:                quit,
+		showWorkspaceNumber: showWorkspaceNumber,
+		logger:              logger,
+		ctx:                 ctx,
+		cancel:              cancel,
 	}
 }
 
@@ -66,10 +71,14 @@ func (c *Component) OnReady() {
 
 	c.mQuit = AddMenuItem("Quit Mimi")
 
-	SetTitle("M")
+	c.setTrayTitle()
 	SetTooltip("Mimi")
 
 	go c.handleEvents()
+
+	if c.showWorkspaceNumber {
+		go c.handleTitleUpdates()
+	}
 }
 
 // OnExit stops menu event handling.
@@ -106,6 +115,53 @@ func (c *Component) handleEvents() {
 			return
 		}
 	}
+}
+
+func (c *Component) handleTitleUpdates() {
+	if !c.showWorkspaceNumber {
+		return
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond) //nolint:mnd
+	defer ticker.Stop()
+
+	last := ""
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+			n := ActiveWorkspaceNumber()
+			if n >= 0 {
+				title := strconv.Itoa(n + 1)
+				if title != last {
+					SetTitle(title)
+					last = title
+				}
+			} else if last != "M" {
+				SetTitle("M")
+
+				last = "M"
+			}
+		}
+	}
+}
+
+func (c *Component) setTrayTitle() {
+	if !c.showWorkspaceNumber {
+		SetTitle("M")
+
+		return
+	}
+
+	wsNum := ActiveWorkspaceNumber()
+	if wsNum < 0 {
+		SetTitle("M")
+
+		return
+	}
+
+	SetTitle(strconv.Itoa(wsNum + 1))
 }
 
 func (c *Component) openURL(url string, label string) {

--- a/internal/systray/systray.go
+++ b/internal/systray/systray.go
@@ -103,6 +103,11 @@ func SetTooltip(tooltip string) {
 	C.MimiSetTooltip(cTooltip)
 }
 
+// ActiveWorkspaceNumber returns the number of the active workspace.
+func ActiveWorkspaceNumber() int {
+	return int(C.MimiGetActiveWorkspaceNumber())
+}
+
 // SetIcon sets the icon of the system tray item.
 func SetIcon(icon []byte) {
 	if len(icon) == 0 {

--- a/internal/systray/systray.h
+++ b/internal/systray/systray.h
@@ -11,6 +11,7 @@ void MimiQuit(void);
 void MimiSetIcon(const char *iconBytes, int length, bool isTemplate);
 void MimiSetTitle(const char *title);
 void MimiSetTooltip(const char *tooltip);
+int MimiGetActiveWorkspaceNumber(void);
 
 void MimiAddMenuItem(int menuId, const char *title, short disabled, short checked);
 void MimiAddSubMenuItem(int parentId, int menuId, const char *title, short disabled, short checked);

--- a/internal/systray/systray.m
+++ b/internal/systray/systray.m
@@ -8,6 +8,8 @@
 #import "systray.h"
 
 #import <Cocoa/Cocoa.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <dlfcn.h>
 
 #pragma mark - External Function Declarations
 
@@ -31,12 +33,11 @@ static BOOL _exitCalled = NO;
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
 	if (_showSystray) {
-		self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength];
+		self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
 		self.menu = [[NSMenu alloc] init];
 		[self.menu setAutoenablesItems:NO];
 		[self.menu setDelegate:self];
 		[self.statusItem setMenu:self.menu];
-		[self.statusItem.button setImagePosition:NSImageOnly];
 	}
 
 	// Notify Go that we are ready
@@ -126,6 +127,8 @@ void MimiSetIcon(const char *iconBytes, int length, bool isTemplate) {
 		[image setTemplate:isTemplate];
 
 		if (appDelegate && appDelegate.statusItem) {
+			appDelegate.statusItem.button.title = @"";
+			[appDelegate.statusItem.button setImagePosition:NSImageOnly];
 			appDelegate.statusItem.button.image = image;
 		}
 	});
@@ -136,6 +139,8 @@ void MimiSetTitle(const char *title) {
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		if (appDelegate && appDelegate.statusItem) {
+			appDelegate.statusItem.button.image = nil;
+			[appDelegate.statusItem.button setImagePosition:NSNoImage];
 			appDelegate.statusItem.button.title = str;
 		}
 	});
@@ -149,6 +154,119 @@ void MimiSetTooltip(const char *tooltip) {
 			appDelegate.statusItem.button.toolTip = str;
 		}
 	});
+}
+
+int MimiGetActiveWorkspaceNumber(void) {
+	@autoreleasepool {
+		CFArrayRef windowList = CGWindowListCopyWindowInfo(
+		    kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+		if (windowList) {
+			int workspace = -1;
+			for (NSDictionary *info in (__bridge NSArray *)windowList) {
+				NSNumber *layer = info[(__bridge NSString *)kCGWindowLayer];
+				int l = layer ? [layer intValue] : 0;
+				if (l != 0) {
+					continue;
+				}
+
+				id ws = info[@"kCGWindowWorkspace"];
+				if ([ws isKindOfClass:[NSNumber class]]) {
+					workspace = [ws intValue];
+					break;
+				}
+
+				ws = info[@"Workspace"];
+				if ([ws isKindOfClass:[NSNumber class]]) {
+					workspace = [ws intValue];
+					break;
+				}
+			}
+
+			CFRelease(windowList);
+			if (workspace >= 0) {
+				return workspace;
+			}
+		}
+
+		static void *skyLight = NULL;
+		static dispatch_once_t onceToken;
+		dispatch_once(&onceToken, ^{
+			skyLight = dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight", RTLD_LAZY);
+		});
+
+		if (!skyLight) {
+			return -1;
+		}
+
+		typedef int (*SLSMainConnectionIDFunc)(void);
+		typedef uint64_t (*SLSGetActiveSpaceFunc)(int);
+		typedef CFArrayRef (*SLSCopyManagedDisplaySpacesFunc)(int);
+
+		SLSMainConnectionIDFunc SLSMainConnectionID =
+		    (SLSMainConnectionIDFunc)dlsym(skyLight, "SLSMainConnectionID");
+		if (!SLSMainConnectionID) {
+			SLSMainConnectionID = (SLSMainConnectionIDFunc)dlsym(skyLight, "CGSMainConnectionID");
+		}
+
+		SLSGetActiveSpaceFunc SLSGetActiveSpace = (SLSGetActiveSpaceFunc)dlsym(skyLight, "SLSGetActiveSpace");
+		if (!SLSGetActiveSpace) {
+			SLSGetActiveSpace = (SLSGetActiveSpaceFunc)dlsym(skyLight, "CGSGetActiveSpace");
+		}
+
+		SLSCopyManagedDisplaySpacesFunc SLSCopyManagedDisplaySpaces =
+		    (SLSCopyManagedDisplaySpacesFunc)dlsym(skyLight, "SLSCopyManagedDisplaySpaces");
+
+		if (!SLSMainConnectionID || !SLSGetActiveSpace || !SLSCopyManagedDisplaySpaces) {
+			return -1;
+		}
+
+		int conn = SLSMainConnectionID();
+		uint64_t active = SLSGetActiveSpace(conn);
+		if (active == 0) {
+			return -1;
+		}
+
+		CFArrayRef managed = SLSCopyManagedDisplaySpaces(conn);
+		if (!managed) {
+			return -1;
+		}
+
+		int idx = -1;
+		NSArray *displays = (__bridge NSArray *)managed;
+		for (NSDictionary *display in displays) {
+			NSArray *spaces = display[@"Spaces"];
+			if (![spaces isKindOfClass:[NSArray class]]) {
+				continue;
+			}
+
+			for (NSUInteger i = 0; i < [spaces count]; i++) {
+				id spaceDict = spaces[i];
+				if (![spaceDict isKindOfClass:[NSDictionary class]]) {
+					continue;
+				}
+
+				id sid = spaceDict[@"id64"];
+				if (![sid isKindOfClass:[NSNumber class]]) {
+					sid = spaceDict[@"ManagedSpaceID"];
+				}
+				if (![sid isKindOfClass:[NSNumber class]]) {
+					continue;
+				}
+
+				if ((uint64_t)[sid unsignedLongLongValue] == active) {
+					idx = (int)i;
+					break;
+				}
+			}
+
+			if (idx >= 0) {
+				break;
+			}
+		}
+
+		CFRelease(managed);
+		return idx;
+	}
 }
 
 #pragma mark - Menu Item Lookup


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds an opt-in config `show_workspace_number` to show the active workspace number in the systray, if enabled.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
