### PR TITLE
feat(event): add `on_window_resize` observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ For auto-start at login, launchd agent setup, Nix modules, and troubleshooting �
 
 ## ⌨️ Events
 
-Mimi observes **30 macOS system events** across 10 categories. Every hook receives rich context via `mimi_*` environment variables.
+Mimi observes **33 macOS system events** across 11 categories. Every hook receives rich context via `mimi_*` environment variables.
 
 | Category             | Events                                                 |
 | :------------------- | :----------------------------------------------------- |
 | App Lifecycle        | activate, deactivate, launch, quit, hide, unhide       |
-| Window (AX)          | focus, title change, created, closed                   |
+| Window (AX)          | focus, title change, created, closed, resize           |
 | System Power         | sleep, wake, screen lock/unlock, shutdown, session end |
 | Storage              | volume mount, unmount                                  |
 | Display / Appearance | external display connect/disconnect, dark/light mode   |

--- a/cmd/mimi/cmd/config.go
+++ b/cmd/mimi/cmd/config.go
@@ -128,6 +128,7 @@ func countHooks(cfg *config.Config) int {
 		cfg.Hooks.AppHide, cfg.Hooks.AppUnhide,
 		cfg.Hooks.WindowFocus, cfg.Hooks.WindowTitleChange,
 		cfg.Hooks.WindowCreated, cfg.Hooks.WindowClosed,
+		cfg.Hooks.WindowResize,
 		cfg.Hooks.SystemSleep, cfg.Hooks.SystemWake,
 		cfg.Hooks.ScreenLock, cfg.Hooks.ScreenUnlock,
 		cfg.Hooks.SystemShutdown, cfg.Hooks.UserSessionEnd,

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -119,6 +119,11 @@ on_app_activate = []
 #     "echo 'window closed: $mimi_APP_NAME'"
 # ]
 
+# Window finished resizing (debounced, fires once after resize ends).
+# on_window_resize = [
+#     "echo 'window resized: $mimi_APP_NAME — $mimi_WINDOW_TITLE'"
+# ]
+
 # ── System Power Events ────────────────────────────────────────────────────────
 
 # System going to sleep.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,7 +204,7 @@ The bridge has two layers:
 |                     |                                            | volume_mount, unmount                                      |
 | **Appearance**      | NSDistributedNotificationCenter            | appearance_changed                                         |
 | **Space Poll**      | CGWindowListCopyWindowInfo polling (200ms) | workspace_changed (with window info JSON)                  |
-| **AXObserver**      | Accessibility API (per-app)                | window_focus, title_change, created, closed                |
+| **AXObserver**      | Accessibility API (per-app)                | window_focus, title_change, created, closed, window_resize |
 | **Power / Battery** | IOKit (IOPowerSources)                     | power_adapter_connected/disconnected, battery_low/critical |
 | **Audio**           | CoreAudio property listeners               | audio_device_changed                                       |
 | **Clipboard**       | NSPasteboard polling (500ms)               | clipboard_changed                                          |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -283,12 +283,13 @@ For `on_workspace_changed` events, `mimi_INFO` contains a JSON string:
 
 ### Window Events (requires Accessibility permission)
 
-| Hook key                 | Fires when…                 | Variables available         |
-| ------------------------ | --------------------------- | --------------------------- |
-| `on_window_focus`        | Focused window changes      | APP_NAME, WINDOW_TITLE, PID |
-| `on_window_title_change` | Active window title changes | APP_NAME, WINDOW_TITLE, PID |
-| `on_window_created`      | A new window opens          | APP_NAME, PID               |
-| `on_window_closed`       | A window closes             | APP_NAME, PID               |
+| Hook key                 | Fires when…                                   | Variables available                    |
+| ------------------------ | --------------------------------------------- | -------------------------------------- |
+| `on_window_focus`        | Focused window changes                        | APP_NAME, WINDOW_TITLE, BUNDLE_ID, PID |
+| `on_window_title_change` | Active window title changes                   | APP_NAME, WINDOW_TITLE, BUNDLE_ID, PID |
+| `on_window_created`      | A new window opens                            | APP_NAME, BUNDLE_ID, PID               |
+| `on_window_closed`       | A window closes                               | APP_NAME, BUNDLE_ID, PID               |
+| `on_window_resize`       | A window finishes resizing (debounced, 250ms) | APP_NAME, WINDOW_TITLE, BUNDLE_ID, PID |
 
 ### System Events
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -116,7 +116,7 @@ Or use Activity Monitor → search "mimi" → Force Quit.
 
 ### Accessibility Permission
 
-Window events (`window_focus`, `window_title_change`, etc.) require Accessibility permission.
+Window events (`window_focus`, `window_title_change`, `window_resize`, etc.) require Accessibility permission.
 
 **Grant permissions:**
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type HooksConfig struct {
 	WindowTitleChange           []HookEntry `json:"onWindowTitleChange"           toml:"on_window_title_change"`
 	WindowCreated               []HookEntry `json:"onWindowCreated"               toml:"on_window_created"`
 	WindowClosed                []HookEntry `json:"onWindowClosed"                toml:"on_window_closed"`
+	WindowResize                []HookEntry `json:"onWindowResize"                toml:"on_window_resize"`
 	SystemSleep                 []HookEntry `json:"onSystemSleep"                 toml:"on_system_sleep"`
 	SystemWake                  []HookEntry `json:"onSystemWake"                  toml:"on_system_wake"`
 	ScreenLock                  []HookEntry `json:"onScreenLock"                  toml:"on_screen_lock"`
@@ -88,6 +89,7 @@ type rawHooksConfig struct {
 	WindowTitleChange           []any `json:"onWindowTitleChange"           toml:"on_window_title_change"`
 	WindowCreated               []any `json:"onWindowCreated"               toml:"on_window_created"`
 	WindowClosed                []any `json:"onWindowClosed"                toml:"on_window_closed"`
+	WindowResize                []any `json:"onWindowResize"                toml:"on_window_resize"`
 	SystemSleep                 []any `json:"onSystemSleep"                 toml:"on_system_sleep"`
 	SystemWake                  []any `json:"onSystemWake"                  toml:"on_system_wake"`
 	ScreenLock                  []any `json:"onScreenLock"                  toml:"on_screen_lock"`
@@ -176,6 +178,7 @@ func decodeHooks(raw rawHooksConfig) (HooksConfig, error) {
 	hooksCfg.WindowTitleChange = decodeField("on_window_title_change", raw.WindowTitleChange)
 	hooksCfg.WindowCreated = decodeField("on_window_created", raw.WindowCreated)
 	hooksCfg.WindowClosed = decodeField("on_window_closed", raw.WindowClosed)
+	hooksCfg.WindowResize = decodeField("on_window_resize", raw.WindowResize)
 	hooksCfg.SystemSleep = decodeField("on_system_sleep", raw.SystemSleep)
 	hooksCfg.SystemWake = decodeField("on_system_wake", raw.SystemWake)
 	hooksCfg.ScreenLock = decodeField("on_screen_lock", raw.ScreenLock)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -204,6 +204,7 @@ func allHookEntries(cfg *Config) map[string][]HookEntry {
 		string(events.WindowTitleChange):           cfg.Hooks.WindowTitleChange,
 		string(events.WindowCreated):               cfg.Hooks.WindowCreated,
 		string(events.WindowClosed):                cfg.Hooks.WindowClosed,
+		string(events.WindowResize):                cfg.Hooks.WindowResize,
 		string(events.SystemSleep):                 cfg.Hooks.SystemSleep,
 		string(events.SystemWake):                  cfg.Hooks.SystemWake,
 		string(events.ScreenLock):                  cfg.Hooks.ScreenLock,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -185,7 +185,8 @@ func hasWindowEvents(cfg *config.Config) bool {
 	return len(cfg.Hooks.WindowFocus) > 0 ||
 		len(cfg.Hooks.WindowTitleChange) > 0 ||
 		len(cfg.Hooks.WindowCreated) > 0 ||
-		len(cfg.Hooks.WindowClosed) > 0
+		len(cfg.Hooks.WindowClosed) > 0 ||
+		len(cfg.Hooks.WindowResize) > 0
 }
 
 func getObserverConfig(cfg *config.Config) cgo_bridge.ObserverConfig {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -37,6 +37,15 @@ func TestHasWindowEvents(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "window resize only",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					WindowResize: []config.HookEntry{{Run: "echo"}},
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "app activate only",
 			cfg: &config.Config{
 				Hooks: config.HooksConfig{
@@ -161,5 +170,33 @@ func TestGetObserverConfig(t *testing.T) {
 		windowOnlyObs.Display ||
 		windowOnlyObs.SystemState {
 		t.Errorf("expected only AppLifecycle to be enabled, got: %+v", windowOnlyObs)
+	}
+
+	// WindowResize only case — should also enable AppLifecycle
+	resizeOnlyCfg := &config.Config{
+		Hooks: config.HooksConfig{
+			WindowResize: []config.HookEntry{{Run: "echo"}},
+		},
+	}
+
+	resizeOnlyObs := getObserverConfig(resizeOnlyCfg)
+	if !resizeOnlyObs.AppLifecycle {
+		t.Error("expected AppLifecycle to be enabled when WindowResize is configured")
+	}
+
+	if resizeOnlyObs.Audio ||
+		resizeOnlyObs.Power ||
+		resizeOnlyObs.Clipboard ||
+		resizeOnlyObs.USB ||
+		resizeOnlyObs.Network ||
+		resizeOnlyObs.Volume ||
+		resizeOnlyObs.Workspace ||
+		resizeOnlyObs.Appearance ||
+		resizeOnlyObs.Display ||
+		resizeOnlyObs.SystemState {
+		t.Errorf(
+			"expected only AppLifecycle to be enabled for resize-only config, got: %+v",
+			resizeOnlyObs,
+		)
 	}
 }

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -27,6 +27,10 @@ const (
 	WindowCreated EventKind = "window_created"
 	// WindowClosed fires when a window closes.
 	WindowClosed EventKind = "window_closed"
+	// WindowResizing fires when a window is being resized (raw).
+	WindowResizing EventKind = "_window_resizing"
+	// WindowResize fires when a window resize is completed (debounced).
+	WindowResize EventKind = "window_resize"
 
 	// SystemSleep fires when the system or display goes to sleep.
 	SystemSleep EventKind = "system_sleep"
@@ -85,7 +89,7 @@ const (
 // AllKinds lists every known event kind.
 var AllKinds = []EventKind{
 	AppActivate, AppDeactivate, AppLaunch, AppQuit, AppHide, AppUnhide,
-	WindowFocus, WindowTitleChange, WindowCreated, WindowClosed,
+	WindowFocus, WindowTitleChange, WindowCreated, WindowClosed, WindowResize, WindowResizing,
 	SystemSleep, SystemWake, ScreenLock, ScreenUnlock, SystemShutdown, UserSessionEnd,
 	VolumeMount, VolumeUnmount,
 	ExternalDisplayConnected, ExternalDisplayDisconnected, AppearanceChanged,

--- a/internal/hooks/registry.go
+++ b/internal/hooks/registry.go
@@ -80,6 +80,7 @@ func buildMap(cfg *config.Config) (map[events.EventKind][]Hook, error) {
 		events.WindowTitleChange:           cfg.Hooks.WindowTitleChange,
 		events.WindowCreated:               cfg.Hooks.WindowCreated,
 		events.WindowClosed:                cfg.Hooks.WindowClosed,
+		events.WindowResize:                cfg.Hooks.WindowResize,
 		events.SystemSleep:                 cfg.Hooks.SystemSleep,
 		events.SystemWake:                  cfg.Hooks.SystemWake,
 		events.ScreenLock:                  cfg.Hooks.ScreenLock,

--- a/internal/observers/cgo_bridge/axobserver.m
+++ b/internal/observers/cgo_bridge/axobserver.m
@@ -41,6 +41,8 @@ static void axCallback(AXObserverRef observer, AXUIElementRef element, CFStringR
 			kind = 32;
 		else if (CFEqual(notification, kAXUIElementDestroyedNotification))
 			kind = 33;
+		else if (CFEqual(notification, kAXWindowResizedNotification))
+			kind = 34;
 
 		if (kind >= 0) {
 			NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
@@ -71,10 +73,8 @@ static void axInstallBlock(int pid) {
 	}
 
 	CFStringRef notifications[] = {
-	    kAXFocusedWindowChangedNotification,
-	    kAXTitleChangedNotification,
-	    kAXWindowCreatedNotification,
-	    kAXUIElementDestroyedNotification,
+	    kAXFocusedWindowChangedNotification, kAXTitleChangedNotification,  kAXWindowCreatedNotification,
+	    kAXUIElementDestroyedNotification,   kAXWindowResizedNotification,
 	};
 	size_t notifCount = sizeof(notifications) / sizeof(notifications[0]);
 	for (size_t i = 0; i < notifCount; i++) {

--- a/internal/observers/cgo_bridge/bridge.go
+++ b/internal/observers/cgo_bridge/bridge.go
@@ -263,6 +263,7 @@ func kindFromInt(kindInt int) events.EventKind {
 		// Window events
 		30: events.WindowFocus, 31: events.WindowTitleChange,
 		32: events.WindowCreated, 33: events.WindowClosed,
+		34: events.WindowResizing,
 		// Display/Appearance events
 		40: events.ExternalDisplayConnected, 41: events.ExternalDisplayDisconnected,
 		42: events.AppearanceChanged,

--- a/internal/observers/workspace.go
+++ b/internal/observers/workspace.go
@@ -2,18 +2,34 @@ package observers
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"time"
 
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/mimi/internal/events"
 	"github.com/y3owk1n/mimi/internal/observers/cgo_bridge"
 )
 
+const resizeDebounceDuration = 250 * time.Millisecond
+
 // WorkspaceObserver receives CGO bridge events and routes them to the bus.
 type WorkspaceObserver struct {
 	bus    *events.Bus
 	axMgr  *AccessibilityManager
 	logger *zap.SugaredLogger
+
+	mu      sync.Mutex
+	timers  map[string]*resizeState
+	stopped bool
+}
+
+// resizeState holds a pending debounce timer and the latest event snapshot for a window.
+type resizeState struct {
+	timer *time.Timer
+	evt   events.Event
 }
 
 // NewWorkspaceObserver creates a new workspace observer.
@@ -22,22 +38,31 @@ func NewWorkspaceObserver(
 	axMgr *AccessibilityManager,
 	logger *zap.SugaredLogger,
 ) *WorkspaceObserver {
-	return &WorkspaceObserver{bus: bus, axMgr: axMgr, logger: logger}
+	return &WorkspaceObserver{
+		bus:    bus,
+		axMgr:  axMgr,
+		logger: logger,
+		timers: make(map[string]*resizeState),
+	}
 }
 
 // Run starts the observer loop, consuming events and routing them.
 func (o *WorkspaceObserver) Run(ctx context.Context) {
-	ch := cgo_bridge.EventCh()
+	evChannel := cgo_bridge.EventCh()
 	for {
 		select {
 		case <-ctx.Done():
+			o.stopAllTimers()
+
 			return
-		case e, ok := <-ch:
+		case event, ok := <-evChannel:
 			if !ok {
+				o.stopAllTimers()
+
 				return
 			}
 
-			o.handle(e)
+			o.handle(event)
 		}
 	}
 }
@@ -54,7 +79,12 @@ func (o *WorkspaceObserver) handle(evt events.Event) {
 	case events.AppQuit:
 		if evt.PID > 0 {
 			o.axMgr.Remove(evt.PID)
+			o.cancelTimersForPID(evt.PID)
 		}
+	case events.WindowResizing:
+		o.debounceResize(evt)
+
+		return
 	default:
 	}
 
@@ -67,4 +97,100 @@ func (o *WorkspaceObserver) handle(evt events.Event) {
 		"vol", evt.VolumeName,
 	)
 	o.bus.Publish(evt)
+}
+
+// resizeKey returns a unique key for debouncing resize events per window.
+func resizeKey(pid int, title string) string {
+	return fmt.Sprintf("%d:%s", pid, title)
+}
+
+// debounceResize resets or starts a debounce timer for the given resize event.
+// When the timer fires (after 250ms of no further resize events for the same
+// window), a single WindowResize event is published.
+func (o *WorkspaceObserver) debounceResize(evt events.Event) {
+	key := resizeKey(evt.PID, evt.WindowTitle)
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.stopped {
+		return
+	}
+
+	if rState, ok := o.timers[key]; ok {
+		// Stop the existing timer. Even if Stop returns false (timer already
+		// fired or is firing), the callback checks whether the entry still
+		// exists in the map before publishing, so we are safe to overwrite.
+		rState.timer.Stop()
+		rState.evt = evt
+		rState.timer.Reset(resizeDebounceDuration)
+
+		return
+	}
+
+	rState := &resizeState{evt: evt}
+	rState.timer = time.AfterFunc(resizeDebounceDuration, func() {
+		o.mu.Lock()
+		// Guard: if the entry was already removed by cancelTimersForPID,
+		// stopAllTimers, or a concurrent debounceResize that replaced it,
+		// do nothing. Also bail if the observer has been stopped entirely.
+		current, exists := o.timers[key]
+		if !exists || current != rState || o.stopped {
+			o.mu.Unlock()
+
+			return
+		}
+
+		snapshot := rState.evt
+
+		delete(o.timers, key)
+		o.mu.Unlock()
+
+		resizeEvt := events.Event{
+			ID:          uuid.NewString(),
+			Kind:        events.WindowResize,
+			AppName:     snapshot.AppName,
+			BundleID:    snapshot.BundleID,
+			PID:         snapshot.PID,
+			WindowTitle: snapshot.WindowTitle,
+			At:          time.Now(),
+		}
+		o.logger.Debugw("event",
+			"kind", resizeEvt.Kind,
+			"app", resizeEvt.AppName,
+			"bundle", resizeEvt.BundleID,
+			"pid", resizeEvt.PID,
+			"title", resizeEvt.WindowTitle,
+		)
+		o.bus.Publish(resizeEvt)
+	})
+	o.timers[key] = rState
+}
+
+// cancelTimersForPID stops and removes all pending resize timers for a given PID.
+func (o *WorkspaceObserver) cancelTimersForPID(pid int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	for key, rs := range o.timers {
+		if rs.evt.PID == pid {
+			rs.timer.Stop()
+			delete(o.timers, key)
+		}
+	}
+}
+
+// stopAllTimers stops all pending resize timers and marks the observer as
+// stopped so that any timer callbacks that have already started waiting on
+// the mutex will bail out instead of publishing after shutdown.
+func (o *WorkspaceObserver) stopAllTimers() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.stopped = true
+
+	for key, rs := range o.timers {
+		rs.timer.Stop()
+		delete(o.timers, key)
+	}
 }

--- a/internal/observers/workspace_test.go
+++ b/internal/observers/workspace_test.go
@@ -1,0 +1,223 @@
+//nolint:testpackage
+package observers
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+func TestDebounceResize_SingleEvent(t *testing.T) {
+	bus := events.NewBus()
+	sub := bus.Subscribe(16)
+	axMgr := NewAccessibilityManager(false)
+	logger := zap.NewNop().Sugar()
+
+	obs := NewWorkspaceObserver(bus, axMgr, logger)
+
+	evt := events.Event{
+		Kind:        events.WindowResizing,
+		AppName:     "TestApp",
+		BundleID:    "com.test.app",
+		PID:         42,
+		WindowTitle: "Test Window",
+		At:          time.Now(),
+	}
+
+	obs.debounceResize(evt)
+
+	select {
+	case _evt := <-sub:
+		if _evt.Kind != events.WindowResize {
+			t.Errorf("expected WindowResize, got %s", _evt.Kind)
+		}
+
+		if _evt.AppName != "TestApp" {
+			t.Errorf("expected AppName TestApp, got %s", _evt.AppName)
+		}
+
+		if _evt.PID != 42 {
+			t.Errorf("expected PID 42, got %d", _evt.PID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for debounced resize event")
+	}
+
+	// Verify no stale timers remain.
+	obs.mu.Lock()
+	remaining := len(obs.timers)
+	obs.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("expected 0 remaining timers, got %d", remaining)
+	}
+}
+
+func TestDebounceResize_MultipleEventsCoalesce(t *testing.T) {
+	bus := events.NewBus()
+	sub := bus.Subscribe(16)
+	axMgr := NewAccessibilityManager(false)
+	logger := zap.NewNop().Sugar()
+
+	obs := NewWorkspaceObserver(bus, axMgr, logger)
+
+	// Simulate rapid resize events — only the last should produce an event.
+	for index := range 5 {
+		evt := events.Event{
+			Kind:        events.WindowResizing,
+			AppName:     "TestApp",
+			BundleID:    "com.test.app",
+			PID:         42,
+			WindowTitle: "Test Window",
+			At:          time.Now(),
+			Extra:       map[string]string{"seq": string(rune('0' + index))},
+		}
+		obs.debounceResize(evt)
+		time.Sleep(50 * time.Millisecond) // well within the 250ms debounce
+	}
+
+	// Should get exactly one event.
+	select {
+	case e := <-sub:
+		if e.Kind != events.WindowResize {
+			t.Errorf("expected WindowResize, got %s", e.Kind)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for debounced resize event")
+	}
+
+	// Verify no second event arrives.
+	select {
+	case e := <-sub:
+		t.Errorf("unexpected second event: %+v", e)
+	case <-time.After(500 * time.Millisecond):
+		// Expected — no more events.
+	}
+}
+
+func TestDebounceResize_DifferentWindows(t *testing.T) {
+	bus := events.NewBus()
+	sub := bus.Subscribe(16)
+	axMgr := NewAccessibilityManager(false)
+	logger := zap.NewNop().Sugar()
+
+	obs := NewWorkspaceObserver(bus, axMgr, logger)
+
+	// Two different windows should produce two separate events.
+	obs.debounceResize(events.Event{
+		Kind: events.WindowResizing, PID: 1, WindowTitle: "Win A", AppName: "AppA",
+	})
+	obs.debounceResize(events.Event{
+		Kind: events.WindowResizing, PID: 2, WindowTitle: "Win B", AppName: "AppB",
+	})
+
+	received := make(map[string]bool)
+
+	for range 2 {
+		select {
+		case e := <-sub:
+			received[e.AppName] = true
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for debounced resize events")
+		}
+	}
+
+	if !received["AppA"] || !received["AppB"] {
+		t.Errorf("expected events from both windows, got: %v", received)
+	}
+}
+
+func TestDebounceResize_CancelTimersForPID(t *testing.T) {
+	bus := events.NewBus()
+	sub := bus.Subscribe(16)
+	axMgr := NewAccessibilityManager(false)
+	logger := zap.NewNop().Sugar()
+
+	obs := NewWorkspaceObserver(bus, axMgr, logger)
+
+	obs.debounceResize(events.Event{
+		Kind: events.WindowResizing, PID: 99, WindowTitle: "Win", AppName: "App",
+	})
+
+	// Cancel before the timer fires.
+	obs.cancelTimersForPID(99)
+
+	select {
+	case e := <-sub:
+		t.Errorf("expected no event after cancel, got: %+v", e)
+	case <-time.After(500 * time.Millisecond):
+		// Expected — timer was canceled.
+	}
+
+	obs.mu.Lock()
+	remaining := len(obs.timers)
+	obs.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("expected 0 remaining timers after cancel, got %d", remaining)
+	}
+}
+
+func TestDebounceResize_StopAllTimers(t *testing.T) {
+	bus := events.NewBus()
+	sub := bus.Subscribe(16)
+	axMgr := NewAccessibilityManager(false)
+	logger := zap.NewNop().Sugar()
+
+	obs := NewWorkspaceObserver(bus, axMgr, logger)
+
+	// Queue up several resize events for different windows.
+	for i := range 3 {
+		obs.debounceResize(events.Event{
+			Kind: events.WindowResizing, PID: i + 1, WindowTitle: "Win", AppName: "App",
+		})
+	}
+
+	obs.stopAllTimers()
+
+	select {
+	case e := <-sub:
+		t.Errorf("expected no events after stopAllTimers, got: %+v", e)
+	case <-time.After(500 * time.Millisecond):
+		// Expected — all timers were stopped.
+	}
+
+	obs.mu.Lock()
+	remaining := len(obs.timers)
+	stopped := obs.stopped
+	obs.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("expected 0 remaining timers, got %d", remaining)
+	}
+
+	if !stopped {
+		t.Error("expected stopped flag to be true")
+	}
+}
+
+func TestDebounceResize_NoPublishAfterStop(t *testing.T) {
+	bus := events.NewBus()
+	sub := bus.Subscribe(16)
+	axMgr := NewAccessibilityManager(false)
+	logger := zap.NewNop().Sugar()
+
+	obs := NewWorkspaceObserver(bus, axMgr, logger)
+
+	// Stop immediately — any subsequent debounce calls should be no-ops.
+	obs.stopAllTimers()
+
+	obs.debounceResize(events.Event{
+		Kind: events.WindowResizing, PID: 1, WindowTitle: "Win", AppName: "App",
+	})
+
+	select {
+	case e := <-sub:
+		t.Errorf("expected no events after stop, got: %+v", e)
+	case <-time.After(500 * time.Millisecond):
+		// Expected.
+	}
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new `on_window_resize` event to the family. This hook will be called when the window resize is done.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
