### PR TITLE
fix: only run the observers if defined

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,6 +107,9 @@ The tray menu includes links to Mimi docs/source, a config reload action, and Qu
 
 Each hook key maps to an array of hook entries. An entry can be:
 
+> [!NOTE]
+> **Selective Event Listening**: Mimi only starts the underlying macOS system observers (e.g. power, audio, clipboard, USB, display, workspace) if there is at least one active hook configured for those events. If a hook array is empty (`[]`) or omitted, Mimi does not listen to that category of events on the OS level, keeping CPU and resource usage to an absolute minimum.
+
 ### Simplified String Form
 
 ```toml

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -54,17 +54,20 @@ func runCore(
 		}
 	}
 
-	if !cgo_bridge.Start(accessibilityPrompt) {
+	obsCfg := getObserverConfig(cfg)
+	if !cgo_bridge.Start(obsCfg, accessibilityPrompt) {
 		return nil
 	}
 
 	perm = permissions.Check()
-	if !perm.Accessibility {
+
+	axEnabled := perm.Accessibility && hasWindowEvents(cfg)
+	if hasWindowEvents(cfg) && !perm.Accessibility {
 		logger.Warn("accessibility permission not granted — window events disabled")
 	}
 
 	bus := events.NewBus()
-	axMgr := observers.NewAccessibilityManager(perm.Accessibility)
+	axMgr := observers.NewAccessibilityManager(axEnabled)
 	wsObs := observers.NewWorkspaceObserver(bus, axMgr, logger)
 
 	reg := hooks.NewRegistry()
@@ -99,6 +102,10 @@ func runCore(
 		}
 
 		executor.UpdateSettings(&newCfg.Settings)
+		cgo_bridge.UpdateObservers(getObserverConfig(newCfg))
+
+		perm := permissions.Check()
+		axMgr.Update(perm.Accessibility && hasWindowEvents(newCfg))
 		logger.Info("hooks reloaded from config")
 	}, logger)
 	go func() { _ = watcher.Run(ctx) }()
@@ -129,6 +136,10 @@ func runCore(
 
 				_ = reg.Reload(newCfg)
 				executor.UpdateSettings(&newCfg.Settings)
+				cgo_bridge.UpdateObservers(getObserverConfig(newCfg))
+
+				perm := permissions.Check()
+				axMgr.Update(perm.Accessibility && hasWindowEvents(newCfg))
 				logger.Info("reloaded config via SIGHUP")
 
 				continue
@@ -168,4 +179,54 @@ func expandHome(path string) string {
 	}
 
 	return path
+}
+
+func hasWindowEvents(cfg *config.Config) bool {
+	return len(cfg.Hooks.WindowFocus) > 0 ||
+		len(cfg.Hooks.WindowTitleChange) > 0 ||
+		len(cfg.Hooks.WindowCreated) > 0 ||
+		len(cfg.Hooks.WindowClosed) > 0
+}
+
+func getObserverConfig(cfg *config.Config) cgo_bridge.ObserverConfig {
+	return cgo_bridge.ObserverConfig{
+		Power: len(cfg.Hooks.PowerAdapterConnected) > 0 ||
+			len(cfg.Hooks.PowerAdapterDisconnected) > 0 ||
+			len(cfg.Hooks.BatteryLow) > 0 ||
+			len(cfg.Hooks.BatteryCritical) > 0,
+
+		Audio: len(cfg.Hooks.AudioDeviceChanged) > 0,
+
+		Clipboard: len(cfg.Hooks.ClipboardChanged) > 0,
+
+		USB: len(cfg.Hooks.USBDeviceConnected) > 0 ||
+			len(cfg.Hooks.USBDeviceDisconnected) > 0,
+
+		Network: len(cfg.Hooks.NetworkUp) > 0 ||
+			len(cfg.Hooks.NetworkDown) > 0,
+
+		Display: len(cfg.Hooks.ExternalDisplayConnected) > 0 ||
+			len(cfg.Hooks.ExternalDisplayDisconnected) > 0,
+
+		AppLifecycle: len(cfg.Hooks.AppActivate) > 0 ||
+			len(cfg.Hooks.AppDeactivate) > 0 ||
+			len(cfg.Hooks.AppLaunch) > 0 ||
+			len(cfg.Hooks.AppQuit) > 0 ||
+			len(cfg.Hooks.AppHide) > 0 ||
+			len(cfg.Hooks.AppUnhide) > 0,
+
+		SystemState: len(cfg.Hooks.SystemSleep) > 0 ||
+			len(cfg.Hooks.SystemWake) > 0 ||
+			len(cfg.Hooks.ScreenLock) > 0 ||
+			len(cfg.Hooks.ScreenUnlock) > 0 ||
+			len(cfg.Hooks.SystemShutdown) > 0 ||
+			len(cfg.Hooks.UserSessionEnd) > 0,
+
+		Volume: len(cfg.Hooks.VolumeMount) > 0 ||
+			len(cfg.Hooks.VolumeUnmount) > 0,
+
+		Workspace: len(cfg.Hooks.WorkspaceChanged) > 0,
+
+		Appearance: len(cfg.Hooks.AppearanceChanged) > 0,
+	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,140 @@
+//nolint:testpackage
+package daemon
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/config"
+)
+
+func TestHasWindowEvents(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		expected bool
+	}{
+		{
+			name:     "empty config",
+			cfg:      &config.Config{},
+			expected: false,
+		},
+		{
+			name: "window focus only",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					WindowFocus: []config.HookEntry{{Run: "echo"}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "window created only",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					WindowCreated: []config.HookEntry{{Run: "echo"}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "app activate only",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					AppActivate: []config.HookEntry{{Run: "echo"}},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasWindowEvents(tt.cfg)
+			if result != tt.expected {
+				t.Errorf("hasWindowEvents() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetObserverConfig(t *testing.T) {
+	cfg := &config.Config{
+		Hooks: config.HooksConfig{
+			AppActivate:              []config.HookEntry{{Run: "echo"}},
+			AudioDeviceChanged:       []config.HookEntry{{Run: "echo"}},
+			BatteryLow:               []config.HookEntry{{Run: "echo"}},
+			ClipboardChanged:         []config.HookEntry{{Run: "echo"}},
+			USBDeviceConnected:       []config.HookEntry{{Run: "echo"}},
+			NetworkUp:                []config.HookEntry{{Run: "echo"}},
+			VolumeMount:              []config.HookEntry{{Run: "echo"}},
+			WorkspaceChanged:         []config.HookEntry{{Run: "echo"}},
+			AppearanceChanged:        []config.HookEntry{{Run: "echo"}},
+			ExternalDisplayConnected: []config.HookEntry{{Run: "echo"}},
+			SystemSleep:              []config.HookEntry{{Run: "echo"}},
+		},
+	}
+
+	obs := getObserverConfig(cfg)
+
+	if !obs.AppLifecycle {
+		t.Error("expected AppLifecycle to be true")
+	}
+
+	if !obs.Audio {
+		t.Error("expected Audio to be true")
+	}
+
+	if !obs.Power {
+		t.Error("expected Power to be true")
+	}
+
+	if !obs.Clipboard {
+		t.Error("expected Clipboard to be true")
+	}
+
+	if !obs.USB {
+		t.Error("expected USB to be true")
+	}
+
+	if !obs.Network {
+		t.Error("expected Network to be true")
+	}
+
+	if !obs.Volume {
+		t.Error("expected Volume to be true")
+	}
+
+	if !obs.Workspace {
+		t.Error("expected Workspace to be true")
+	}
+
+	if !obs.Appearance {
+		t.Error("expected Appearance to be true")
+	}
+
+	if !obs.Display {
+		t.Error("expected Display to be true")
+	}
+
+	if !obs.SystemState {
+		t.Error("expected SystemState to be true")
+	}
+
+	// Empty config case
+	emptyCfg := &config.Config{}
+
+	emptyObs := getObserverConfig(emptyCfg)
+	if emptyObs.AppLifecycle ||
+		emptyObs.Audio ||
+		emptyObs.Power ||
+		emptyObs.Clipboard ||
+		emptyObs.USB ||
+		emptyObs.Network ||
+		emptyObs.Volume ||
+		emptyObs.Workspace ||
+		emptyObs.Appearance ||
+		emptyObs.Display ||
+		emptyObs.SystemState {
+		t.Errorf("expected all observers to be disabled on empty config, got: %+v", emptyObs)
+	}
+}

--- a/internal/observers/accessibility.go
+++ b/internal/observers/accessibility.go
@@ -21,6 +21,21 @@ func NewAccessibilityManager(axEnabled bool) *AccessibilityManager {
 	}
 }
 
+// Update updates the enabled state of the manager.
+// If disabled, it removes all active AX observers.
+func (m *AccessibilityManager) Update(axEnabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.enabled = axEnabled
+	if !axEnabled {
+		for pid := range m.tracked {
+			cgo_bridge.RemoveAXObserver(pid)
+			delete(m.tracked, pid)
+		}
+	}
+}
+
 // Install installs an AX observer for the given PID. Returns false if AX is disabled.
 func (m *AccessibilityManager) Install(pid int) bool {
 	if !m.enabled {

--- a/internal/observers/cgo_bridge/bridge.go
+++ b/internal/observers/cgo_bridge/bridge.go
@@ -27,8 +27,23 @@ var eventCh = make(chan events.Event, eventChBufSize)
 // EventCh returns a read-only channel of events from the CGO bridge.
 func EventCh() <-chan events.Event { return eventCh }
 
-// Start initializes and starts all macOS event observers.
-func Start(beforeRunLoop func() bool) bool {
+// ObserverConfig specifies which macOS event observers are active.
+type ObserverConfig struct {
+	Power        bool
+	Audio        bool
+	Clipboard    bool
+	USB          bool
+	Network      bool
+	Display      bool
+	AppLifecycle bool
+	SystemState  bool
+	Volume       bool
+	Workspace    bool
+	Appearance   bool
+}
+
+// Start initializes and starts all configured macOS event observers.
+func Start(obsCfg ObserverConfig, beforeRunLoop func() bool) bool {
 	// Lock to main OS thread to initialize NSApplication properly.
 	// NSWorkspace notifications require proper Cocoa initialization.
 	mainThread := make(chan bool)
@@ -45,15 +60,33 @@ func Start(beforeRunLoop func() bool) bool {
 		C.InitBridgeRunLoop()
 		// Run-loop-backed observers must be created on the same locked thread
 		// that owns the Cocoa run loop below.
-		C.PowerObserverStart()
-		C.AudioObserverStart()
-		C.ClipboardObserverStart()
-		C.USBObserverStart()
-		C.NetworkObserverStart()
-		C.DisplayObserverStart()
+		if obsCfg.Power {
+			C.PowerObserverStart()
+		}
+		if obsCfg.Audio {
+			C.AudioObserverStart()
+		}
+		if obsCfg.Clipboard {
+			C.ClipboardObserverStart()
+		}
+		if obsCfg.USB {
+			C.USBObserverStart()
+		}
+		if obsCfg.Network {
+			C.NetworkObserverStart()
+		}
+		if obsCfg.Display {
+			C.DisplayObserverStart()
+		}
 
 		mainThread <- true
-		C.WorkspaceObserverStart()
+		C.WorkspaceObserverStart(
+			C.bool(obsCfg.AppLifecycle),
+			C.bool(obsCfg.SystemState),
+			C.bool(obsCfg.Volume),
+			C.bool(obsCfg.Workspace),
+			C.bool(obsCfg.Appearance),
+		)
 	}()
 	if !<-mainThread {
 		return false
@@ -69,6 +102,53 @@ func Start(beforeRunLoop func() bool) bool {
 	}
 
 	return true
+}
+
+// UpdateObservers dynamically starts or stops macOS event observers based on config.
+func UpdateObservers(obsCfg ObserverConfig) {
+	if obsCfg.Power {
+		C.PowerObserverStart()
+	} else {
+		C.PowerObserverStop()
+	}
+
+	if obsCfg.Audio {
+		C.AudioObserverStart()
+	} else {
+		C.AudioObserverStop()
+	}
+
+	if obsCfg.Clipboard {
+		C.ClipboardObserverStart()
+	} else {
+		C.ClipboardObserverStop()
+	}
+
+	if obsCfg.USB {
+		C.USBObserverStart()
+	} else {
+		C.USBObserverStop()
+	}
+
+	if obsCfg.Network {
+		C.NetworkObserverStart()
+	} else {
+		C.NetworkObserverStop()
+	}
+
+	if obsCfg.Display {
+		C.DisplayObserverStart()
+	} else {
+		C.DisplayObserverStop()
+	}
+
+	C.WorkspaceObserverUpdate(
+		C.bool(obsCfg.AppLifecycle),
+		C.bool(obsCfg.SystemState),
+		C.bool(obsCfg.Volume),
+		C.bool(obsCfg.Workspace),
+		C.bool(obsCfg.Appearance),
+	)
 }
 
 // Stop stops all macOS event observers.

--- a/internal/observers/cgo_bridge/system_events.m
+++ b/internal/observers/cgo_bridge/system_events.m
@@ -140,10 +140,12 @@ static void PowerSourceCallback(void *context) {
 static PowerObserver *gPowerObserver = nil;
 
 void PowerObserverStart(void) {
-	@autoreleasepool {
-		gPowerObserver = [[PowerObserver alloc] init];
-		[gPowerObserver startObserving];
-	}
+	runOnBridgeRunLoopSync(^{
+		if (!gPowerObserver) {
+			gPowerObserver = [[PowerObserver alloc] init];
+			[gPowerObserver startObserving];
+		}
+	});
 }
 
 void PowerObserverStop(void) {
@@ -164,30 +166,44 @@ static OSStatus AudioPropertyListener(
 	return noErr;
 }
 
-void AudioObserverStart(void) {
-	AudioObjectPropertyAddress address1 = {
-	    kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
-	AudioObjectPropertyAddress address2 = {
-	    kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
-	AudioObjectPropertyAddress address3 = {
-	    kAudioHardwarePropertyDefaultInputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
+static BOOL gAudioObserverRunning = NO;
 
-	AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address1, AudioPropertyListener, NULL);
-	AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address2, AudioPropertyListener, NULL);
-	AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address3, AudioPropertyListener, NULL);
+void AudioObserverStart(void) {
+	runOnBridgeRunLoopSync(^{
+		if (gAudioObserverRunning)
+			return;
+		AudioObjectPropertyAddress address1 = {
+		    kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
+		AudioObjectPropertyAddress address2 = {
+		    kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal,
+		    kAudioObjectPropertyElementMain};
+		AudioObjectPropertyAddress address3 = {
+		    kAudioHardwarePropertyDefaultInputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
+
+		AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address1, AudioPropertyListener, NULL);
+		AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address2, AudioPropertyListener, NULL);
+		AudioObjectAddPropertyListener(kAudioObjectSystemObject, &address3, AudioPropertyListener, NULL);
+		gAudioObserverRunning = YES;
+	});
 }
 
 void AudioObserverStop(void) {
-	AudioObjectPropertyAddress address1 = {
-	    kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
-	AudioObjectPropertyAddress address2 = {
-	    kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
-	AudioObjectPropertyAddress address3 = {
-	    kAudioHardwarePropertyDefaultInputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
+	runOnBridgeRunLoopSync(^{
+		if (!gAudioObserverRunning)
+			return;
+		AudioObjectPropertyAddress address1 = {
+		    kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
+		AudioObjectPropertyAddress address2 = {
+		    kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal,
+		    kAudioObjectPropertyElementMain};
+		AudioObjectPropertyAddress address3 = {
+		    kAudioHardwarePropertyDefaultInputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain};
 
-	AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address1, AudioPropertyListener, NULL);
-	AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address2, AudioPropertyListener, NULL);
-	AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address3, AudioPropertyListener, NULL);
+		AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address1, AudioPropertyListener, NULL);
+		AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address2, AudioPropertyListener, NULL);
+		AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &address3, AudioPropertyListener, NULL);
+		gAudioObserverRunning = NO;
+	});
 }
 
 #pragma mark - Clipboard Observer
@@ -230,10 +246,12 @@ void AudioObserverStop(void) {
 static ClipboardObserver *gClipboardObserver = nil;
 
 void ClipboardObserverStart(void) {
-	@autoreleasepool {
-		gClipboardObserver = [[ClipboardObserver alloc] init];
-		[gClipboardObserver startObserving];
-	}
+	runOnBridgeRunLoopSync(^{
+		if (!gClipboardObserver) {
+			gClipboardObserver = [[ClipboardObserver alloc] init];
+			[gClipboardObserver startObserving];
+		}
+	});
 }
 
 void ClipboardObserverStop(void) {
@@ -330,10 +348,12 @@ static void USBDeviceRemoved(void *refCon, io_iterator_t iterator) {
 static USBObserver *gUSBObserver = nil;
 
 void USBObserverStart(void) {
-	@autoreleasepool {
-		gUSBObserver = [[USBObserver alloc] init];
-		[gUSBObserver startObserving];
-	}
+	runOnBridgeRunLoopSync(^{
+		if (!gUSBObserver) {
+			gUSBObserver = [[USBObserver alloc] init];
+			[gUSBObserver startObserving];
+		}
+	});
 }
 
 void USBObserverStop(void) {
@@ -416,10 +436,12 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 static NetworkObserver *gNetworkObserver = nil;
 
 void NetworkObserverStart(void) {
-	@autoreleasepool {
-		gNetworkObserver = [[NetworkObserver alloc] init];
-		[gNetworkObserver startObserving];
-	}
+	runOnBridgeRunLoopSync(^{
+		if (!gNetworkObserver) {
+			gNetworkObserver = [[NetworkObserver alloc] init];
+			[gNetworkObserver startObserving];
+		}
+	});
 }
 
 void NetworkObserverStop(void) {
@@ -446,6 +468,22 @@ static void DisplayReconfigurationCallBack(
 	}
 }
 
-void DisplayObserverStart(void) { CGDisplayRegisterReconfigurationCallback(DisplayReconfigurationCallBack, NULL); }
+static BOOL gDisplayObserverRunning = NO;
 
-void DisplayObserverStop(void) { CGDisplayRemoveReconfigurationCallback(DisplayReconfigurationCallBack, NULL); }
+void DisplayObserverStart(void) {
+	runOnBridgeRunLoopSync(^{
+		if (gDisplayObserverRunning)
+			return;
+		CGDisplayRegisterReconfigurationCallback(DisplayReconfigurationCallBack, NULL);
+		gDisplayObserverRunning = YES;
+	});
+}
+
+void DisplayObserverStop(void) {
+	runOnBridgeRunLoopSync(^{
+		if (!gDisplayObserverRunning)
+			return;
+		CGDisplayRemoveReconfigurationCallback(DisplayReconfigurationCallBack, NULL);
+		gDisplayObserverRunning = NO;
+	});
+}

--- a/internal/observers/cgo_bridge/workspace.h
+++ b/internal/observers/cgo_bridge/workspace.h
@@ -8,7 +8,9 @@ void InitCocoaApp(void);
 
 void InitBridgeRunLoop(void);
 
-void WorkspaceObserverStart(void);
+void WorkspaceObserverStart(bool appLifecycle, bool systemState, bool volume, bool workspace, bool appearance);
+
+void WorkspaceObserverUpdate(bool appLifecycle, bool systemState, bool volume, bool workspace, bool appearance);
 
 void WorkspaceObserverStop(void);
 

--- a/internal/observers/cgo_bridge/workspace.m
+++ b/internal/observers/cgo_bridge/workspace.m
@@ -12,7 +12,11 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 @property(nonatomic, strong) NSDictionary *notifToKind;
 @property(nonatomic, strong) NSTimer *spacePollTimer;
 @property(nonatomic, strong) NSSet *lastWindowIDs;
-- (void)startObserving;
+- (void)updateObserversWithAppLifecycle:(BOOL)appLifecycle
+                            systemState:(BOOL)systemState
+                                 volume:(BOOL)volume
+                              workspace:(BOOL)workspace
+                             appearance:(BOOL)appearance;
 - (int)kindForNotificationName:(NSString *)name;
 - (NSArray *)currentWindowList;
 - (NSSet *)currentWindowIDs;
@@ -94,35 +98,70 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 	return [[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding];
 }
 
-- (void)startObserving {
-	self.notifToKind = @{
-		NSWorkspaceDidActivateApplicationNotification : @(0),
-		NSWorkspaceDidDeactivateApplicationNotification : @(1),
-		NSWorkspaceDidLaunchApplicationNotification : @(2),
-		NSWorkspaceDidTerminateApplicationNotification : @(3),
-		NSWorkspaceDidHideApplicationNotification : @(4),
-		NSWorkspaceDidUnhideApplicationNotification : @(5),
-		NSWorkspaceWillSleepNotification : @(10),
-		NSWorkspaceDidWakeNotification : @(11),
-		NSWorkspaceSessionDidResignActiveNotification : @(12),
-		NSWorkspaceSessionDidBecomeActiveNotification : @(13),
-		NSWorkspaceWillPowerOffNotification : @(14),
-		NSWorkspaceDidMountNotification : @(20),
-		NSWorkspaceDidUnmountNotification : @(21),
-		NSWorkspaceActiveSpaceDidChangeNotification : @(70),
-	};
-
+- (void)updateObserversWithAppLifecycle:(BOOL)appLifecycle
+                            systemState:(BOOL)systemState
+                                 volume:(BOOL)volume
+                              workspace:(BOOL)workspace
+                             appearance:(BOOL)appearance {
 	NSNotificationCenter *wsnc = [[NSWorkspace sharedWorkspace] notificationCenter];
+	[wsnc removeObserver:self];
+	[[NSDistributedNotificationCenter defaultCenter] removeObserver:self];
+
+	if (self.spacePollTimer) {
+		[self.spacePollTimer invalidate];
+		self.spacePollTimer = nil;
+	}
+
+	NSMutableDictionary *tempNotifToKind = [NSMutableDictionary dictionary];
+
+	if (appLifecycle) {
+		tempNotifToKind[NSWorkspaceDidActivateApplicationNotification] = @(0);
+		tempNotifToKind[NSWorkspaceDidDeactivateApplicationNotification] = @(1);
+		tempNotifToKind[NSWorkspaceDidLaunchApplicationNotification] = @(2);
+		tempNotifToKind[NSWorkspaceDidTerminateApplicationNotification] = @(3);
+		tempNotifToKind[NSWorkspaceDidHideApplicationNotification] = @(4);
+		tempNotifToKind[NSWorkspaceDidUnhideApplicationNotification] = @(5);
+	}
+
+	if (systemState) {
+		tempNotifToKind[NSWorkspaceWillSleepNotification] = @(10);
+		tempNotifToKind[NSWorkspaceDidWakeNotification] = @(11);
+		tempNotifToKind[NSWorkspaceSessionDidResignActiveNotification] = @(12);
+		tempNotifToKind[NSWorkspaceSessionDidBecomeActiveNotification] = @(13);
+		tempNotifToKind[NSWorkspaceWillPowerOffNotification] = @(14);
+	}
+
+	if (volume) {
+		tempNotifToKind[NSWorkspaceDidMountNotification] = @(20);
+		tempNotifToKind[NSWorkspaceDidUnmountNotification] = @(21);
+	}
+
+	if (workspace) {
+		tempNotifToKind[NSWorkspaceActiveSpaceDidChangeNotification] = @(70);
+	}
+
+	self.notifToKind = tempNotifToKind;
+
 	for (NSString *notifName in self.notifToKind) {
 		[wsnc addObserver:self selector:@selector(handleNotification:) name:notifName object:nil];
 	}
 
-	self.lastWindowIDs = [self currentWindowIDs];
-	self.spacePollTimer = [NSTimer scheduledTimerWithTimeInterval:0.2
-	                                                       target:self
-	                                                     selector:@selector(checkSpaceChange:)
-	                                                     userInfo:nil
-	                                                      repeats:YES];
+	if (appearance) {
+		NSDistributedNotificationCenter *dnc = [NSDistributedNotificationCenter defaultCenter];
+		[dnc addObserver:self
+		        selector:@selector(appearanceChanged:)
+		            name:@"AppleInterfaceThemeChangedNotification"
+		          object:nil];
+	}
+
+	if (workspace) {
+		self.lastWindowIDs = [self currentWindowIDs];
+		self.spacePollTimer = [NSTimer scheduledTimerWithTimeInterval:0.2
+		                                                       target:self
+		                                                     selector:@selector(checkSpaceChange:)
+		                                                     userInfo:nil
+		                                                      repeats:YES];
+	}
 }
 
 - (void)checkSpaceChange:(NSTimer *)timer {
@@ -184,21 +223,50 @@ void InitCocoaApp(void) {
 
 void InitBridgeRunLoop(void) { atomic_store(&gRunLoop, CFRunLoopGetCurrent()); }
 
-void WorkspaceObserverStart(void) {
+void WorkspaceObserverStart(bool appLifecycle, bool systemState, bool volume, bool workspace, bool appearance) {
 	@autoreleasepool {
 		InitBridgeRunLoop();
 		gObserver = [[WorkspaceObserver alloc] init];
-		[gObserver startObserving];
-
-		NSDistributedNotificationCenter *dnc = [NSDistributedNotificationCenter defaultCenter];
-		[dnc addObserver:gObserver
-		        selector:@selector(appearanceChanged:)
-		            name:@"AppleInterfaceThemeChangedNotification"
-		          object:nil];
+		[gObserver updateObserversWithAppLifecycle:appLifecycle
+		                               systemState:systemState
+		                                    volume:volume
+		                                 workspace:workspace
+		                                appearance:appearance];
 
 		CFRunLoopRun();
 		atomic_store(&gRunLoop, NULL);
 	}
+}
+
+void WorkspaceObserverUpdate(bool appLifecycle, bool systemState, bool volume, bool workspace, bool appearance) {
+	CFRunLoopRef rl = GetRunLoop();
+	if (!rl)
+		return;
+
+	if (CFRunLoopGetCurrent() == rl) {
+		if (gObserver) {
+			[gObserver updateObserversWithAppLifecycle:appLifecycle
+			                               systemState:systemState
+			                                    volume:volume
+			                                 workspace:workspace
+			                                appearance:appearance];
+		}
+		return;
+	}
+
+	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+	CFRunLoopPerformBlock(rl, kCFRunLoopDefaultMode, ^{
+		if (gObserver) {
+			[gObserver updateObserversWithAppLifecycle:appLifecycle
+			                               systemState:systemState
+			                                    volume:volume
+			                                 workspace:workspace
+			                                appearance:appearance];
+		}
+		dispatch_semaphore_signal(sem);
+	});
+	CFRunLoopWakeUp(rl);
+	dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
 }
 
 void WorkspaceObserverStop(void) {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue where we should only register the related observers when at least one of the event are configured.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #17 

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
