### PR TITLE
fix(observers): resolve window focus observer registration regression

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -213,7 +213,8 @@ func getObserverConfig(cfg *config.Config) cgo_bridge.ObserverConfig {
 			len(cfg.Hooks.AppLaunch) > 0 ||
 			len(cfg.Hooks.AppQuit) > 0 ||
 			len(cfg.Hooks.AppHide) > 0 ||
-			len(cfg.Hooks.AppUnhide) > 0,
+			len(cfg.Hooks.AppUnhide) > 0 ||
+			hasWindowEvents(cfg),
 
 		SystemState: len(cfg.Hooks.SystemSleep) > 0 ||
 			len(cfg.Hooks.SystemWake) > 0 ||

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -137,4 +137,29 @@ func TestGetObserverConfig(t *testing.T) {
 		emptyObs.SystemState {
 		t.Errorf("expected all observers to be disabled on empty config, got: %+v", emptyObs)
 	}
+
+	// Window events only case
+	windowOnlyCfg := &config.Config{
+		Hooks: config.HooksConfig{
+			WindowFocus: []config.HookEntry{{Run: "echo"}},
+		},
+	}
+
+	windowOnlyObs := getObserverConfig(windowOnlyCfg)
+	if !windowOnlyObs.AppLifecycle {
+		t.Error("expected AppLifecycle to be enabled when WindowFocus is configured")
+	}
+
+	if windowOnlyObs.Audio ||
+		windowOnlyObs.Power ||
+		windowOnlyObs.Clipboard ||
+		windowOnlyObs.USB ||
+		windowOnlyObs.Network ||
+		windowOnlyObs.Volume ||
+		windowOnlyObs.Workspace ||
+		windowOnlyObs.Appearance ||
+		windowOnlyObs.Display ||
+		windowOnlyObs.SystemState {
+		t.Errorf("expected only AppLifecycle to be enabled, got: %+v", windowOnlyObs)
+	}
 }

--- a/internal/observers/cgo_bridge/bridge.go
+++ b/internal/observers/cgo_bridge/bridge.go
@@ -81,11 +81,11 @@ func Start(obsCfg ObserverConfig, beforeRunLoop func() bool) bool {
 
 		mainThread <- true
 		C.WorkspaceObserverStart(
-			C.bool(obsCfg.AppLifecycle),
-			C.bool(obsCfg.SystemState),
-			C.bool(obsCfg.Volume),
-			C.bool(obsCfg.Workspace),
-			C.bool(obsCfg.Appearance),
+			boolToInt(obsCfg.AppLifecycle),
+			boolToInt(obsCfg.SystemState),
+			boolToInt(obsCfg.Volume),
+			boolToInt(obsCfg.Workspace),
+			boolToInt(obsCfg.Appearance),
 		)
 	}()
 	if !<-mainThread {
@@ -143,11 +143,11 @@ func UpdateObservers(obsCfg ObserverConfig) {
 	}
 
 	C.WorkspaceObserverUpdate(
-		C.bool(obsCfg.AppLifecycle),
-		C.bool(obsCfg.SystemState),
-		C.bool(obsCfg.Volume),
-		C.bool(obsCfg.Workspace),
-		C.bool(obsCfg.Appearance),
+		boolToInt(obsCfg.AppLifecycle),
+		boolToInt(obsCfg.SystemState),
+		boolToInt(obsCfg.Volume),
+		boolToInt(obsCfg.Workspace),
+		boolToInt(obsCfg.Appearance),
 	)
 }
 
@@ -285,4 +285,12 @@ func kindFromInt(kindInt int) events.EventKind {
 	}
 
 	return events.EventKind("unknown")
+}
+
+func boolToInt(b bool) C.int {
+	if b {
+		return 1
+	}
+
+	return 0
 }

--- a/internal/observers/cgo_bridge/workspace.h
+++ b/internal/observers/cgo_bridge/workspace.h
@@ -8,9 +8,9 @@ void InitCocoaApp(void);
 
 void InitBridgeRunLoop(void);
 
-void WorkspaceObserverStart(bool appLifecycle, bool systemState, bool volume, bool workspace, bool appearance);
+void WorkspaceObserverStart(int appLifecycle, int systemState, int volume, int workspace, int appearance);
 
-void WorkspaceObserverUpdate(bool appLifecycle, bool systemState, bool volume, bool workspace, bool appearance);
+void WorkspaceObserverUpdate(int appLifecycle, int systemState, int volume, int workspace, int appearance);
 
 void WorkspaceObserverStop(void);
 

--- a/internal/observers/cgo_bridge/workspace.m
+++ b/internal/observers/cgo_bridge/workspace.m
@@ -223,33 +223,41 @@ void InitCocoaApp(void) {
 
 void InitBridgeRunLoop(void) { atomic_store(&gRunLoop, CFRunLoopGetCurrent()); }
 
-void WorkspaceObserverStart(bool appLifecycle, bool systemState, bool volume, bool workspace, bool appearance) {
+void WorkspaceObserverStart(int appLifecycle, int systemState, int volume, int workspace, int appearance) {
 	@autoreleasepool {
 		InitBridgeRunLoop();
 		gObserver = [[WorkspaceObserver alloc] init];
-		[gObserver updateObserversWithAppLifecycle:appLifecycle
-		                               systemState:systemState
-		                                    volume:volume
-		                                 workspace:workspace
-		                                appearance:appearance];
+		[gObserver updateObserversWithAppLifecycle:appLifecycle != 0
+		                               systemState:systemState != 0
+		                                    volume:volume != 0
+		                                 workspace:workspace != 0
+		                                appearance:appearance != 0];
+
+		CFRunLoopSourceContext context = {0};
+		CFRunLoopSourceRef dummySource = CFRunLoopSourceCreate(NULL, 0, &context);
+		CFRunLoopAddSource(CFRunLoopGetCurrent(), dummySource, kCFRunLoopDefaultMode);
 
 		CFRunLoopRun();
+
+		CFRunLoopRemoveSource(CFRunLoopGetCurrent(), dummySource, kCFRunLoopDefaultMode);
+		CFRelease(dummySource);
+
 		atomic_store(&gRunLoop, NULL);
 	}
 }
 
-void WorkspaceObserverUpdate(bool appLifecycle, bool systemState, bool volume, bool workspace, bool appearance) {
+void WorkspaceObserverUpdate(int appLifecycle, int systemState, int volume, int workspace, int appearance) {
 	CFRunLoopRef rl = GetRunLoop();
 	if (!rl)
 		return;
 
 	if (CFRunLoopGetCurrent() == rl) {
 		if (gObserver) {
-			[gObserver updateObserversWithAppLifecycle:appLifecycle
-			                               systemState:systemState
-			                                    volume:volume
-			                                 workspace:workspace
-			                                appearance:appearance];
+			[gObserver updateObserversWithAppLifecycle:appLifecycle != 0
+			                               systemState:systemState != 0
+			                                    volume:volume != 0
+			                                 workspace:workspace != 0
+			                                appearance:appearance != 0];
 		}
 		return;
 	}
@@ -257,11 +265,11 @@ void WorkspaceObserverUpdate(bool appLifecycle, bool systemState, bool volume, b
 	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
 	CFRunLoopPerformBlock(rl, kCFRunLoopDefaultMode, ^{
 		if (gObserver) {
-			[gObserver updateObserversWithAppLifecycle:appLifecycle
-			                               systemState:systemState
-			                                    volume:volume
-			                                 workspace:workspace
-			                                appearance:appearance];
+			[gObserver updateObserversWithAppLifecycle:appLifecycle != 0
+			                               systemState:systemState != 0
+			                                    volume:volume != 0
+			                                 workspace:workspace != 0
+			                                appearance:appearance != 0];
 		}
 		dispatch_semaphore_signal(sem);
 	});


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes some window related observer registration.

- Prevent the background thread run loop from exiting immediately by attaching a dummy CFRunLoopSource when no active timers are scheduled.
- Fix Go-C ABI alignment mismatch by passing WorkspaceObserver parameters as standard int types instead of bool.
- Ensure AppLifecycle notifications are enabled whenever window events are configured, so accessibility observers can register dynamically on activation.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
