### PR TITLE
fix(nix): set PATH for launchd agent hooks

### DIFF
--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -37,6 +37,9 @@ in
         serviceConfig = {
           KeepAlive = true;
           RunAtLoad = true;
+          EnvironmentVariables = {
+            PATH = "/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+          };
           StandardOutPath = "/tmp/mimi.log";
           StandardErrorPath = "/tmp/mimi.err.log";
           ProcessType = "Interactive";

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -79,6 +79,9 @@ in
           "--config"
           "${config.xdg.configHome}/mimi/config.toml"
         ];
+        EnvironmentVariables = {
+          PATH = "${config.home.profileDirectory}/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+        };
         RunAtLoad = true;
         KeepAlive = cfg.launchd.keepAlive;
         StandardOutPath = "/tmp/mimi.log";


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

Mimi hook commands can fail with exit status 127 when started via Home Manager / launchd because the daemon inherits a minimal environment and PATH may not include the user profile bin. This causes hooks that reference external tools (e.g. neru) to not run.

This change sets `EnvironmentVariables.PATH` for the Mimi launchd agent in both the Home Manager module and the nix-darwin module so hook commands can resolve binaries from the expected Nix profile paths.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
