### PR TITLE
feat: add IPC subsystem and event-driven workspace title

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you like native Spaces and want to stay close to stock macOS — or you are t
 
 | Mode               | When to use it                                                                                 |
 | :----------------- | :--------------------------------------------------------------------------------------------- |
-| **CLI actions**    | One-shot commands — bind to hotkeys, scripts, or Alfred/Raycast. No daemon required.           |
+| **CLI actions**    | One-shot commands — bind to hotkeys, scripts, or Alfred/Raycast. Work without the daemon; route over IPC when it is running for lower latency. |
 | **Daemon + hooks** | React to window and space changes with shell commands (`on_window_*`, `on_workspace_changed`). |
 | **Menu bar**       | See the active space number, reload config, or quit — enabled by default when the daemon runs. |
 

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -56,7 +56,7 @@ current space are included.`,
 				args = append(args, "--backward")
 			}
 
-			return action.Execute(string(action.NameFocusWindow), args)
+			return runAction(string(action.NameFocusWindow), args)
 		},
 	}
 
@@ -87,7 +87,7 @@ Examples:
   mimi action space 3     Focus the third`,
 		Args: validateActionSpaceArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return action.Execute(string(action.NameSpace), []string{strings.TrimSpace(args[0])})
+			return runAction(string(action.NameSpace), []string{strings.TrimSpace(args[0])})
 		},
 	}
 }
@@ -109,7 +109,7 @@ Examples:
   mimi action move_window_to_space 4     Move current window to space 4`,
 		Args: validateActionMoveWindowToSpaceArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return action.Execute(
+			return runAction(
 				string(action.NameMoveWindowToSpace),
 				[]string{strings.TrimSpace(args[0])},
 			)

--- a/cmd/mimi/cmd/action_runner.go
+++ b/cmd/mimi/cmd/action_runner.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/ipc"
+)
+
+func runAction(name string, args []string) error {
+	socketPath := ipc.ResolveSocketPath(configPath)
+
+	err := ipc.TryExecute(socketPath, name, args)
+	if err == nil {
+		return nil
+	}
+
+	if derrors.IsCode(err, derrors.CodeDaemonUnavailable) {
+		return action.Execute(name, args)
+	}
+
+	return err
+}

--- a/cmd/mimi/cmd/config.go
+++ b/cmd/mimi/cmd/config.go
@@ -114,6 +114,7 @@ var configValidateCmd = &cobra.Command{
 }
 
 func init() {
+	addConfigPreRun(configCmd)
 	configCmd.AddCommand(configDumpCmd)
 	configCmd.AddCommand(configReloadCmd)
 	configCmd.AddCommand(configInitCmd)

--- a/cmd/mimi/cmd/configpath.go
+++ b/cmd/mimi/cmd/configpath.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/mimi/internal/config"
+)
+
+func resolveConfigPath() {
+	configPath = config.ResolvePath(configPath)
+}
+
+func addConfigPreRun(cmd *cobra.Command) {
+	existing := cmd.PreRun
+	cmd.PreRun = func(c *cobra.Command, args []string) {
+		resolveConfigPath()
+
+		if existing != nil {
+			existing(c, args)
+		}
+	}
+}

--- a/cmd/mimi/cmd/root.go
+++ b/cmd/mimi/cmd/root.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
-	"github.com/y3owk1n/mimi/internal/config"
 )
 
 var (
@@ -27,9 +25,6 @@ var RootCmd = &cobra.Command{
 
 Use "mimi action" for immediate commands (focus window, switch space, move window).
 Use "mimi start" to run the background daemon and react to window/space events via hooks.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		configPath = config.ResolvePath(configPath)
-	},
 }
 
 // Execute runs the root command and returns any error.

--- a/cmd/mimi/cmd/runtime_paths.go
+++ b/cmd/mimi/cmd/runtime_paths.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/y3owk1n/mimi/internal/config"
+)
+
+func resolveRuntimePaths() (string, string) {
+	resolvedConfig := config.ResolvePath(configPath)
+
+	cfg, err := config.Load(resolvedConfig)
+	if err == nil {
+		return cfg.Settings.PIDFile, cfg.Settings.SocketFile
+	}
+
+	return config.DefaultPIDPath, config.DefaultSocketPath
+}

--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -126,6 +126,7 @@ var servicesStatusCmd = &cobra.Command{
 }
 
 func init() {
+	addConfigPreRun(servicesInstallCmd)
 	servicesCmd.AddCommand(servicesInstallCmd)
 	servicesCmd.AddCommand(servicesUninstallCmd)
 	servicesCmd.AddCommand(servicesStartCmd)

--- a/cmd/mimi/cmd/start.go
+++ b/cmd/mimi/cmd/start.go
@@ -39,3 +39,7 @@ var startCmd = &cobra.Command{
 		return daemon.Run(cfg, logger, configPath, Version)
 	},
 }
+
+func init() {
+	addConfigPreRun(startCmd)
+}

--- a/cmd/mimi/cmd/status.go
+++ b/cmd/mimi/cmd/status.go
@@ -13,7 +13,9 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show daemon and permission status",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		pid, err := readPID(defaultPIDPath())
+		pidPath, socketPath := resolveRuntimePaths()
+
+		pid, err := readPID(pidPath)
 		if err != nil {
 			cmd.Println("mimi: not running")
 		} else {
@@ -32,6 +34,13 @@ var statusCmd = &cobra.Command{
 			cmd.Println("accessibility: granted")
 		} else {
 			cmd.Println("accessibility: not granted (required for window hooks and actions)")
+		}
+
+		_, statErr := os.Stat(expandHome(socketPath))
+		if statErr == nil {
+			cmd.Printf("ipc: socket available at %s\n", expandHome(socketPath))
+		} else {
+			cmd.Println("ipc: socket not available (actions run directly until daemon starts)")
 		}
 
 		return nil

--- a/cmd/mimi/cmd/stop.go
+++ b/cmd/mimi/cmd/stop.go
@@ -16,7 +16,9 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the running mimi daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		pid, err := readPID(defaultPIDPath())
+		pidPath, _ := resolveRuntimePaths()
+
+		pid, err := readPID(pidPath)
 		if err != nil {
 			cmd.Println("mimi: not running (no PID file)")
 
@@ -48,10 +50,6 @@ func readPID(path string) (int, error) {
 	}
 
 	return strconv.Atoi(strings.TrimSpace(string(data)))
-}
-
-func defaultPIDPath() string {
-	return "~/.local/share/mimi/mimi.pid"
 }
 
 func expandHome(path string) string {

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -4,11 +4,13 @@
 # Validate:      mimi config validate
 # Re-create:     mimi config init
 #
-# Immediate actions (no daemon required):
+# Immediate actions (no daemon required, but faster when it is running):
 #   mimi action focus_window
 #   mimi action space <number>
 #   mimi action move_window_to_space <number>
 #
+# When the daemon is running, actions are routed over a Unix socket
+# (~/.local/share/mimi/mimi.sock by default) to avoid process startup cost.
 # Every hook receives these environment variables:
 #   mimi_EVENT        — event kind (e.g. "window_focus", "workspace_changed")
 #   mimi_EVENT_ID     — unique event UUID
@@ -29,6 +31,7 @@ hook_timeout_secs = 10
 hook_shell = "/bin/sh"
 max_hook_workers = 4
 pid_file = "~/.local/share/mimi/mimi.pid"
+socket_file = "~/.local/share/mimi/mimi.sock"
 
 [systray]
 enabled = true

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,10 @@
 # Architecture
 
-mimi is a macOS window and space utility with two execution paths:
+mimi is a macOS window and space utility with three execution paths:
 
-1. **CLI actions** — immediate one-shot commands (`mimi action …`)
-2. **Hook daemon** — background process that fires shell hooks on window/space events
+1. **CLI actions (direct)** — immediate one-shot commands (`mimi action …`)
+2. **CLI actions (via daemon IPC)** — same commands routed over a Unix socket when the daemon is running
+3. **Hook daemon** — background process that fires shell hooks on window/space events
 
 Both paths use native macOS APIs via CGO. No SIP disable is required.
 
@@ -25,6 +26,8 @@ mimi action <subcommand>
 | `move_window_to_space` | Private SkyLight (`SLSMoveWindowsToManagedSpace`) |
 
 CLI actions pump the run loop briefly after posting events so gestures complete before the process exits.
+
+When the daemon is running, `mimi action` first tries the Unix socket at `settings.socket_file`. The daemon executes the action on a dedicated OS thread and returns the result. If the socket is unavailable, the CLI falls back to direct execution.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -26,7 +26,7 @@ mimi is a macOS window and space utility. Use `mimi action` for immediate comman
 
 ## Window & Space Actions
 
-These commands run directly in the CLI process. The daemon does not need to be running. **Accessibility permission is required.**
+These commands run directly in the CLI process when the daemon is not running. When the daemon **is** running, mimi routes actions over its Unix socket (`settings.socket_file`, default `~/.local/share/mimi/mimi.sock`) so hotkeys feel instant. **Accessibility permission is required.**
 
 ```bash
 mimi action focus_window
@@ -76,7 +76,7 @@ mimi stop
 
 ### `mimi status`
 
-Show whether the daemon is running and whether Accessibility permission is granted.
+Show whether the daemon is running, whether Accessibility permission is granted, and whether the IPC socket is available.
 
 ```bash
 mimi status

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type SettingsConfig struct {
 	HookShell       string `json:"hookShell"       toml:"hook_shell"`
 	MaxHookWorkers  int    `json:"maxHookWorkers"  toml:"max_hook_workers"`
 	PIDFile         string `json:"pidFile"         toml:"pid_file"`
+	SocketFile      string `json:"socketFile"      toml:"socket_file"`
 }
 
 // SystrayConfig holds the [systray] section of the config.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -16,6 +16,12 @@ import (
 // DefaultConfigPath is the default path for the mimi config file.
 const DefaultConfigPath = "~/.config/mimi/config.toml"
 
+// DefaultPIDPath is the default path for the mimi PID file.
+const DefaultPIDPath = "~/.local/share/mimi/mimi.pid"
+
+// DefaultSocketPath is the default Unix socket path for daemon IPC.
+const DefaultSocketPath = "~/.local/share/mimi/mimi.sock"
+
 // Exists returns true if the config file exists.
 func Exists(path string) bool {
 	_, err := os.Stat(expandHome(path))
@@ -158,6 +164,10 @@ func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 		settings.PIDFile = "~/.local/share/mimi/mimi.pid"
 	}
 
+	if settings.SocketFile == "" {
+		settings.SocketFile = DefaultSocketPath
+	}
+
 	if !systrayEnabledSet {
 		cfg.Systray.Enabled = true
 	}
@@ -206,6 +216,7 @@ func allHookEntries(cfg *Config) map[string][]HookEntry {
 func expandPaths(cfg *Config) {
 	cfg.Settings.LogFile = expandHome(cfg.Settings.LogFile)
 	cfg.Settings.PIDFile = expandHome(cfg.Settings.PIDFile)
+	cfg.Settings.SocketFile = expandHome(cfg.Settings.SocketFile)
 }
 
 func expandHome(path string) string {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/events"
 	"github.com/y3owk1n/mimi/internal/hooks"
+	"github.com/y3owk1n/mimi/internal/ipc"
 	"github.com/y3owk1n/mimi/internal/logging"
 	"github.com/y3owk1n/mimi/internal/native"
 	"github.com/y3owk1n/mimi/internal/observe"
@@ -163,6 +164,14 @@ func runCore(
 		logger.Info("hooks reloaded from config")
 	}, logger)
 	go func() { _ = watcher.Run(ctx) }()
+
+	ipcServer := ipc.NewServer(cfg.Settings.SocketFile)
+	go func() {
+		err := ipcServer.Run(ctx)
+		if err != nil && ctx.Err() == nil {
+			logger.Warnw("IPC server stopped", "err", err)
+		}
+	}()
 
 	sigCh := make(chan os.Signal, 1)
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -46,6 +46,12 @@ const (
 	// CodeBridgeFailed indicates a failure in native bridge interactions.
 	CodeBridgeFailed Code = "BRIDGE_FAILED"
 
+	// CodeDaemonUnavailable indicates the daemon is not running or unreachable.
+	CodeDaemonUnavailable Code = "DAEMON_UNAVAILABLE"
+
+	// CodeIPCFailed indicates a failure in IPC communication.
+	CodeIPCFailed Code = "IPCF_FAILED"
+
 	// CodeNotSupported indicates the operation is not supported on the current platform.
 	// Use this in stub implementations so callers can distinguish "not implemented yet"
 	// from "actually failed". Example:

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -1,0 +1,88 @@
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+const dialTimeout = 100 * time.Millisecond
+
+// TryExecute sends an action to the daemon over the Unix socket when available.
+// Returns CodeDaemonUnavailable when the daemon is not reachable so callers can
+// fall back to direct execution.
+func TryExecute(socketPath, action string, args []string) error {
+	socketPath = expandHome(socketPath)
+
+	_, err := os.Stat(socketPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return derrors.New(derrors.CodeDaemonUnavailable, "daemon socket not found")
+		}
+
+		return derrors.Wrapf(err, derrors.CodeIPCFailed, "checking daemon socket")
+	}
+
+	dialer := net.Dialer{Timeout: dialTimeout}
+
+	conn, err := dialer.DialContext(context.Background(), "unix", socketPath)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return derrors.New(derrors.CodeDaemonUnavailable, "daemon socket timed out")
+		}
+
+		return derrors.New(derrors.CodeDaemonUnavailable, "daemon not reachable")
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+
+	err = writeRequest(conn, Request{Action: action, Args: args})
+	if err != nil {
+		return err
+	}
+
+	resp, err := readResponse(reader)
+	if err != nil {
+		return err
+	}
+
+	return errorFromResponse(resp)
+}
+
+// ResolveSocketPath returns the configured socket path when --config is set,
+// otherwise the default socket path without reading config from disk.
+func ResolveSocketPath(cliConfigPath string) string {
+	if cliConfigPath == "" {
+		return config.DefaultSocketPath
+	}
+
+	resolved := config.ResolvePath(cliConfigPath)
+
+	cfg, err := config.Load(resolved)
+	if err != nil {
+		return config.DefaultSocketPath
+	}
+
+	return cfg.Settings.SocketFile
+}
+
+func expandHome(path string) string {
+	if strings.HasPrefix(path, "~") {
+		home, _ := os.UserHomeDir()
+
+		return filepath.Join(home, path[1:])
+	}
+
+	return path
+}

--- a/internal/ipc/doc.go
+++ b/internal/ipc/doc.go
@@ -1,0 +1,3 @@
+// Package ipc provides Unix socket communication between CLI action commands
+// and the running mimi daemon for low-latency hotkey execution.
+package ipc

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -1,0 +1,115 @@
+package ipc
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// Request is a JSON-encoded action request sent over the Unix socket.
+type Request struct {
+	Action string   `json:"action"`
+	Args   []string `json:"args"`
+}
+
+// Response is a JSON-encoded action result sent back to the client.
+type Response struct {
+	OK      bool   `json:"ok"`
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func writeRequest(writer io.Writer, req Request) error {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeSerializationFailed, "encoding IPC request")
+	}
+
+	_, err = writer.Write(append(data, '\n'))
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeIPCFailed, "writing IPC request")
+	}
+
+	return nil
+}
+
+func readRequest(r *bufio.Reader) (Request, error) {
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return Request{}, derrors.Wrapf(err, derrors.CodeIPCFailed, "reading IPC request")
+	}
+
+	var req Request
+
+	err = json.Unmarshal(line, &req)
+	if err != nil {
+		return Request{}, derrors.Wrapf(
+			err,
+			derrors.CodeSerializationFailed,
+			"decoding IPC request",
+		)
+	}
+
+	return req, nil
+}
+
+func writeResponse(writer io.Writer, resp Response) error {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeSerializationFailed, "encoding IPC response")
+	}
+
+	_, err = writer.Write(append(data, '\n'))
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeIPCFailed, "writing IPC response")
+	}
+
+	return nil
+}
+
+func readResponse(r *bufio.Reader) (Response, error) {
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return Response{}, derrors.Wrapf(err, derrors.CodeIPCFailed, "reading IPC response")
+	}
+
+	var resp Response
+
+	err = json.Unmarshal(line, &resp)
+	if err != nil {
+		return Response{}, derrors.Wrapf(
+			err,
+			derrors.CodeSerializationFailed,
+			"decoding IPC response",
+		)
+	}
+
+	return resp, nil
+}
+
+func responseFromError(err error) Response {
+	if err == nil {
+		return Response{OK: true}
+	}
+
+	return Response{
+		OK:      false,
+		Code:    string(derrors.GetCode(err)),
+		Message: err.Error(),
+	}
+}
+
+func errorFromResponse(resp Response) error {
+	if resp.OK {
+		return nil
+	}
+
+	code := derrors.Code(resp.Code)
+	if code == "" {
+		code = derrors.CodeIPCFailed
+	}
+
+	return derrors.New(code, resp.Message)
+}

--- a/internal/ipc/protocol_test.go
+++ b/internal/ipc/protocol_test.go
@@ -1,0 +1,67 @@
+package ipc //nolint:testpackage // tests unexported protocol functions
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+func TestResponseFromError(t *testing.T) {
+	t.Parallel()
+
+	resp := responseFromError(nil)
+	if !resp.OK {
+		t.Fatal("expected ok response for nil error")
+	}
+
+	resp = responseFromError(derrors.New(derrors.CodeActionFailed, "boom"))
+	if resp.OK || resp.Code != string(derrors.CodeActionFailed) {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestWriteReadRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	req := Request{Action: "space", Args: []string{"2"}}
+
+	err := writeRequest(&buf, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readRequest(bufio.NewReader(&buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Action != req.Action || len(got.Args) != 1 || got.Args[0] != "2" {
+		t.Fatalf("unexpected request: %+v", got)
+	}
+}
+
+func TestWriteReadResponseRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	resp := Response{OK: false, Code: "ACTION_FAILED", Message: "nope"}
+
+	err := writeResponse(&buf, resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readResponse(bufio.NewReader(&buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.OK || got.Code != resp.Code || got.Message != resp.Message {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -1,0 +1,127 @@
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/systray"
+)
+
+// Server accepts action requests over a Unix domain socket.
+type Server struct {
+	path string
+	ln   net.Listener
+
+	actionCh chan actionJob
+	once     sync.Once
+}
+
+type actionJob struct {
+	name string
+	args []string
+	done chan error
+}
+
+// NewServer creates a Unix socket server at path.
+func NewServer(path string) *Server {
+	return &Server{
+		path:     expandHome(path),
+		actionCh: make(chan actionJob),
+	}
+}
+
+// Run listens for connections until ctx is canceled.
+func (s *Server) Run(ctx context.Context) error {
+	s.once.Do(s.startActionWorker)
+
+	err := os.MkdirAll(filepath.Dir(s.path), 0o755) //nolint:mnd
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeIPCFailed, "creating socket directory")
+	}
+
+	_ = os.Remove(s.path)
+
+	lc := net.ListenConfig{}
+
+	listener, err := lc.Listen(ctx, "unix", s.path)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeIPCFailed, "listening on socket")
+	}
+
+	s.ln = listener
+
+	go func() {
+		<-ctx.Done()
+
+		_ = listener.Close()
+		_ = os.Remove(s.path)
+	}()
+
+	for {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				if errorsIsUseClosed(acceptErr) {
+					return nil
+				}
+
+				continue
+			}
+		}
+
+		go s.handleConn(conn)
+	}
+}
+
+func (s *Server) startActionWorker() {
+	go func() {
+		runtime.LockOSThread()
+
+		for job := range s.actionCh {
+			job.done <- action.Execute(job.name, job.args)
+		}
+	}()
+}
+
+func (s *Server) handleConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	reader := bufio.NewReader(conn)
+
+	req, err := readRequest(reader)
+	if err != nil {
+		_ = writeResponse(conn, responseFromError(err))
+
+		return
+	}
+
+	done := make(chan error, 1)
+	s.actionCh <- actionJob{name: req.Action, args: req.Args, done: done}
+
+	err = <-done
+	if err == nil &&
+		(req.Action == string(action.NameSpace) || req.Action == string(action.NameMoveWindowToSpace)) {
+		systray.RefreshWorkspaceTitle()
+	}
+
+	_ = writeResponse(conn, responseFromError(err))
+}
+
+func errorsIsUseClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "use of closed network connection")
+}

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -1,0 +1,62 @@
+package ipc_test
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/ipc"
+)
+
+func TestTryExecuteDaemonUnavailable(t *testing.T) {
+	t.Parallel()
+
+	err := ipc.TryExecute(filepath.Join(t.TempDir(), "missing.sock"), "space", []string{"1"})
+	if err == nil {
+		t.Fatal("expected error for missing socket")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeDaemonUnavailable) {
+		t.Fatalf("expected CodeDaemonUnavailable, got %v", err)
+	}
+}
+
+func TestServerClientRoundTrip(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "mimi.sock")
+	server := ipc.NewServer(socketPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Run(ctx)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		dialer := net.Dialer{}
+
+		_, dialErr := dialer.DialContext(ctx, "unix", socketPath)
+		if dialErr == nil {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	err := ipc.TryExecute(socketPath, "unknown_action", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+
+	cancel()
+	<-errCh
+}

--- a/internal/native/constants.h
+++ b/internal/native/constants.h
@@ -9,8 +9,8 @@
 extern "C" {
 #endif
 
-static const CFTimeInterval kMimiSpaceGestureProcessingDelay = 0.05;
-static const CFTimeInterval kMimiMoveWindowProcessingDelay = 0.3;
+static const CFTimeInterval kMimiSpaceGestureProcessingDelay = 0.03;
+static const CFTimeInterval kMimiMoveWindowProcessingDelay = 0.2;
 
 #ifdef __cplusplus
 }

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -6,6 +6,43 @@
 #import "mimi.h"
 
 #import <Cocoa/Cocoa.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+static NSSet<NSNumber *> *mimiVisibleRegularAppPIDs(void) {
+	CFArrayRef windowList = CGWindowListCopyWindowInfo(
+	    kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+	if (!windowList)
+		return [NSSet set];
+
+	NSMutableSet<NSNumber *> *pids = [NSMutableSet set];
+	CFIndex count = CFArrayGetCount(windowList);
+	for (CFIndex i = 0; i < count; i++) {
+		CFDictionaryRef info = CFArrayGetValueAtIndex(windowList, i);
+		if (!info)
+			continue;
+
+		CFNumberRef layerRef = CFDictionaryGetValue(info, kCGWindowLayer);
+		if (!layerRef)
+			continue;
+
+		int layer = 0;
+		if (!CFNumberGetValue(layerRef, kCFNumberIntType, &layer) || layer != 0)
+			continue;
+
+		CFNumberRef pidRef = CFDictionaryGetValue(info, kCGWindowOwnerPID);
+		if (!pidRef)
+			continue;
+
+		int pid = 0;
+		if (!CFNumberGetValue(pidRef, kCFNumberIntType, &pid) || pid <= 0)
+			continue;
+
+		[pids addObject:@(pid)];
+	}
+
+	CFRelease(windowList);
+	return [pids copy];
+}
 
 void *MimiGetFrontmostWindow(void) {
 	@autoreleasepool {
@@ -117,6 +154,7 @@ void **MimiGetAllFocusableWindowsOnActiveSpace(int *count) {
 	@autoreleasepool {
 		*count = 0;
 
+		NSSet<NSNumber *> *visiblePIDs = mimiVisibleRegularAppPIDs();
 		NSArray *runningApps = [[NSWorkspace sharedWorkspace].runningApplications
 		    sortedArrayUsingComparator:^NSComparisonResult(NSRunningApplication *obj1, NSRunningApplication *obj2) {
 			    if (obj1.processIdentifier < obj2.processIdentifier) {
@@ -137,6 +175,9 @@ void **MimiGetAllFocusableWindowsOnActiveSpace(int *count) {
 				continue;
 
 			pid_t pid = app.processIdentifier;
+			if (![visiblePIDs containsObject:@(pid)])
+				continue;
+
 			AXUIElementRef appElement = AXUIElementCreateApplication(pid);
 			if (!appElement)
 				continue;

--- a/internal/systray/component.go
+++ b/internal/systray/component.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os/exec"
 	"strconv"
-	"time"
 
 	"go.uber.org/zap"
 )
@@ -77,17 +76,25 @@ func (c *Component) OnReady() {
 	go c.handleEvents()
 
 	if c.showWorkspaceNumber {
-		go c.handleTitleUpdates()
+		StartWorkspaceTitleObserver()
 	}
 }
 
 // OnExit stops menu event handling.
 func (c *Component) OnExit() {
+	if c.showWorkspaceNumber {
+		StopWorkspaceTitleObserver()
+	}
+
 	c.cancel()
 }
 
 // Close stops menu event handling.
 func (c *Component) Close() {
+	if c.showWorkspaceNumber {
+		StopWorkspaceTitleObserver()
+	}
+
 	c.cancel()
 }
 
@@ -113,36 +120,6 @@ func (c *Component) handleEvents() {
 			c.quit()
 
 			return
-		}
-	}
-}
-
-func (c *Component) handleTitleUpdates() {
-	if !c.showWorkspaceNumber {
-		return
-	}
-
-	ticker := time.NewTicker(500 * time.Millisecond) //nolint:mnd
-	defer ticker.Stop()
-
-	last := ""
-	for {
-		select {
-		case <-c.ctx.Done():
-			return
-		case <-ticker.C:
-			n := ActiveWorkspaceNumber()
-			if n >= 0 {
-				title := strconv.Itoa(n + 1)
-				if title != last {
-					SetTitle(title)
-					last = title
-				}
-			} else if last != "M" {
-				SetTitle("M")
-
-				last = "M"
-			}
 		}
 	}
 }

--- a/internal/systray/systray.go
+++ b/internal/systray/systray.go
@@ -106,6 +106,21 @@ func ActiveWorkspaceNumber() int {
 	return int(C.MimiGetActiveWorkspaceNumber())
 }
 
+// StartWorkspaceTitleObserver listens for space changes and updates the tray title immediately.
+func StartWorkspaceTitleObserver() {
+	C.MimiStartWorkspaceTitleObserver()
+}
+
+// StopWorkspaceTitleObserver stops listening for space changes.
+func StopWorkspaceTitleObserver() {
+	C.MimiStopWorkspaceTitleObserver()
+}
+
+// RefreshWorkspaceTitle updates the tray title to match the active space immediately.
+func RefreshWorkspaceTitle() {
+	C.MimiRefreshWorkspaceTitle()
+}
+
 // SetIcon sets the icon of the system tray item.
 func SetIcon(icon []byte) {
 	if len(icon) == 0 {

--- a/internal/systray/systray.h
+++ b/internal/systray/systray.h
@@ -12,6 +12,9 @@ void MimiSetIcon(const char *iconBytes, int length, bool isTemplate);
 void MimiSetTitle(const char *title);
 void MimiSetTooltip(const char *tooltip);
 int MimiGetActiveWorkspaceNumber(void);
+void MimiStartWorkspaceTitleObserver(void);
+void MimiStopWorkspaceTitleObserver(void);
+void MimiRefreshWorkspaceTitle(void);
 
 void MimiAddMenuItem(int menuId, const char *title, short disabled, short checked);
 void MimiAddSubMenuItem(int parentId, int menuId, const char *title, short disabled, short checked);

--- a/internal/systray/systray.m
+++ b/internal/systray/systray.m
@@ -10,12 +10,96 @@
 #import <Cocoa/Cocoa.h>
 #include <CoreGraphics/CoreGraphics.h>
 #include <dlfcn.h>
+#include <limits.h>
 
 #pragma mark - External Function Declarations
 
 extern void systray_menu_item_selected(int menuId);
 extern void systray_on_ready(void);
 extern void systray_on_exit(void);
+
+#pragma mark - Workspace Title Observer
+
+static id gWorkspaceObserver = nil;
+static int gLastWorkspaceTitle = INT_MIN;
+
+static int activeWorkspaceNumberFromSkyLight(void) {
+	static void *skyLight = NULL;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		skyLight = dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight", RTLD_LAZY);
+	});
+
+	if (!skyLight) {
+		return -1;
+	}
+
+	typedef int (*SLSMainConnectionIDFunc)(void);
+	typedef uint64_t (*SLSGetActiveSpaceFunc)(int);
+	typedef CFArrayRef (*SLSCopyManagedDisplaySpacesFunc)(int);
+
+	SLSMainConnectionIDFunc SLSMainConnectionID = (SLSMainConnectionIDFunc)dlsym(skyLight, "SLSMainConnectionID");
+	if (!SLSMainConnectionID) {
+		SLSMainConnectionID = (SLSMainConnectionIDFunc)dlsym(skyLight, "CGSMainConnectionID");
+	}
+
+	SLSGetActiveSpaceFunc SLSGetActiveSpace = (SLSGetActiveSpaceFunc)dlsym(skyLight, "SLSGetActiveSpace");
+	if (!SLSGetActiveSpace) {
+		SLSGetActiveSpace = (SLSGetActiveSpaceFunc)dlsym(skyLight, "CGSGetActiveSpace");
+	}
+
+	SLSCopyManagedDisplaySpacesFunc SLSCopyManagedDisplaySpaces =
+	    (SLSCopyManagedDisplaySpacesFunc)dlsym(skyLight, "SLSCopyManagedDisplaySpaces");
+
+	if (!SLSMainConnectionID || !SLSGetActiveSpace || !SLSCopyManagedDisplaySpaces) {
+		return -1;
+	}
+
+	int conn = SLSMainConnectionID();
+	uint64_t active = SLSGetActiveSpace(conn);
+	if (active == 0) {
+		return -1;
+	}
+
+	CFArrayRef managed = SLSCopyManagedDisplaySpaces(conn);
+	if (!managed) {
+		return -1;
+	}
+
+	int counter = 0;
+	NSArray *displays = (__bridge NSArray *)managed;
+	for (NSDictionary *display in displays) {
+		NSArray *spaces = display[@"Spaces"];
+		if (![spaces isKindOfClass:[NSArray class]]) {
+			continue;
+		}
+
+		for (id spaceDict in spaces) {
+			if (![spaceDict isKindOfClass:[NSDictionary class]]) {
+				continue;
+			}
+
+			id sid = spaceDict[@"id64"];
+			if (![sid isKindOfClass:[NSNumber class]]) {
+				sid = spaceDict[@"ManagedSpaceID"];
+			}
+			if (![sid isKindOfClass:[NSNumber class]]) {
+				counter++;
+				continue;
+			}
+
+			if ((uint64_t)[sid unsignedLongLongValue] == active) {
+				CFRelease(managed);
+				return counter;
+			}
+
+			counter++;
+		}
+	}
+
+	CFRelease(managed);
+	return -1;
+}
 
 #pragma mark - Static State
 
@@ -158,6 +242,11 @@ void MimiSetTooltip(const char *tooltip) {
 
 int MimiGetActiveWorkspaceNumber(void) {
 	@autoreleasepool {
+		int skyLightIndex = activeWorkspaceNumberFromSkyLight();
+		if (skyLightIndex >= 0) {
+			return skyLightIndex;
+		}
+
 		CFArrayRef windowList = CGWindowListCopyWindowInfo(
 		    kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
 		if (windowList) {
@@ -188,83 +277,7 @@ int MimiGetActiveWorkspaceNumber(void) {
 			}
 		}
 
-		static void *skyLight = NULL;
-		static dispatch_once_t onceToken;
-		dispatch_once(&onceToken, ^{
-			skyLight = dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight", RTLD_LAZY);
-		});
-
-		if (!skyLight) {
-			return -1;
-		}
-
-		typedef int (*SLSMainConnectionIDFunc)(void);
-		typedef uint64_t (*SLSGetActiveSpaceFunc)(int);
-		typedef CFArrayRef (*SLSCopyManagedDisplaySpacesFunc)(int);
-
-		SLSMainConnectionIDFunc SLSMainConnectionID = (SLSMainConnectionIDFunc)dlsym(skyLight, "SLSMainConnectionID");
-		if (!SLSMainConnectionID) {
-			SLSMainConnectionID = (SLSMainConnectionIDFunc)dlsym(skyLight, "CGSMainConnectionID");
-		}
-
-		SLSGetActiveSpaceFunc SLSGetActiveSpace = (SLSGetActiveSpaceFunc)dlsym(skyLight, "SLSGetActiveSpace");
-		if (!SLSGetActiveSpace) {
-			SLSGetActiveSpace = (SLSGetActiveSpaceFunc)dlsym(skyLight, "CGSGetActiveSpace");
-		}
-
-		SLSCopyManagedDisplaySpacesFunc SLSCopyManagedDisplaySpaces =
-		    (SLSCopyManagedDisplaySpacesFunc)dlsym(skyLight, "SLSCopyManagedDisplaySpaces");
-
-		if (!SLSMainConnectionID || !SLSGetActiveSpace || !SLSCopyManagedDisplaySpaces) {
-			return -1;
-		}
-
-		int conn = SLSMainConnectionID();
-		uint64_t active = SLSGetActiveSpace(conn);
-		if (active == 0) {
-			return -1;
-		}
-
-		CFArrayRef managed = SLSCopyManagedDisplaySpaces(conn);
-		if (!managed) {
-			return -1;
-		}
-
-		int idx = -1;
-		NSArray *displays = (__bridge NSArray *)managed;
-		for (NSDictionary *display in displays) {
-			NSArray *spaces = display[@"Spaces"];
-			if (![spaces isKindOfClass:[NSArray class]]) {
-				continue;
-			}
-
-			for (NSUInteger i = 0; i < [spaces count]; i++) {
-				id spaceDict = spaces[i];
-				if (![spaceDict isKindOfClass:[NSDictionary class]]) {
-					continue;
-				}
-
-				id sid = spaceDict[@"id64"];
-				if (![sid isKindOfClass:[NSNumber class]]) {
-					sid = spaceDict[@"ManagedSpaceID"];
-				}
-				if (![sid isKindOfClass:[NSNumber class]]) {
-					continue;
-				}
-
-				if ((uint64_t)[sid unsignedLongLongValue] == active) {
-					idx = (int)i;
-					break;
-				}
-			}
-
-			if (idx >= 0) {
-				break;
-			}
-		}
-
-		CFRelease(managed);
-		return idx;
+		return -1;
 	}
 }
 
@@ -306,6 +319,73 @@ void runOnMainThread(void (^block)(void)) {
 	} else {
 		dispatch_async(dispatch_get_main_queue(), block);
 	}
+}
+
+#pragma mark - Workspace Title Observer
+
+static void applyWorkspaceTitle(int workspaceNumber) {
+	if (!appDelegate || !appDelegate.statusItem) {
+		return;
+	}
+
+	NSString *title = workspaceNumber >= 0 ? [NSString stringWithFormat:@"%d", workspaceNumber + 1] : @"M";
+
+	appDelegate.statusItem.button.image = nil;
+	[appDelegate.statusItem.button setImagePosition:NSNoImage];
+	appDelegate.statusItem.button.title = title;
+}
+
+static void refreshWorkspaceTitle(void) {
+	int workspace = MimiGetActiveWorkspaceNumber();
+	if (workspace == gLastWorkspaceTitle) {
+		return;
+	}
+
+	gLastWorkspaceTitle = workspace;
+	applyWorkspaceTitle(workspace);
+}
+
+static void scheduleWorkspaceTitleRefresh(void) {
+	refreshWorkspaceTitle();
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.03 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+		refreshWorkspaceTitle();
+	});
+}
+
+void MimiStartWorkspaceTitleObserver(void) {
+	runOnMainThread(^{
+		if (gWorkspaceObserver) {
+			scheduleWorkspaceTitleRefresh();
+			return;
+		}
+
+		scheduleWorkspaceTitleRefresh();
+
+		gWorkspaceObserver = [[[NSWorkspace sharedWorkspace] notificationCenter]
+		    addObserverForName:NSWorkspaceActiveSpaceDidChangeNotification
+		                object:nil
+		                 queue:[NSOperationQueue mainQueue]
+		            usingBlock:^(__unused NSNotification *note) {
+			            scheduleWorkspaceTitleRefresh();
+		            }];
+	});
+}
+
+void MimiStopWorkspaceTitleObserver(void) {
+	runOnMainThread(^{
+		if (gWorkspaceObserver) {
+			[[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:gWorkspaceObserver];
+			gWorkspaceObserver = nil;
+		}
+
+		gLastWorkspaceTitle = INT_MIN;
+	});
+}
+
+void MimiRefreshWorkspaceTitle(void) {
+	runOnMainThread(^{
+		scheduleWorkspaceTitleRefresh();
+	});
 }
 
 #pragma mark - Menu Item Functions


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a IPC layer for mimi daemon and replace polling workspace title to native notification observer.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
