### PR TITLE
feat: add `space`, `focus_window` and `move_window_to_space` action

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/mimi/internal/actions"
+)
+
+var actionFocusWindowBackward bool
+
+// actionCmd is the parent command for direct (non-event-driven)
+// mimi actions. Subcommands invoke individual handlers
+// implemented in the internal/actions package.
+var actionCmd = &cobra.Command{
+	Use:   "action",
+	Short: "Perform an immediate mimi action",
+	Long:  "Perform an immediate mimi action without going through a running daemon.\n\nEach subcommand runs the requested action synchronously and exits.\nFrom a hook shell command, invoke these as ordinary mimi\nsubcommands, e.g.:\n\n  on_app_activate = ['mimi action focus_window']\n  on_app_activate = ['mimi action focus_window --backward']\n  on_workspace_changed = ['mimi action space 1']\n  on_workspace_changed = ['mimi action move_window_to_space 2']\n\nAvailable subcommands:\n  focus_window               Cycle focus through windows on the active space\n  <n>                  Focus Mission Control space at index N (1-based)\n  move_window_to_space <n>   Move the frontmost window to Mission Control space at index N",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
+}
+
+var actionFocusWindowCmd = &cobra.Command{
+	Use:   actions.NameFocusWindow,
+	Short: "Cycle focus through windows on the active space",
+	Long: `Cycle keyboard focus through all focusable windows on the current space.
+
+Cycles forward by default; pass --backward to cycle in the opposite
+direction. Both directions wrap at the end of the list. Only windows
+that are focusable (not minimized, not hidden) and on the current
+space are included.`,
+	Args: cobra.NoArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		ensureCocoaInitialized()
+
+		err := actions.FocusWindow(actionFocusWindowBackward)
+		if err != nil {
+			return err
+		}
+
+		RootCmd.Printf("%s performed\n", actions.NameFocusWindow)
+
+		return nil
+	},
+}
+
+var actionSpaceCmd = &cobra.Command{
+	Use:   actions.NameSpace + " <number>",
+	Short: "Focus a Mission Control space by 1-based index",
+	Long: `Focus a Mission Control space by its 1-based index.
+
+Spaces are enumerated in Mission Control ordering across all
+connected displays. Index 1 is the first space (typically the
+leftmost on the primary display), index 2 the second, and so on.
+
+macOS does not expose a public API to activate a space, so the
+command synthesizes a high-velocity horizontal dock swipe
+gesture to fast-forward to the destination space without the
+standard swipe animation. When the destination sits on a
+different display, the cursor is warped to its center first so
+the gesture is attributed to the correct screen.
+
+Examples:
+  mimi action space 1
+  mimi action space 3`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		ensureCocoaInitialized()
+
+		index, err := actions.ParseIndexArg(args, actions.NameSpace)
+		if err != nil {
+			return err
+		}
+
+		err = actions.Space(index)
+		if err != nil {
+			return err
+		}
+
+		RootCmd.Printf("%s performed (index %d)\n", actions.NameSpace, index)
+
+		return nil
+	},
+}
+
+var actionMoveWindowToSpaceCmd = &cobra.Command{
+	Use:   actions.NameMoveWindowToSpace + " <number>",
+	Short: "Move the frontmost window to a Mission Control space by 1-based index",
+	Long: `Move the currently focused window to a Mission Control space by its
+1-based index.
+
+Spaces are enumerated in Mission Control ordering across all
+connected displays. Index 1 is the first space, index 2 the
+second, and so on. The move uses private SkyLight APIs and
+completes asynchronously; the command returns once the move has
+been dispatched.
+
+Examples:
+  mimi action move_window_to_space 2
+  mimi action move_window_to_space 4`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		ensureCocoaInitialized()
+
+		index, err := actions.ParseIndexArg(args, actions.NameMoveWindowToSpace)
+		if err != nil {
+			return err
+		}
+
+		err = actions.MoveWindowToSpace(index)
+		if err != nil {
+			return err
+		}
+
+		RootCmd.Printf("%s performed (index %d)\n", actions.NameMoveWindowToSpace, index)
+
+		return nil
+	},
+}
+
+func init() {
+	actionFocusWindowCmd.Flags().
+		BoolVar(&actionFocusWindowBackward, "backward", false,
+			"cycle to the previous window instead of the next one")
+
+	actionCmd.AddCommand(actionFocusWindowCmd)
+	actionCmd.AddCommand(actionSpaceCmd)
+	actionCmd.AddCommand(actionMoveWindowToSpaceCmd)
+
+	RootCmd.AddCommand(actionCmd)
+}

--- a/cmd/mimi/cmd/cocoa_init.go
+++ b/cmd/mimi/cmd/cocoa_init.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"sync"
+
+	"github.com/y3owk1n/mimi/internal/space"
+)
+
+// cocoaInitOnce ensures we only call [NSApplication
+// sharedApplication] once per process. Action subcommands need
+// an initialized NSApplication to use AppKit helpers such as
+// NSRunningApplication and NSWorkspace from the CGo bridge.
+var cocoaInitOnce sync.Once
+
+// ensureCocoaInitialized brings up NSApplication on the calling
+// thread. Safe to call from multiple goroutines; only the first
+// call does real work. main() already locks the main OS thread,
+// which is the thread NSApplication expects.
+func ensureCocoaInitialized() {
+	cocoaInitOnce.Do(space.InitCocoa)
+}

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -1,0 +1,256 @@
+package actions
+
+import (
+	"strconv"
+	"strings"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/space"
+)
+
+// FocusWindow cycles focus through focusable windows on the
+// active space. When backward is true it walks the list in the
+// opposite direction. Both directions wrap at the boundaries.
+//
+// Returns nil on success. Errors are domain errors with
+// CodeInvalidInput for caller mistakes and CodeActionFailed for
+// platform or accessibility failures.
+func FocusWindow(backward bool) error {
+	windows, err := space.AllFocusableWindowsOnActiveSpace()
+	if err != nil {
+		return derrors.Wrap(err, derrors.CodeActionFailed, "enumerate focusable windows")
+	}
+
+	defer space.ReleaseAll(windows)
+
+	if len(windows) == 0 {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"no focusable windows found on the active space",
+		)
+	}
+
+	// Determine the index of the currently focused window. We use
+	// the system-wide frontmost window (kAXFocusedWindowAttribute
+	// on the app element) rather than per-window IsFocused(),
+	// because kAXFocusedAttribute on window elements is unreliable
+	// across applications.
+	frontmost := space.FrontmostWindow()
+	defer space.ReleaseWindow(frontmost)
+
+	currentIndex := -1
+	if frontmost != nil {
+		for i, w := range windows {
+			if space.ElementsEqual(w, frontmost) {
+				currentIndex = i
+
+				break
+			}
+		}
+	}
+
+	targetIndex := nextIndex(currentIndex, len(windows), backward)
+
+	err = space.ActivateWindow(windows[targetIndex])
+	if err != nil {
+		return derrors.Wrap(err, derrors.CodeActionFailed, "activate target window")
+	}
+
+	return nil
+}
+
+// Space focuses the Mission Control space at the given 1-based
+// index. Refuses to run while Mission Control is visible, since
+// the synthetic swipe would fight the user's own gesture.
+func Space(index int) error {
+	if index < 1 {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"space number must be a positive integer, got %d",
+			index,
+		)
+	}
+
+	if space.IsMissionControlActive() {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"cannot switch spaces while Mission Control is active",
+		)
+	}
+
+	var err error
+
+	count := space.CountMissionControlSpaces()
+	if count == 0 {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"failed to enumerate Mission Control spaces",
+		)
+	}
+
+	if index > count {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"space number %d is out of range; valid range is 1..%d",
+			index,
+			count,
+		)
+	}
+
+	sid := space.MissionControlSpaceID(index)
+	if sid == 0 {
+		return derrors.Newf(
+			derrors.CodeActionFailed,
+			"failed to resolve Mission Control space at index %d",
+			index,
+		)
+	}
+
+	did := space.DisplayIDForSpace(sid)
+	if did == 0 {
+		return derrors.Newf(
+			derrors.CodeActionFailed,
+			"failed to resolve display for Mission Control space at index %d",
+			index,
+		)
+	}
+
+	err = space.FocusSpaceUsingGesture(did, sid)
+	if err != nil {
+		return derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"focus space at index %d",
+			index,
+		)
+	}
+
+	return nil
+}
+
+// MoveWindowToSpace moves the current focused window to the
+// Mission Control space at the given 1-based index. Refuses to
+// run while Mission Control is visible.
+func MoveWindowToSpace(index int) error {
+	if index < 1 {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"space number must be a positive integer, got %d",
+			index,
+		)
+	}
+
+	if space.IsMissionControlActive() {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"cannot move window while Mission Control is active",
+		)
+	}
+
+	var err error
+
+	count := space.CountMissionControlSpaces()
+	if count == 0 {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"failed to enumerate Mission Control spaces",
+		)
+	}
+
+	if index > count {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"space number %d is out of range; valid range is 1..%d",
+			index,
+			count,
+		)
+	}
+
+	sid := space.MissionControlSpaceID(index)
+	if sid == 0 {
+		return derrors.Newf(
+			derrors.CodeActionFailed,
+			"failed to resolve Mission Control space at index %d",
+			index,
+		)
+	}
+
+	frontmost := space.FrontmostWindow()
+	if frontmost == nil {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"no active window found to move",
+		)
+	}
+	defer space.ReleaseWindow(frontmost)
+
+	err = space.MoveWindowToSpace(frontmost, sid)
+	if err != nil {
+		return derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"move window to space at index %d",
+			index,
+		)
+	}
+
+	return nil
+}
+
+// ParseIndexArg extracts and validates a single 1-based index
+// argument. actionName is interpolated into the error message
+// ("<actionName> requires exactly one positional argument...").
+// The returned *derrors.Error is suitable for direct return from
+// a cobra RunE.
+func ParseIndexArg(args []string, actionName string) (int, error) {
+	if len(args) != 1 {
+		return 0, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"%s requires exactly one positional argument: the 1-based space number",
+			actionName,
+		)
+	}
+
+	raw := strings.TrimSpace(args[0])
+	if raw == "" {
+		return 0, derrors.New(
+			derrors.CodeInvalidInput,
+			"space number cannot be empty",
+		)
+	}
+
+	index, parseErr := strconv.Atoi(raw)
+	if parseErr != nil || index < 1 {
+		return 0, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"space number must be a positive integer, got %q",
+			raw,
+		)
+	}
+
+	return index, nil
+}
+
+// nextIndex returns the next focusable-window index relative to
+// currentIndex. currentIndex may be -1 (no current window),
+// which causes the function to return 0 (or len-1 when
+// backward). The result always wraps into the [0, total) range.
+func nextIndex(currentIndex, total int, backward bool) int {
+	if total <= 0 {
+		return 0
+	}
+
+	if backward {
+		if currentIndex < 0 {
+			return total - 1
+		}
+
+		return (currentIndex - 1 + total) % total
+	}
+
+	if currentIndex < 0 {
+		return 0
+	}
+
+	return (currentIndex + 1) % total
+}

--- a/internal/actions/doc.go
+++ b/internal/actions/doc.go
@@ -1,0 +1,9 @@
+// Package actions implements the macOS user-facing actions that
+// mimi exposes: FocusWindow (cycle focus through windows on the
+// active space), Space (switch to a Mission Control space by
+// index), and MoveWindowToSpace (send the frontmost window to a
+// Mission Control space by index).
+//
+// The handlers in this package are intentionally macOS-only;
+// mimi is a macOS-only project.
+package actions

--- a/internal/actions/names.go
+++ b/internal/actions/names.go
@@ -1,0 +1,19 @@
+package actions
+
+// Names of the user-facing actions exposed by this package. These
+// are the names that appear in CLI invocations and (in the
+// future) as references from hook shell commands.
+const (
+	// NameFocusWindow cycles focus through focusable windows on the
+	// active space. Accepts an optional --backward flag.
+	NameFocusWindow = "focus_window"
+
+	// NameSpace focuses a Mission Control space by its 1-based
+	// index. Requires a single positional argument.
+	NameSpace = "space"
+
+	// NameMoveWindowToSpace moves the current focused window to a
+	// Mission Control space by its 1-based index. Requires a
+	// single positional argument.
+	NameMoveWindowToSpace = "move_window_to_space"
+)

--- a/internal/space/doc.go
+++ b/internal/space/doc.go
@@ -1,0 +1,6 @@
+// Package space exposes macOS Mission Control space and window
+// enumeration helpers used by the action package.
+//
+// All exported functions are macOS-only; mimi has no other
+// build targets.
+package space

--- a/internal/space/errors.go
+++ b/internal/space/errors.go
@@ -1,0 +1,25 @@
+package space
+
+import derrors "github.com/y3owk1n/mimi/internal/errors"
+
+var (
+	errNoWindow = derrors.New(
+		derrors.CodeActionFailed,
+		"no window reference provided",
+	)
+
+	errActivateFailed = derrors.New(
+		derrors.CodeActionFailed,
+		"failed to activate window",
+	)
+
+	errFocusSpaceFailed = derrors.New(
+		derrors.CodeActionFailed,
+		"failed to focus Mission Control space",
+	)
+
+	errMoveWindowFailed = derrors.New(
+		derrors.CodeActionFailed,
+		"failed to move window to space",
+	)
+)

--- a/internal/space/space.go
+++ b/internal/space/space.go
@@ -1,0 +1,179 @@
+package space
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#cgo LDFLAGS: -framework AppKit -framework ApplicationServices -framework CoreFoundation -framework Foundation -F/System/Library/PrivateFrameworks -framework SkyLight
+
+#include "space.h"
+*/
+import "C"
+
+import (
+	"sync"
+	"unsafe"
+)
+
+// WindowRef is an opaque reference to a macOS AXUIElementRef
+// representing a window. Callers must hand it back to
+// ReleaseWindow / ReleaseAll when done.
+type WindowRef unsafe.Pointer
+
+// initCocoaOnce ensures InitCocoa performs its NSApplication
+// bootstrap exactly once per process.
+var initCocoaOnce sync.Once
+
+// AllFocusableWindowsOnActiveSpace returns every focusable
+// window on the active space, sorted by screen position
+// (y-coordinate first, then x-coordinate). Each returned
+// WindowRef is retained; call ReleaseAll to release them.
+func AllFocusableWindowsOnActiveSpace() ([]WindowRef, error) {
+	var count C.int
+	raw := C.MimiGetAllFocusableWindowsOnActiveSpace(&count)
+	if raw == nil || count == 0 {
+		empty := []WindowRef(nil)
+		if raw != nil {
+			C.free(unsafe.Pointer(raw))
+		}
+
+		return empty, nil
+	}
+	defer C.free(unsafe.Pointer(raw)) //nolint:nlreturn
+
+	n := int(count)
+	slice := (*[1 << 28]unsafe.Pointer)(unsafe.Pointer(raw))[:n:n]
+
+	result := make([]WindowRef, n)
+	for i := range slice {
+		result[i] = WindowRef(slice[i])
+	}
+
+	return result, nil
+}
+
+// FrontmostWindow returns the current frontmost window or nil
+// when the system has no focused window. The returned reference
+// is retained; the caller is responsible for calling
+// ReleaseWindow on it.
+func FrontmostWindow() WindowRef {
+	ref := C.MimiGetFrontmostWindow()
+	if ref == nil {
+		return nil
+	}
+
+	return WindowRef(ref)
+}
+
+// ReleaseWindow releases a window reference obtained from
+// AllFocusableWindowsOnActiveSpace or FrontmostWindow. Safe to
+// call on nil.
+func ReleaseWindow(ref WindowRef) {
+	if ref == nil {
+		return
+	}
+	C.MimiReleaseElement(unsafe.Pointer(ref))
+}
+
+// ReleaseAll releases every window reference in the slice.
+// Safe to call on nil or empty slices.
+func ReleaseAll(refs []WindowRef) {
+	for _, ref := range refs {
+		ReleaseWindow(ref)
+	}
+}
+
+// ElementsEqual reports whether two window references refer to
+// the same underlying accessibility element.
+func ElementsEqual(a, b WindowRef) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	equal := C.MimiAreElementsEqual(unsafe.Pointer(a), unsafe.Pointer(b)) //nolint:nlreturn
+
+	return equal == 1
+}
+
+// ActivateWindow brings the window to the foreground and gives
+// it keyboard focus. Returns nil on success, an error otherwise.
+func ActivateWindow(ref WindowRef) error {
+	if ref == nil {
+		return errNoWindow
+	}
+	ok := C.MimiActivateWindow(unsafe.Pointer(ref)) //nolint:nlreturn
+	if ok == 1 {
+		return nil
+	}
+
+	return errActivateFailed
+}
+
+// IsMissionControlActive returns true while Mission Control is
+// currently on screen.
+func IsMissionControlActive() bool {
+	return bool(C.MimiIsMissionControlActive())
+}
+
+// CountMissionControlSpaces returns the total number of Mission
+// Control spaces across all connected displays. Returns 0 when
+// spaces cannot be enumerated.
+func CountMissionControlSpaces() int {
+	return int(C.MimiCountMissionControlSpaces())
+}
+
+// MissionControlSpaceID returns the space ID for the 1-based
+// Mission Control index. Returns 0 when the index is out of
+// range.
+func MissionControlSpaceID(index int) uint64 {
+	return uint64(C.MimiMissionControlSpaceID(C.int(index)))
+}
+
+// DisplayIDForSpace returns the display ID that owns a given
+// space. Returns 0 when the space is invalid.
+func DisplayIDForSpace(sid uint64) uint32 {
+	return uint32(C.MimiSpaceDisplayID(C.uint64_t(sid)))
+}
+
+// FocusSpaceUsingGesture focuses the given space using a
+// synthetic high-velocity horizontal dock swipe gesture.
+//
+// The caller must have already verified Mission Control is not
+// active. Returns nil on success.
+func FocusSpaceUsingGesture(did uint32, sid uint64) error {
+	ok := C.MimiFocusSpaceUsingGesture(C.uint32_t(did), C.uint64_t(sid))
+	if ok == 1 {
+		return nil
+	}
+
+	return errFocusSpaceFailed
+}
+
+// MoveWindowToSpace moves the window to the given space. On
+// the primary path the move is dispatched asynchronously; the
+// return value reports whether the operation was queued, not
+// whether the window has already moved.
+func MoveWindowToSpace(ref WindowRef, sid uint64) error {
+	if ref == nil {
+		return errNoWindow
+	}
+	ok := C.MimiMoveWindowToSpace(unsafe.Pointer(ref), C.uint64_t(sid)) //nolint:nlreturn
+	if ok == 1 {
+		return nil
+	}
+
+	return errMoveWindowFailed
+}
+
+// InitCocoa initializes NSApplication on the calling thread.
+// Must be called once, from the main OS thread, before any
+// other call in this package. AppKit helpers such as
+// NSRunningApplication and NSWorkspace require a live
+// NSApplication to function.
+//
+// The function is idempotent and safe to call from multiple
+// goroutines, but only the first call does work. Subsequent
+// callers block on the internal once.
+func InitCocoa() {
+	initCocoaOnce.Do(func() {
+		C.MimiInitCocoaApp()
+	})
+}

--- a/internal/space/space.h
+++ b/internal/space/space.h
@@ -1,0 +1,94 @@
+// Package internal/space CGo bridge header.
+//
+// Cherry-picked from neru: only the symbols required by
+// action.FocusWindow, action.Space, and action.MoveWindowToSpace
+// are exposed here. Symbol names use the Mimi* prefix; they have
+// been renamed from the upstream Neru* identifiers.
+#pragma once
+#include <ApplicationServices/ApplicationServices.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#pragma mark - Cocoa Bootstrap
+
+/// Bring up NSApplication on the calling thread. Must be
+/// called once, from the main OS thread, before any other
+/// call in this header. Required because AppKit helpers
+/// (NSRunningApplication, NSWorkspace) need a live
+/// NSApplication. The function is safe to call from any
+/// thread; the actual setup only runs the first time.
+void MimiInitCocoaApp(void);
+
+#pragma mark - Element Reference Lifecycle
+
+/// Release an AXUIElementRef obtained from one of the window
+/// enumeration helpers below. Safe to call on NULL.
+void MimiReleaseElement(void *element);
+
+#pragma mark - Window Enumeration (focus_window)
+
+/// Return all focusable windows on the active space across every
+/// running application. Filters out non-focusable windows
+/// (minimized, hidden, off-space, non-AXWindow roles).
+///
+/// Each returned reference is retained; the caller must release
+/// them with MimiReleaseElement and free the returned array
+/// with the C library free(3).
+///
+/// @param count Output parameter that receives the window count.
+/// @return NULL-terminated array of AXUIElementRef pointers, or NULL
+///         on failure or when no focusable windows exist.
+void **MimiGetAllFocusableWindowsOnActiveSpace(int *count);
+
+/// Return the frontmost window across the system. The returned
+/// reference is retained; the caller must release it with
+/// MimiReleaseElement.
+void *MimiGetFrontmostWindow(void);
+
+/// Bring the window to the foreground and give it keyboard focus.
+int MimiActivateWindow(void *window);
+
+/// Check whether two window references refer to the same
+/// underlying AXUIElement. Returns 1 on equal, 0 otherwise.
+int MimiAreElementsEqual(void *element1, void *element2);
+
+#pragma mark - Mission Control Detection (space / move_window_to_space)
+
+/// Return true when Mission Control is currently on screen.
+bool MimiIsMissionControlActive(void);
+
+#pragma mark - Space Switching (space)
+
+/// Total number of Mission Control spaces across all displays
+/// in their current ordering.
+int MimiCountMissionControlSpaces(void);
+
+/// Space ID for a 1-based Mission Control index. Returns 0
+/// when the index is out of range or unavailable.
+uint64_t MimiMissionControlSpaceID(int index);
+
+/// Display ID that owns the given space ID. Returns 0 when the
+/// space is invalid.
+uint32_t MimiSpaceDisplayID(uint64_t sid);
+
+/// Focus a space using a synthetic high-velocity horizontal
+/// dock swipe gesture.
+///
+/// The caller must have already verified Mission Control is
+/// not active and that the destination differs from the current
+/// one. When focus crosses displays, the cursor is warped to
+/// the destination display first so the gesture is attributed
+/// to the correct screen.
+int MimiFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid);
+
+#pragma mark - Window-to-Space (move_window_to_space)
+
+/// Move a window to a specific space ID via the dynamic
+/// SkyLight class. On the primary path the move is dispatched
+/// asynchronously; 1 means the operation was queued, not that
+/// the window has already moved. The synchronous
+/// SLSMoveWindowsToManagedSpace fallback provides a stronger
+/// completion guarantee but is only used when the primary
+/// path is unavailable.
+int MimiMoveWindowToSpace(void *windowElement, uint64_t spaceID);

--- a/internal/space/space.m
+++ b/internal/space/space.m
@@ -1,0 +1,971 @@
+//
+//  space.m
+//  Mimi
+//
+//  Implementation of the space/window CGo bridge. Cherry-picked
+//  from neru/internal/core/infra/platform/darwin/ and renamed
+//  from Neru* to Mimi* identifiers. macOS-only by design; mimi
+//  is a macOS-only project.
+//
+
+#include "space.h"
+
+#import <AppKit/AppKit.h>
+#import <ApplicationServices/ApplicationServices.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+#import <mach-o/dyld.h>
+#import <mach-o/loader.h>
+#import <mach-o/nlist.h>
+#import <objc/message.h>
+#import <objc/objc.h>
+#import <objc/runtime.h>
+
+#pragma mark - Private SkyLight / WindowServer Declarations
+
+extern int SLSMainConnectionID(void);
+extern CFArrayRef SLSCopyManagedDisplaySpaces(int cid);
+extern CFStringRef SLSCopyManagedDisplayForSpace(int cid, uint64_t sid);
+extern uint64_t SLSManagedDisplayGetCurrentSpace(int cid, CFStringRef uuid);
+extern CGError SLSSetActiveMenuBarDisplayIdentifier(int cid, CFStringRef uuid, CFStringRef repeat_uuid);
+extern CGError SLSGetCurrentCursorLocation(int cid, CGPoint *point);
+extern AXError _AXUIElementGetWindow(AXUIElementRef element, CGWindowID *out);
+extern CGError SLSMoveWindowsToManagedSpace(int cid, CFArrayRef window_list, uint64_t sid);
+
+#pragma mark - Cocoa Bootstrap
+
+static dispatch_once_t kMimiCocoaInitOnce = 0;
+static bool kMimiCocoaInitialized = false;
+
+void MimiInitCocoaApp(void) {
+	dispatch_once(&kMimiCocoaInitOnce, ^{
+		@autoreleasepool {
+			[NSApplication sharedApplication];
+			[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+		}
+		kMimiCocoaInitialized = true;
+	});
+}
+
+#pragma mark - Element Reference Lifecycle
+
+void MimiReleaseElement(void *element) {
+	if (element) {
+		CFRelease((AXUIElementRef)element);
+	}
+}
+
+#pragma mark - Window Enumeration Helpers
+
+/// Sort-friendly key: store a CGPoint by value (NSPoint structs
+/// are interchangeable with CGPoint for our purposes).
+static NSValue *mimiPositionKey(CGPoint point) {
+	NSValue *value = [[NSValue alloc] initWithBytes:&point objCType:@encode(CGPoint)];
+
+	return value;
+}
+
+static CGPoint mimiGetWindowPosition(AXUIElementRef window) {
+	CFTypeRef positionValue = NULL;
+	if (AXUIElementCopyAttributeValue(window, kAXPositionAttribute, &positionValue) == kAXErrorSuccess &&
+	    positionValue) {
+		CGPoint point = CGPointZero;
+		if (CFGetTypeID(positionValue) == AXValueGetTypeID()) {
+			AXValueGetValue((AXValueRef)positionValue, kAXValueCGPointType, &point);
+		}
+		CFRelease(positionValue);
+
+		return point;
+	}
+
+	return CGPointZero;
+}
+
+#pragma mark - Window Enumeration (focus_window)
+
+void **MimiGetAllFocusableWindowsOnActiveSpace(int *count) {
+	if (!count) {
+		return NULL;
+	}
+
+	@autoreleasepool {
+		*count = 0;
+
+		NSArray *runningApps = [[NSWorkspace sharedWorkspace].runningApplications
+		    sortedArrayUsingComparator:^NSComparisonResult(NSRunningApplication *obj1, NSRunningApplication *obj2) {
+			    if (obj1.processIdentifier < obj2.processIdentifier) {
+				    return NSOrderedAscending;
+			    } else if (obj1.processIdentifier > obj2.processIdentifier) {
+				    return NSOrderedDescending;
+			    }
+
+			    return NSOrderedSame;
+		    }];
+		CFMutableArrayRef windowsCollector = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+		if (!windowsCollector) {
+			return NULL;
+		}
+
+		for (NSRunningApplication *app in runningApps) {
+			if (app.activationPolicy != NSApplicationActivationPolicyRegular) {
+				continue;
+			}
+			if (app.hidden) {
+				continue;
+			}
+
+			pid_t pid = app.processIdentifier;
+			AXUIElementRef appElement = AXUIElementCreateApplication(pid);
+			if (!appElement) {
+				continue;
+			}
+
+			CFTypeRef windowsValue = NULL;
+			AXError error = AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute, &windowsValue);
+			if (error != kAXErrorSuccess || !windowsValue) {
+				CFRelease(appElement);
+
+				continue;
+			}
+
+			if (CFGetTypeID(windowsValue) != CFArrayGetTypeID()) {
+				CFRelease(windowsValue);
+				CFRelease(appElement);
+
+				continue;
+			}
+
+			CFArrayRef windows = (CFArrayRef)windowsValue;
+			CFIndex windowCount = CFArrayGetCount(windows);
+
+			for (CFIndex i = 0; i < windowCount; i++) {
+				AXUIElementRef window = (AXUIElementRef)CFArrayGetValueAtIndex(windows, i);
+				if (!window) {
+					continue;
+				}
+
+				CFStringRef attrs[] = {
+				    kAXRoleAttribute,
+				    kAXMinimizedAttribute,
+				    CFSTR("AXWindowIsOnActiveSpace"),
+				};
+				CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 3, &kCFTypeArrayCallBacks);
+				if (!attrArray) {
+					continue;
+				}
+
+				CFArrayRef values = NULL;
+				AXUIElementCopyMultipleAttributeValues(window, attrArray, 0, &values);
+				CFRelease(attrArray);
+
+				if (!values) {
+					continue;
+				}
+
+				bool shouldInclude = false;
+
+				if (CFArrayGetCount(values) > 0) {
+					CFTypeRef roleVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 0);
+					if (roleVal && CFGetTypeID(roleVal) == CFStringGetTypeID() &&
+					    CFStringCompare((CFStringRef)roleVal, CFSTR("AXWindow"), 0) == kCFCompareEqualTo) {
+						shouldInclude = true;
+					}
+				}
+
+				if (shouldInclude && CFArrayGetCount(values) > 1) {
+					CFTypeRef minVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 1);
+					if (minVal && CFGetTypeID(minVal) == CFBooleanGetTypeID() &&
+					    CFBooleanGetValue((CFBooleanRef)minVal)) {
+						shouldInclude = false;
+					}
+				}
+
+				// AXWindowIsOnActiveSpace: exclude if explicitly false
+				// (gracefully include when the attribute is unsupported).
+				if (shouldInclude && CFArrayGetCount(values) > 2) {
+					CFTypeRef spaceVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 2);
+					if (spaceVal && CFGetTypeID(spaceVal) == CFBooleanGetTypeID() &&
+					    !CFBooleanGetValue((CFBooleanRef)spaceVal)) {
+						shouldInclude = false;
+					}
+				}
+
+				CFRelease(values);
+
+				if (shouldInclude) {
+					CFArrayAppendValue(windowsCollector, window);
+				}
+			}
+
+			CFRelease(windowsValue);
+			CFRelease(appElement);
+		}
+
+		CFIndex total = CFArrayGetCount(windowsCollector);
+		if (total == 0) {
+			CFRelease(windowsCollector);
+
+			return NULL;
+		}
+
+		// Pre-compute positions and PIDs once so the sort comparator
+		// doesn't trigger fresh AX round-trips per comparison.
+		NSMutableDictionary<NSValue *, NSValue *> *positions = [NSMutableDictionary dictionaryWithCapacity:total];
+		NSMutableDictionary<NSValue *, NSNumber *> *pids = [NSMutableDictionary dictionaryWithCapacity:total];
+		for (CFIndex i = 0; i < total; i++) {
+			AXUIElementRef w = (AXUIElementRef)CFArrayGetValueAtIndex(windowsCollector, i);
+			CGPoint pos = mimiGetWindowPosition(w);
+			positions[[NSValue valueWithPointer:w]] = mimiPositionKey(pos);
+
+			pid_t pid = 0;
+			AXUIElementGetPid(w, &pid);
+			pids[[NSValue valueWithPointer:w]] = @(pid);
+		}
+
+		NSArray *sortedWindows =
+		    [(__bridge NSArray *)windowsCollector sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+			    AXUIElementRef w1 = (__bridge AXUIElementRef)obj1;
+			    AXUIElementRef w2 = (__bridge AXUIElementRef)obj2;
+
+			    NSValue *key1 = [NSValue valueWithPointer:w1];
+			    NSValue *key2 = [NSValue valueWithPointer:w2];
+
+			    CGPoint p1 = CGPointZero;
+			    CGPoint p2 = CGPointZero;
+			    [positions[key1] getValue:&p1];
+			    [positions[key2] getValue:&p2];
+
+			    if (p1.y < p2.y) {
+				    return NSOrderedAscending;
+			    }
+			    if (p1.y > p2.y) {
+				    return NSOrderedDescending;
+			    }
+			    if (p1.x < p2.x) {
+				    return NSOrderedAscending;
+			    }
+			    if (p1.x > p2.x) {
+				    return NSOrderedDescending;
+			    }
+
+			    int pid1 = [pids[key1] intValue];
+			    int pid2 = [pids[key2] intValue];
+			    if (pid1 < pid2) {
+				    return NSOrderedAscending;
+			    }
+			    if (pid1 > pid2) {
+				    return NSOrderedDescending;
+			    }
+
+			    return NSOrderedSame;
+		    }];
+
+		void **result = (void **)malloc(total * sizeof(void *));
+		if (!result) {
+			CFRelease(windowsCollector);
+
+			return NULL;
+		}
+
+		for (CFIndex i = 0; i < total; i++) {
+			result[i] = (void *)(__bridge AXUIElementRef)sortedWindows[i];
+			CFRetain(result[i]);
+		}
+
+		CFRelease(windowsCollector);
+		*count = (int)total;
+
+		return result;
+	}
+}
+
+void *MimiGetFrontmostWindow(void) {
+	@autoreleasepool {
+		// Resolve the focused application.
+		AXUIElementRef sysWide = AXUIElementCreateSystemWide();
+		AXUIElementRef focusedApp = NULL;
+		if (sysWide) {
+			AXUIElementCopyAttributeValue(sysWide, kAXFocusedApplicationAttribute, (CFTypeRef *)&focusedApp);
+			CFRelease(sysWide);
+		}
+
+		AXUIElementRef appRef = focusedApp;
+		bool shouldReleaseAppRef = false;
+
+		if (!appRef) {
+			NSRunningApplication *front = [NSWorkspace sharedWorkspace].frontmostApplication;
+			if (!front) {
+				return NULL;
+			}
+
+			pid_t pid = front.processIdentifier;
+			appRef = AXUIElementCreateApplication(pid);
+			if (!appRef) {
+				return NULL;
+			}
+
+			shouldReleaseAppRef = true;
+		}
+
+		CFArrayRef windowAttrs = CFArrayCreate(
+		    NULL,
+		    (CFTypeRef[]){
+		        kAXFocusedWindowAttribute,
+		        kAXWindowsAttribute,
+		    },
+		    2, &kCFTypeArrayCallBacks);
+		if (!windowAttrs) {
+			if (shouldReleaseAppRef && appRef) {
+				CFRelease(appRef);
+			} else if (focusedApp) {
+				CFRelease(focusedApp);
+			}
+
+			return NULL;
+		}
+
+		CFArrayRef windowValues = NULL;
+		AXError batchError = AXUIElementCopyMultipleAttributeValues(appRef, windowAttrs, 0, &windowValues);
+		CFRelease(windowAttrs);
+
+		AXUIElementRef window = NULL;
+		CFArrayRef windows = NULL;
+
+		if (batchError == kAXErrorSuccess && windowValues && CFArrayGetCount(windowValues) >= 2) {
+			CFTypeRef focusedVal = (CFTypeRef)CFArrayGetValueAtIndex(windowValues, 0);
+			if (focusedVal && CFGetTypeID(focusedVal) != CFNullGetTypeID()) {
+				window = (AXUIElementRef)focusedVal;
+				CFRetain(window);
+			}
+
+			CFTypeRef windowsVal = (CFTypeRef)CFArrayGetValueAtIndex(windowValues, 1);
+			if (windowsVal && CFGetTypeID(windowsVal) == CFArrayGetTypeID()) {
+				windows = (CFArrayRef)windowsVal;
+				CFRetain(windows);
+			}
+		}
+
+		if (windowValues) {
+			CFRelease(windowValues);
+		}
+
+		if (shouldReleaseAppRef && appRef) {
+			CFRelease(appRef);
+		}
+
+		if (window) {
+			if (focusedApp) {
+				CFRelease(focusedApp);
+			}
+			if (windows) {
+				CFRelease(windows);
+			}
+
+			return (void *)window;
+		}
+
+		if (windows && CFArrayGetCount(windows) > 0) {
+			AXUIElementRef firstWindow = (AXUIElementRef)CFArrayGetValueAtIndex(windows, 0);
+			CFRetain(firstWindow);
+			CFRelease(windows);
+			if (focusedApp) {
+				CFRelease(focusedApp);
+			}
+
+			return (void *)firstWindow;
+		}
+
+		if (windows) {
+			CFRelease(windows);
+		}
+
+		if (focusedApp) {
+			CFRelease(focusedApp);
+		}
+
+		return NULL;
+	}
+}
+
+int MimiActivateWindow(void *window) {
+	if (!window) {
+		return 0;
+	}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+	@autoreleasepool {
+		AXUIElementRef axWindow = (AXUIElementRef)window;
+
+		pid_t pid;
+		if (AXUIElementGetPid(axWindow, &pid) != kAXErrorSuccess) {
+			return 0;
+		}
+
+		NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+		if (!app) {
+			return 0;
+		}
+
+		// NSApplicationActivateIgnoringOtherApps is deprecated in macOS 14+
+		// but remains the only public way to programmatically activate an
+		// app from a non-bundled CLI process. Suppress the warning locally.
+		[app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+
+		AXUIElementSetAttributeValue(axWindow, kAXMainAttribute, kCFBooleanTrue);
+		AXUIElementSetAttributeValue(axWindow, kAXFocusedAttribute, kCFBooleanTrue);
+
+		AXError raiseError = AXUIElementPerformAction(axWindow, kAXRaiseAction);
+
+		return (raiseError == kAXErrorSuccess) ? 1 : 0;
+	}
+#pragma clang diagnostic pop
+}
+
+int MimiAreElementsEqual(void *element1, void *element2) {
+	if (!element1 || !element2) {
+		return element1 == element2;
+	}
+
+	return CFEqual((AXUIElementRef)element1, (AXUIElementRef)element2) ? 1 : 0;
+}
+
+#pragma mark - Mission Control Detection (space / move_window_to_space)
+
+/// Hybrid Mission Control detector used by both space and
+/// move_window_to_space.
+///
+/// macOS does not expose a public API to query the Mission Control
+/// state, so we inspect the window list. The "Mission Control" app
+/// surfaces its window on macOS 13 and earlier; Sonoma/Sequoia/Tahoe
+/// instead expose a Dock overlay at higher CGWindowLayer values.
+static bool mimiDetectMissionControlActive(void) {
+	@autoreleasepool {
+		CFArrayRef windowList = CGWindowListCopyWindowInfo(kCGWindowListOptionAll, kCGNullWindowID);
+		if (!windowList) {
+			return false;
+		}
+
+		CFIndex count = CFArrayGetCount(windowList);
+		int dockHighLayerWindows = 0;
+		int dockOverlayWindows = 0;
+
+		for (CFIndex i = 0; i < count; i++) {
+			CFDictionaryRef windowInfo = (CFDictionaryRef)CFArrayGetValueAtIndex(windowList, i);
+			if (!windowInfo) {
+				continue;
+			}
+
+			CFStringRef ownerName = (CFStringRef)CFDictionaryGetValue(windowInfo, kCGWindowOwnerName);
+			if (!ownerName) {
+				continue;
+			}
+
+			if (CFStringCompare(ownerName, CFSTR("Mission Control"), 0) == kCFCompareEqualTo) {
+				CFRelease(windowList);
+
+				return YES;
+			}
+
+			if (CFStringCompare(ownerName, CFSTR("Dock"), 0) != kCFCompareEqualTo) {
+				continue;
+			}
+
+			CFNumberRef windowLayer = (CFNumberRef)CFDictionaryGetValue(windowInfo, kCGWindowLayer);
+			if (!windowLayer) {
+				continue;
+			}
+
+			int layer = 0;
+			CFNumberGetValue(windowLayer, CFNumberGetType(windowLayer), &layer);
+
+			// Layers 18-20: Dock MC overlays on macOS 14 Sonoma
+			if (layer >= 18 && layer <= 20) {
+				dockHighLayerWindows++;
+				if (dockHighLayerWindows >= 2) {
+					CFRelease(windowList);
+
+					return YES;
+				}
+			}
+
+			// Layers 14-25: broader range covering macOS 15 Sequoia/Tahoe
+			// where the window manager may use different layers.
+			if (layer >= 14 && layer <= 25) {
+				dockOverlayWindows++;
+				if (dockOverlayWindows >= 3) {
+					CFRelease(windowList);
+
+					return YES;
+				}
+			}
+		}
+
+		CFRelease(windowList);
+
+		return NO;
+	}
+}
+
+bool MimiIsMissionControlActive(void) { return mimiDetectMissionControlActive(); }
+
+#pragma mark - Display / Space Helpers (space)
+
+/// Translate a display ID to its UUID string.
+/// @return Retained CFStringRef (caller must CFRelease), or NULL on failure
+static CFStringRef mimiDisplayUUID(uint32_t did) {
+	CFUUIDRef uuidRef = CGDisplayCreateUUIDFromDisplayID(did);
+	if (!uuidRef) {
+		return NULL;
+	}
+
+	CFStringRef uuidStr = CFUUIDCreateString(NULL, uuidRef);
+	CFRelease(uuidRef);
+
+	return uuidStr;
+}
+
+/// Get the current Mission Control space for a display.
+/// @return Space ID, or 0 on failure
+static uint64_t mimiDisplaySpaceID(uint32_t did) {
+	CFStringRef uuid = mimiDisplayUUID(did);
+	if (!uuid) {
+		return 0;
+	}
+
+	uint64_t sid = SLSManagedDisplayGetCurrentSpace(SLSMainConnectionID(), uuid);
+	CFRelease(uuid);
+
+	return sid;
+}
+
+/// Return the center point of a display's bounds (in CG coordinates).
+static CGPoint mimiDisplayCenter(uint32_t did) {
+	CGRect bounds = CGDisplayBounds(did);
+
+	return (CGPoint){bounds.origin.x + bounds.size.width / 2.0, bounds.origin.y + bounds.size.height / 2.0};
+}
+
+/// Return the display ID that currently contains the cursor.
+static uint32_t mimiCursorDisplayID(void) {
+	CGPoint cursor;
+	SLSGetCurrentCursorLocation(SLSMainConnectionID(), &cursor);
+
+	uint32_t matchingDisplays[16];
+	uint32_t matchingCount = 0;
+
+	CGError err = CGGetDisplaysWithPoint(cursor, 16, matchingDisplays, &matchingCount);
+	if (err == kCGErrorSuccess && matchingCount > 0) {
+		return matchingDisplays[0];
+	}
+
+	// Fall back to the main display if the cursor is somehow outside every display.
+	return CGMainDisplayID();
+}
+
+/// Set the active menu bar display, which updates which display is the
+/// "focused" one for Space purposes.
+static void mimiSetActiveMenuBarDisplay(uint32_t did) {
+	CFStringRef uuid = mimiDisplayUUID(did);
+	if (!uuid) {
+		return;
+	}
+
+	SLSSetActiveMenuBarDisplayIdentifier(SLSMainConnectionID(), uuid, uuid);
+	CFRelease(uuid);
+}
+
+#pragma mark - Mission Control Index Resolution (space)
+
+/// Find the 1-based Mission Control indices of two space IDs in a single
+/// pass over SLSCopyManagedDisplaySpaces. Returns false if either sid is
+/// not found in the current Mission Control ordering.
+static bool mimiResolveMCIndices(uint64_t curSid, uint64_t newSid, int *outCurIndex, int *outNewIndex) {
+	*outCurIndex = 0;
+	*outNewIndex = 0;
+
+	@autoreleasepool {
+		CFArrayRef displaySpaces = SLSCopyManagedDisplaySpaces(SLSMainConnectionID());
+		if (!displaySpaces) {
+			return false;
+		}
+
+		int counter = 1;
+
+		CFIndex displayCount = CFArrayGetCount(displaySpaces);
+		for (CFIndex i = 0; i < displayCount; i++) {
+			CFDictionaryRef displayRef = (CFDictionaryRef)CFArrayGetValueAtIndex(displaySpaces, i);
+			CFArrayRef spacesRef = (CFArrayRef)CFDictionaryGetValue(displayRef, CFSTR("Spaces"));
+			if (!spacesRef) {
+				continue;
+			}
+
+			CFIndex spacesCount = CFArrayGetCount(spacesRef);
+			for (CFIndex j = 0; j < spacesCount; j++) {
+				CFDictionaryRef spaceRef = (CFDictionaryRef)CFArrayGetValueAtIndex(spacesRef, j);
+				CFNumberRef sidRef = (CFNumberRef)CFDictionaryGetValue(spaceRef, CFSTR("id64"));
+				if (!sidRef) {
+					continue;
+				}
+
+				uint64_t sid = 0;
+				CFNumberGetValue(sidRef, CFNumberGetType(sidRef), &sid);
+
+				if (sid == curSid) {
+					*outCurIndex = counter;
+				}
+
+				if (sid == newSid) {
+					*outNewIndex = counter;
+				}
+
+				counter++;
+			}
+		}
+
+		CFRelease(displaySpaces);
+
+		return (*outCurIndex > 0) && (*outNewIndex > 0);
+	}
+}
+
+#pragma mark - Space Counting and Lookup (space)
+
+int MimiCountMissionControlSpaces(void) {
+	@autoreleasepool {
+		CFArrayRef displaySpaces = SLSCopyManagedDisplaySpaces(SLSMainConnectionID());
+		if (!displaySpaces) {
+			return 0;
+		}
+
+		int total = 0;
+		CFIndex displayCount = CFArrayGetCount(displaySpaces);
+		for (CFIndex i = 0; i < displayCount; i++) {
+			CFDictionaryRef displayRef = (CFDictionaryRef)CFArrayGetValueAtIndex(displaySpaces, i);
+			CFArrayRef spacesRef = (CFArrayRef)CFDictionaryGetValue(displayRef, CFSTR("Spaces"));
+			if (!spacesRef) {
+				continue;
+			}
+
+			total += (int)CFArrayGetCount(spacesRef);
+		}
+
+		CFRelease(displaySpaces);
+
+		return total;
+	}
+}
+
+uint64_t MimiMissionControlSpaceID(int index) {
+	if (index < 1) {
+		return 0;
+	}
+
+	@autoreleasepool {
+		CFArrayRef displaySpaces = SLSCopyManagedDisplaySpaces(SLSMainConnectionID());
+		if (!displaySpaces) {
+			return 0;
+		}
+
+		uint64_t result = 0;
+		int counter = 1;
+
+		CFIndex displayCount = CFArrayGetCount(displaySpaces);
+		for (CFIndex i = 0; i < displayCount; i++) {
+			CFDictionaryRef displayRef = (CFDictionaryRef)CFArrayGetValueAtIndex(displaySpaces, i);
+			CFArrayRef spacesRef = (CFArrayRef)CFDictionaryGetValue(displayRef, CFSTR("Spaces"));
+			if (!spacesRef) {
+				continue;
+			}
+
+			CFIndex spacesCount = CFArrayGetCount(spacesRef);
+			for (CFIndex j = 0; j < spacesCount; j++) {
+				if (counter == index) {
+					CFDictionaryRef spaceRef = (CFDictionaryRef)CFArrayGetValueAtIndex(spacesRef, j);
+					CFNumberRef sidRef = (CFNumberRef)CFDictionaryGetValue(spaceRef, CFSTR("id64"));
+					if (sidRef) {
+						CFNumberGetValue(sidRef, CFNumberGetType(sidRef), &result);
+					}
+
+					CFRelease(displaySpaces);
+
+					return result;
+				}
+
+				counter++;
+			}
+		}
+
+		CFRelease(displaySpaces);
+
+		return 0;
+	}
+}
+
+uint32_t MimiSpaceDisplayID(uint64_t sid) {
+	CFStringRef uuid = SLSCopyManagedDisplayForSpace(SLSMainConnectionID(), sid);
+	if (!uuid) {
+		return 0;
+	}
+
+	// Convert UUID string back to numeric display ID. The CFStringRef
+	// is also a valid input to CFUUIDCreateFromString, so we can
+	// resolve the ID without an extra round trip.
+	CFUUIDRef uuidRef = CFUUIDCreateFromString(NULL, uuid);
+	uint32_t did = 0;
+	if (uuidRef) {
+		did = CGDisplayGetDisplayIDFromUUID(uuidRef);
+		CFRelease(uuidRef);
+	}
+	CFRelease(uuid);
+
+	return did;
+}
+
+#pragma mark - Gesture-Based Space Focus (space)
+
+// Private Core Graphics event field IDs used to synthesize a
+// high-velocity horizontal dock swipe that the Dock treats as a
+// real multi-finger swipe gesture. These constants are not part
+// of the public SDK and require suppressing
+// -Wdeprecated-declarations around the implementation.
+static const int kMimiCGSEventTypeField = 55;              // kCGSEventTypeField
+static const int kMimiCGSEventDockControl = 30;            // kCGSEventDockControl
+static const int kMimiCGEventGestureHIDType = 110;         // kCGEventGestureHIDType
+static const int kMimiIOHIDEventTypeDockSwipe = 23;        // kIOHIDEventTypeDockSwipe
+static const int kMimiCGEventGestureSwipeProgress = 124;   // kCGEventGestureSwipeProgress
+static const int kMimiCGEventGestureSwipeMotion = 123;     // kCGEventGestureSwipeMotion
+static const int kMimiCGGestureMotionHorizontal = 1;       // kCGGestureMotionHorizontal
+static const int kMimiCGEventGestureSwipeVelocityX = 129;  // kCGEventGestureSwipeVelocityX
+static const int kMimiCGEventGesturePhase = 132;           // kCGEventGesturePhase
+static const int kMimiCGSGesturePhaseBegan = 1;            // kCGSGesturePhaseBegan
+static const int kMimiCGSGesturePhaseEnded = 4;            // kCGSGesturePhaseEnded
+
+int MimiFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+	uint32_t curDid = mimiCursorDisplayID();
+	uint64_t curSid = mimiDisplaySpaceID(curDid);
+	CGPoint point = mimiDisplayCenter(new_did);
+	bool focusDisplay = curDid != new_did;
+
+	if (focusDisplay) {
+		CGWarpMouseCursorPosition(point);
+	}
+
+	int curIndex = 0;
+	int newIndex = 0;
+	if (!mimiResolveMCIndices(curSid, new_sid, &curIndex, &newIndex)) {
+		// Could not resolve Mission Control indices (e.g. transient
+		// state). Best-effort fallback: ensure the right display is
+		// active so the OS picks the closest matching space on that
+		// display.
+		mimiSetActiveMenuBarDisplay(new_did);
+
+		return 1;
+	}
+
+	int count = abs(newIndex - curIndex);
+	if (count == 0) {
+		// Already on the same Mission Control index. Make sure the
+		// right display is active in case the destination space sits
+		// on a different display at the same index.
+		if (focusDisplay) {
+			mimiSetActiveMenuBarDisplay(new_did);
+			if (mimiDisplaySpaceID(new_did) != new_sid) {
+				CGPostMouseEvent(point, false, 1, true);
+				CGPostMouseEvent(point, false, 1, false);
+			}
+		}
+
+		return 1;
+	}
+
+	CGEventRef event = CGEventCreate(NULL);
+	if (!event) {
+		return 0;
+	}
+
+	double sign = (newIndex - curIndex) > 0 ? 1.0 : -1.0;
+
+	CGEventSetIntegerValueField(event, kMimiCGSEventTypeField, kMimiCGSEventDockControl);
+	CGEventSetIntegerValueField(event, kMimiCGEventGestureHIDType, kMimiIOHIDEventTypeDockSwipe);
+	CGEventSetIntegerValueField(event, kMimiCGEventGestureSwipeMotion, kMimiCGGestureMotionHorizontal);
+	CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipeProgress, sign);
+	CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipeVelocityX, sign * 9999.0);
+
+	for (int i = 0; i < count; i++) {
+		CGEventSetIntegerValueField(event, kMimiCGEventGesturePhase, kMimiCGSGesturePhaseBegan);
+		CGEventPost(kCGSessionEventTap, event);
+		CGEventSetIntegerValueField(event, kMimiCGEventGesturePhase, kMimiCGSGesturePhaseEnded);
+		CGEventPost(kCGSessionEventTap, event);
+	}
+
+	CFRelease(event);
+
+	// Short run loop iteration so the WindowServer connection
+	// flushes the posted gesture events to the Dock. The Mach
+	// IPC is queued by CGEventPost and needs servicing.
+	[NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+
+	if (focusDisplay) {
+		mimiSetActiveMenuBarDisplay(new_did);
+		if (mimiDisplaySpaceID(new_did) != new_sid) {
+			CGPostMouseEvent(point, false, 1, true);
+			CGPostMouseEvent(point, false, 1, false);
+		}
+	}
+
+	return 1;
+
+#pragma clang diagnostic pop
+}
+
+#pragma mark - Mach-O / Symbol Resolution Helpers (move_window_to_space)
+
+static struct mach_header_64 *mimiMachOFindImageHeader(const char *target_name, uint64_t *slide) {
+	uint32_t image_count = _dyld_image_count();
+	for (uint32_t i = 0; i < image_count; ++i) {
+		const char *image_name = _dyld_get_image_name(i);
+		if (!image_name) {
+			continue;
+		}
+		if (strcmp(image_name, target_name) == 0) {
+			*slide = _dyld_get_image_vmaddr_slide(i);
+
+			return (struct mach_header_64 *)_dyld_get_image_header(i);
+		}
+	}
+
+	return NULL;
+}
+
+static struct segment_command_64 *mimiMachOFindLinkeditSegment(struct mach_header_64 *header) {
+	uint64_t offset = sizeof(struct mach_header_64);
+	for (uint32_t i = 0; i < header->ncmds; ++i) {
+		struct load_command *cmd = (struct load_command *)(((uint8_t *)header) + offset);
+		if (cmd->cmd == LC_SEGMENT_64) {
+			struct segment_command_64 *segment = (struct segment_command_64 *)cmd;
+			if (strcmp(segment->segname, SEG_LINKEDIT) == 0) {
+				return segment;
+			}
+		}
+		offset += cmd->cmdsize;
+	}
+
+	return NULL;
+}
+
+static struct symtab_command *mimiMachOFindSymtabCommand(struct mach_header_64 *header) {
+	uint64_t offset = sizeof(struct mach_header_64);
+	for (uint32_t i = 0; i < header->ncmds; ++i) {
+		struct load_command *cmd = (struct load_command *)(((uint8_t *)header) + offset);
+		if (cmd->cmd == LC_SYMTAB) {
+			return (struct symtab_command *)cmd;
+		}
+		offset += cmd->cmdsize;
+	}
+
+	return NULL;
+}
+
+static void *mimiMachOFindSymbol(const char *target_image, const char *target_symbol) {
+	uint64_t slide = 0;
+	struct mach_header_64 *header = mimiMachOFindImageHeader(target_image, &slide);
+	if (!header) {
+		return NULL;
+	}
+	struct segment_command_64 *linkedit_segment = mimiMachOFindLinkeditSegment(header);
+	if (!linkedit_segment) {
+		return NULL;
+	}
+	struct symtab_command *symtab_command = mimiMachOFindSymtabCommand(header);
+	if (!symtab_command) {
+		return NULL;
+	}
+	uint32_t symbol_count = symtab_command->nsyms;
+	void *symbol_str = (void *)(linkedit_segment->vmaddr - linkedit_segment->fileoff) + symtab_command->stroff + slide;
+	void *symbol_sym = (void *)(linkedit_segment->vmaddr - linkedit_segment->fileoff) + symtab_command->symoff + slide;
+	for (uint32_t i = 0; i < symbol_count; ++i) {
+		struct nlist_64 *list = (void *)symbol_sym + (i * sizeof(struct nlist_64));
+		char *symbol_name = (char *)symbol_str + list->n_un.n_strx;
+		if (strcmp(symbol_name, target_symbol) == 0) {
+			return (void *)(list->n_value + slide);
+		}
+	}
+
+	return NULL;
+}
+
+#pragma mark - Window-to-Space Movement (move_window_to_space)
+
+@protocol MimiSLSBridgedMoveWindowsToManagedSpaceOperationProtocol <NSObject>
+- (instancetype)initWithWindows:(id)windows spaceID:(uint64_t)spaceID;
+@end
+
+int MimiMoveWindowToSpace(void *windowElement, uint64_t spaceID) {
+	if (!windowElement) {
+		return 0;
+	}
+
+	CGWindowID windowId = 0;
+	AXError err = _AXUIElementGetWindow((AXUIElementRef)windowElement, &windowId);
+	if (err != kAXErrorSuccess || windowId == 0) {
+		return 0;
+	}
+
+	// Wrap the window ID in a single-element CFArray.
+	CFNumberRef windowNumber = CFNumberCreate(NULL, kCFNumberSInt32Type, &windowId);
+	if (!windowNumber) {
+		return 0;
+	}
+	CFArrayRef windowList = CFArrayCreate(NULL, (const void **)&windowNumber, 1, &kCFTypeArrayCallBacks);
+	CFRelease(windowNumber);
+	if (!windowList) {
+		return 0;
+	}
+
+	int success = 0;
+
+	// Resolve SLSPerformAsynchronousBridgedWindowManagementOperation
+	// dynamically so we don't have to link the unexported SkyLight
+	// symbol at build time.
+	static int64_t (*mimiSLSPerformAsyncBridged)(void *) = NULL;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		mimiSLSPerformAsyncBridged = (int64_t (*)(void *))mimiMachOFindSymbol(
+		    "/System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight",
+		    "__"
+		    "ZL54SLSPerformAsynchronousBridgedWindowManagementOperationP47SLSAsynchronousBridgedWindowManagementOperati"
+		    "on");
+	});
+
+	// Prefer the synchronous path for short-lived CLI processes.
+	// The async bridged path is designed for daemon-style processes
+	// that stay alive for the WindowServer to complete the operation.
+	CGError cgErr = SLSMoveWindowsToManagedSpace(SLSMainConnectionID(), windowList, spaceID);
+	if (cgErr == kCGErrorSuccess) {
+		// Pump so the WindowServer processes the move.
+		[NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+		success = 1;
+	} else if (mimiSLSPerformAsyncBridged) {
+		Class cls = objc_getClass("SLSBridgedMoveWindowsToManagedSpaceOperation");
+		if (cls) {
+			id operation = [(id<MimiSLSBridgedMoveWindowsToManagedSpaceOperationProtocol>)[cls alloc]
+			    initWithWindows:(__bridge id)windowList
+			            spaceID:spaceID];
+			if (operation) {
+				mimiSLSPerformAsyncBridged((__bridge void *)operation);
+				// Pump so the async operation dispatches before exit.
+				[NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+				success = 1;
+			}
+		}
+	}
+
+	CFRelease(windowList);
+
+	return success;
+}

--- a/justfile
+++ b/justfile
@@ -104,7 +104,7 @@ fmt-check:
         if [ $RESULT -ne 0 ] && [ -n "$FILTERED" ]; then
             EXIT_CODE=1
         fi
-    done < <(find internal/observers/cgo_bridge \( -name "*.h" -o -name "*.m" -o -name "*.c" \) -print0)
+    done < <(find internal/observers/cgo_bridge internal/space \( -name "*.h" -o -name "*.m" -o -name "*.c" \) -print0)
     if [ $EXIT_CODE -ne 0 ]; then
         echo "Some Objective-C files are not properly formatted. Run 'just fmt' to fix them."
         exit 1
@@ -131,7 +131,7 @@ fmt:
     golangci-lint fmt
     golangci-lint run --fix
     @echo "Formatting Objective-C files..."
-    @find internal/observers/cgo_bridge \( -name "*.h" -o -name "*.m" -o -name "*.c" \) -exec sh -c 'case "$1" in *.c) af=file.c;; *) af=file.m;; esac; clang-format -i --style=file --assume-filename="$af" "$1"' _ {} \;
+    @find internal/observers/cgo_bridge internal/space \( -name "*.h" -o -name "*.m" -o -name "*.c" \) -exec sh -c 'case "$1" in *.c) af=file.c;; *) af=file.m;; esac; clang-format -i --style=file --assume-filename="$af" "$1"' _ {} \;
     @echo "✓ Format complete"
 
 # Lint code


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds new action commands for space and window management.

```bash
mimi action focus_window
mimi action space <number>
mimi action move_window_to_space <number
```

This is part of the restructure to make mimi more of a space and window management tool.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A