### PR TITLE
perf: reduce polling overhead, fix event loss and timer races, consolidate duplicated utilities

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -218,17 +218,6 @@ func installService() error {
 		return fmt.Errorf("failed to expand LaunchAgents path: %w", err)
 	}
 
-	expandedPlist := filepath.Join(expandedDir, serviceLabel+".plist")
-
-	_, statErr := os.Stat(expandedPlist)
-	if statErr == nil {
-		return fmt.Errorf(
-			"%w at %s; remove it manually or uninstall first",
-			errPlistAlreadyExists,
-			expandedPlist,
-		)
-	}
-
 	const dirPerm = 0o755
 
 	err = os.MkdirAll(expandedDir, dirPerm)
@@ -236,11 +225,35 @@ func installService() error {
 		return fmt.Errorf("failed to create LaunchAgents directory: %w", err)
 	}
 
+	expandedPlist := filepath.Join(expandedDir, serviceLabel+".plist")
+
 	const filePerm = 0o644
 
-	err = os.WriteFile(expandedPlist, []byte(plistContent), filePerm)
+	// Use O_EXCL to atomically create the file, avoiding TOCTOU between Stat and WriteFile.
+	plistFile, err := os.OpenFile(expandedPlist, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
 	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf(
+				"%w at %s; remove it manually or uninstall first",
+				errPlistAlreadyExists,
+				expandedPlist,
+			)
+		}
+
+		return fmt.Errorf("failed to create plist: %w", err)
+	}
+
+	_, err = plistFile.WriteString(plistContent)
+	if err != nil {
+		_ = plistFile.Close()
+		_ = os.Remove(expandedPlist)
+
 		return fmt.Errorf("failed to write plist: %w", err)
+	}
+
+	err = plistFile.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close plist: %w", err)
 	}
 
 	currentUser, err := user.Current()

--- a/cmd/mimi/cmd/status.go
+++ b/cmd/mimi/cmd/status.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/y3owk1n/mimi/internal/paths"
 	"github.com/y3owk1n/mimi/internal/permissions"
 )
 
@@ -36,9 +37,9 @@ var statusCmd = &cobra.Command{
 			cmd.Println("accessibility: not granted (required for window hooks and actions)")
 		}
 
-		_, statErr := os.Stat(expandHome(socketPath))
+		_, statErr := os.Stat(paths.ExpandHome(socketPath))
 		if statErr == nil {
-			cmd.Printf("ipc: socket available at %s\n", expandHome(socketPath))
+			cmd.Printf("ipc: socket available at %s\n", paths.ExpandHome(socketPath))
 		} else {
 			cmd.Println("ipc: socket not available (actions run directly until daemon starts)")
 		}

--- a/cmd/mimi/cmd/stop.go
+++ b/cmd/mimi/cmd/stop.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -10,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/paths"
 )
 
 var stopCmd = &cobra.Command{
@@ -42,7 +42,7 @@ var stopCmd = &cobra.Command{
 }
 
 func readPID(path string) (int, error) {
-	path = expandHome(path)
+	path = paths.ExpandHome(path)
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -50,14 +50,4 @@ func readPID(path string) (int, error) {
 	}
 
 	return strconv.Atoi(strings.TrimSpace(string(data)))
-}
-
-func expandHome(path string) string {
-	if strings.HasPrefix(path, "~") {
-		home, _ := os.UserHomeDir()
-
-		return filepath.Join(home, path[1:])
-	}
-
-	return path
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/y3owk1n/mimi/configs"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/events"
+	"github.com/y3owk1n/mimi/internal/paths"
 )
 
 // DefaultConfigPath is the default path for the mimi config file.
@@ -24,7 +25,7 @@ const DefaultSocketPath = "~/.local/share/mimi/mimi.sock"
 
 // Exists returns true if the config file exists.
 func Exists(path string) bool {
-	_, err := os.Stat(expandHome(path))
+	_, err := os.Stat(paths.ExpandHome(path))
 
 	return err == nil
 }
@@ -38,24 +39,21 @@ func Exists(path string) bool {
 // $XDG_CONFIG_HOME/mimi/config.toml (if env set) or ~/.config/mimi/config.toml.
 func ResolvePath(cliPath string) string {
 	if cliPath != "" {
-		return expandHome(cliPath)
+		return paths.ExpandHome(cliPath)
 	}
 
-	// 1. Check $XDG_CONFIG_HOME/mimi/config.toml
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		p := filepath.Join(xdg, "mimi/config.toml")
 		if Exists(p) {
-			return expandHome(p)
+			return paths.ExpandHome(p)
 		}
 	}
 
-	// 2. Check ~/.config/mimi/config.toml
 	p2 := "~/.config/mimi/config.toml"
 	if Exists(p2) {
-		return expandHome(p2)
+		return paths.ExpandHome(p2)
 	}
 
-	// 3. Check mimi.toml (current directory)
 	altPath := "mimi.toml"
 	if Exists(altPath) {
 		abs, err := filepath.Abs(altPath)
@@ -66,17 +64,16 @@ func ResolvePath(cliPath string) string {
 		return altPath
 	}
 
-	// Fallback when none exists
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return expandHome(filepath.Join(xdg, "mimi/config.toml"))
+		return paths.ExpandHome(filepath.Join(xdg, "mimi/config.toml"))
 	}
 
-	return expandHome("~/.config/mimi/config.toml")
+	return paths.ExpandHome("~/.config/mimi/config.toml")
 }
 
 // WriteDefault writes the default config to the given path.
 func WriteDefault(path string) error {
-	path = expandHome(path)
+	path = paths.ExpandHome(path)
 
 	err := os.MkdirAll(filepath.Dir(path), 0o755) //nolint:mnd
 	if err != nil {
@@ -93,7 +90,7 @@ func WriteDefault(path string) error {
 
 // Load parses and validates the config from a TOML file.
 func Load(path string) (*Config, error) {
-	path = expandHome(path)
+	path = paths.ExpandHome(path)
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -214,17 +211,7 @@ func allHookEntries(cfg *Config) map[string][]HookEntry {
 }
 
 func expandPaths(cfg *Config) {
-	cfg.Settings.LogFile = expandHome(cfg.Settings.LogFile)
-	cfg.Settings.PIDFile = expandHome(cfg.Settings.PIDFile)
-	cfg.Settings.SocketFile = expandHome(cfg.Settings.SocketFile)
-}
-
-func expandHome(path string) string {
-	if strings.HasPrefix(path, "~") {
-		home, _ := os.UserHomeDir()
-
-		return filepath.Join(home, path[1:])
-	}
-
-	return path
+	cfg.Settings.LogFile = paths.ExpandHome(cfg.Settings.LogFile)
+	cfg.Settings.PIDFile = paths.ExpandHome(cfg.Settings.PIDFile)
+	cfg.Settings.SocketFile = paths.ExpandHome(cfg.Settings.SocketFile)
 }

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"go.uber.org/zap"
+
+	"github.com/y3owk1n/mimi/internal/paths"
 )
 
 const debounceDelay = 300 * time.Millisecond
@@ -20,7 +22,7 @@ type Watcher struct {
 
 // NewWatcher creates a new config file watcher.
 func NewWatcher(path string, onChange func(*Config), logger *zap.SugaredLogger) *Watcher {
-	return &Watcher{path: expandHome(path), onChange: onChange, logger: logger}
+	return &Watcher{path: paths.ExpandHome(path), onChange: onChange, logger: logger}
 }
 
 // Run starts the config file watcher loop. It blocks until the context is canceled.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -6,7 +6,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"syscall"
 
 	"go.uber.org/zap"
@@ -19,6 +18,7 @@ import (
 	"github.com/y3owk1n/mimi/internal/logging"
 	"github.com/y3owk1n/mimi/internal/native"
 	"github.com/y3owk1n/mimi/internal/observe"
+	"github.com/y3owk1n/mimi/internal/paths"
 	"github.com/y3owk1n/mimi/internal/permissions"
 	"github.com/y3owk1n/mimi/internal/systray"
 )
@@ -98,10 +98,61 @@ func runCore(
 	}
 	defer removePID(cfg.Settings.PIDFile)
 
+	obsCfg, accessibilityGranted := setupObservers(cfg, logger)
+	if obsCfg == nil {
+		return nil
+	}
+
+	bus, axTracker, router, reg, executor, logSub, hookSub, ctx, cancel, err := setupEventPipeline(
+		cfg,
+		logger,
+		accessibilityGranted,
+	)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	go router.Run(ctx)
+	go executor.Run(ctx, hookSub)
+	go logging.WriteEventLog(ctx, logSub, cfg.Settings.LogFile, logger)
+
+	onChange := newReloadHandler(reg, executor, axTracker, logger)
+
+	watcher := config.NewWatcher(configPath, onChange, logger)
+	go func() { _ = watcher.Run(ctx) }()
+
+	ipcServer := ipc.NewServer(cfg.Settings.SocketFile)
+	go func() {
+		err := ipcServer.Run(ctx)
+		if err != nil && ctx.Err() == nil {
+			logger.Warnw("IPC server stopped", "err", err)
+		}
+	}()
+
+	runSignalLoop(
+		cancel,
+		quitCh,
+		reg,
+		executor,
+		axTracker,
+		logger,
+		configPath,
+		bus,
+		logSub,
+		hookSub,
+	)
+
+	return nil
+}
+
+func setupObservers(cfg *config.Config, logger *zap.SugaredLogger) (*native.ObserverConfig, bool) {
 	perm := permissions.Check()
 
+	accessibilityGranted := perm.Accessibility
+
 	var accessibilityPrompt func() bool
-	if !perm.Accessibility {
+	if !accessibilityGranted {
 		accessibilityPrompt = func() bool {
 			choice := permissions.ShowAccessibilityStartupAlert()
 
@@ -111,15 +162,27 @@ func runCore(
 
 	obsCfg := getObserverConfig(cfg)
 	if !native.StartObservers(obsCfg, accessibilityPrompt) {
-		return nil
+		return nil, false
 	}
 
 	perm = permissions.Check()
+	accessibilityGranted = perm.Accessibility
 
-	axEnabled := perm.Accessibility && hasWindowEvents(cfg)
-	if hasWindowEvents(cfg) && !perm.Accessibility {
+	if hasWindowEvents(cfg) && !accessibilityGranted {
 		logger.Warn("accessibility permission not granted — window hooks disabled")
 	}
+
+	return &obsCfg, accessibilityGranted
+}
+
+func setupEventPipeline(
+	cfg *config.Config,
+	logger *zap.SugaredLogger,
+	accessibilityGranted bool,
+) (*events.Bus, *observe.AXTracker, *observe.Router, *hooks.Registry, *hooks.Executor,
+	events.Subscriber, events.Subscriber, context.Context, context.CancelFunc, error,
+) {
+	axEnabled := accessibilityGranted && hasWindowEvents(cfg)
 
 	bus := events.NewBus()
 	axTracker := observe.NewAXTracker(axEnabled)
@@ -127,9 +190,10 @@ func runCore(
 
 	reg := hooks.NewRegistry()
 
-	err = reg.Reload(cfg)
+	err := reg.Reload(cfg)
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading hooks")
+		return nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading hooks")
 	}
 
 	executor := hooks.NewExecutor(reg, &cfg.Settings, logger)
@@ -138,13 +202,17 @@ func runCore(
 	hookSub := bus.Subscribe(hookSubBufSize)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
-	go router.Run(ctx)
-	go executor.Run(ctx, hookSub)
-	go logging.WriteEventLog(ctx, logSub, cfg.Settings.LogFile, logger)
+	return bus, axTracker, router, reg, executor, logSub, hookSub, ctx, cancel, nil
+}
 
-	watcher := config.NewWatcher(configPath, func(newCfg *config.Config) {
+func newReloadHandler(
+	reg *hooks.Registry,
+	executor *hooks.Executor,
+	axTracker *observe.AXTracker,
+	logger *zap.SugaredLogger,
+) func(*config.Config) {
+	return func(newCfg *config.Config) {
 		if newCfg == nil {
 			return
 		}
@@ -162,17 +230,21 @@ func runCore(
 		perm := permissions.Check()
 		axTracker.Update(perm.Accessibility && hasWindowEvents(newCfg))
 		logger.Info("hooks reloaded from config")
-	}, logger)
-	go func() { _ = watcher.Run(ctx) }()
+	}
+}
 
-	ipcServer := ipc.NewServer(cfg.Settings.SocketFile)
-	go func() {
-		err := ipcServer.Run(ctx)
-		if err != nil && ctx.Err() == nil {
-			logger.Warnw("IPC server stopped", "err", err)
-		}
-	}()
-
+func runSignalLoop(
+	cancel context.CancelFunc,
+	quitCh <-chan struct{},
+	reg *hooks.Registry,
+	executor *hooks.Executor,
+	axTracker *observe.AXTracker,
+	logger *zap.SugaredLogger,
+	configPath string,
+	bus *events.Bus,
+	logSub events.Subscriber,
+	hookSub events.Subscriber,
+) {
 	sigCh := make(chan os.Signal, 1)
 
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
@@ -182,45 +254,61 @@ func runCore(
 		select {
 		case <-quitCh:
 			logger.Info("shutting down from systray")
-			cancel()
-			native.StopObservers()
-			bus.Unsubscribe(logSub)
-			bus.Unsubscribe(hookSub)
+			shutdown(cancel, bus, logSub, hookSub)
 
-			return nil
+			return
 		case sig := <-sigCh:
 			if sig == syscall.SIGHUP {
-				newCfg, err := config.Load(configPath)
-				if err != nil {
-					logger.Warnw("SIGHUP reload failed", "err", err)
-
-					continue
-				}
-
-				_ = reg.Reload(newCfg)
-				executor.UpdateSettings(&newCfg.Settings)
-				native.UpdateObservers(getObserverConfig(newCfg))
-
-				perm := permissions.Check()
-				axTracker.Update(perm.Accessibility && hasWindowEvents(newCfg))
-				logger.Info("reloaded config via SIGHUP")
+				reloadConfig(configPath, reg, executor, axTracker, logger)
 
 				continue
 			}
 
 			logger.Infow("shutting down", "signal", sig)
-			cancel()
-			native.StopObservers()
-			bus.Unsubscribe(logSub)
-			bus.Unsubscribe(hookSub)
+			shutdown(cancel, bus, logSub, hookSub)
 
-			return nil
+			return
 		}
 	}
 }
 
+func reloadConfig(
+	configPath string,
+	reg *hooks.Registry,
+	executor *hooks.Executor,
+	axTracker *observe.AXTracker,
+	logger *zap.SugaredLogger,
+) {
+	newCfg, err := config.Load(configPath)
+	if err != nil {
+		logger.Warnw("SIGHUP reload failed", "err", err)
+
+		return
+	}
+
+	_ = reg.Reload(newCfg)
+	executor.UpdateSettings(&newCfg.Settings)
+	native.UpdateObservers(getObserverConfig(newCfg))
+
+	perm := permissions.Check()
+	axTracker.Update(perm.Accessibility && hasWindowEvents(newCfg))
+	logger.Info("reloaded config via SIGHUP")
+}
+
+func shutdown(
+	cancel context.CancelFunc,
+	bus *events.Bus,
+	logSub events.Subscriber,
+	hookSub events.Subscriber,
+) {
+	cancel()
+	native.StopObservers()
+	bus.Unsubscribe(logSub)
+	bus.Unsubscribe(hookSub)
+}
+
 func writePID(path string) error {
-	path = expandHome(path)
+	path = paths.ExpandHome(path)
 
 	err := os.MkdirAll(filepath.Dir(path), 0o755) //nolint:mnd
 	if err != nil {
@@ -231,17 +319,7 @@ func writePID(path string) error {
 }
 
 func removePID(path string) {
-	_ = os.Remove(expandHome(path))
-}
-
-func expandHome(path string) string {
-	if strings.HasPrefix(path, "~") {
-		home, _ := os.UserHomeDir()
-
-		return filepath.Join(home, path[1:])
-	}
-
-	return path
+	_ = os.Remove(paths.ExpandHome(path))
 }
 
 func hasWindowEvents(cfg *config.Config) bool {

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -6,12 +6,11 @@ import (
 	"errors"
 	"net"
 	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/y3owk1n/mimi/internal/config"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/paths"
 )
 
 const dialTimeout = 100 * time.Millisecond
@@ -20,7 +19,7 @@ const dialTimeout = 100 * time.Millisecond
 // Returns CodeDaemonUnavailable when the daemon is not reachable so callers can
 // fall back to direct execution.
 func TryExecute(socketPath, action string, args []string) error {
-	socketPath = expandHome(socketPath)
+	socketPath = paths.ExpandHome(socketPath)
 
 	_, err := os.Stat(socketPath)
 	if err != nil {
@@ -75,14 +74,4 @@ func ResolveSocketPath(cliConfigPath string) string {
 	}
 
 	return cfg.Settings.SocketFile
-}
-
-func expandHome(path string) string {
-	if strings.HasPrefix(path, "~") {
-		home, _ := os.UserHomeDir()
-
-		return filepath.Join(home, path[1:])
-	}
-
-	return path
 }

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/paths"
 	"github.com/y3owk1n/mimi/internal/systray"
 )
 
@@ -33,7 +34,7 @@ type actionJob struct {
 // NewServer creates a Unix socket server at path.
 func NewServer(path string) *Server {
 	return &Server{
-		path:     expandHome(path),
+		path:     paths.ExpandHome(path),
 		actionCh: make(chan actionJob),
 	}
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/y3owk1n/mimi/internal/config"
 	"github.com/y3owk1n/mimi/internal/events"
+	"github.com/y3owk1n/mimi/internal/paths"
 )
 
 const (
@@ -60,7 +61,7 @@ func New(cfg *config.Config) *zap.SugaredLogger {
 
 	if cfg.Settings.LogFile != "" {
 		logWriter := &lumberjack.Logger{
-			Filename:   expandHome(cfg.Settings.LogFile),
+			Filename:   paths.ExpandHome(cfg.Settings.LogFile),
 			MaxSize:    logMaxSizeMB,
 			MaxBackups: logMaxBackups,
 			MaxAge:     logMaxAgeDays,
@@ -119,7 +120,7 @@ func WriteEventLog(
 }
 
 func openAppend(path string) (*os.File, error) {
-	path = expandHome(path)
+	path = paths.ExpandHome(path)
 
 	err := os.MkdirAll(filepath.Dir(path), 0o755) //nolint:mnd
 	if err != nil {
@@ -127,16 +128,6 @@ func openAppend(path string) (*os.File, error) {
 	}
 
 	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:mnd
-}
-
-func expandHome(path string) string {
-	if strings.HasPrefix(path, "~") {
-		home, _ := os.UserHomeDir()
-
-		return filepath.Join(home, path[1:])
-	}
-
-	return path
 }
 
 func parseLevel(s string) zapcore.Level {

--- a/internal/native/axobserver.m
+++ b/internal/native/axobserver.m
@@ -1,6 +1,7 @@
 #import "axobserver.h"
 
 #include "_cgo_export.h"
+#import "eventkinds.h"
 #import "workspace.h"
 
 #import <ApplicationServices/ApplicationServices.h>
@@ -34,15 +35,15 @@ static void axCallback(AXObserverRef observer, AXUIElementRef element, CFStringR
 
 		int kind = -1;
 		if (CFEqual(notification, kAXFocusedWindowChangedNotification))
-			kind = 30;
+			kind = MIMI_KIND_WINDOW_FOCUS;
 		else if (CFEqual(notification, kAXTitleChangedNotification))
-			kind = 31;
+			kind = MIMI_KIND_WINDOW_TITLE_CHANGE;
 		else if (CFEqual(notification, kAXWindowCreatedNotification))
-			kind = 32;
+			kind = MIMI_KIND_WINDOW_CREATED;
 		else if (CFEqual(notification, kAXUIElementDestroyedNotification))
-			kind = 33;
+			kind = MIMI_KIND_WINDOW_CLOSED;
 		else if (CFEqual(notification, kAXWindowResizedNotification))
-			kind = 34;
+			kind = MIMI_KIND_WINDOW_RESIZING;
 
 		if (kind >= 0) {
 			NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];

--- a/internal/native/bridge.go
+++ b/internal/native/bridge.go
@@ -3,12 +3,14 @@ package native
 /*
 #include "workspace.h"
 #include "axobserver.h"
+#include "eventkinds.h"
 */
 import "C"
 
 import (
 	"runtime"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,12 +18,18 @@ import (
 	"github.com/y3owk1n/mimi/internal/events"
 )
 
-const eventChBufSize = 256
+const eventChBufSize = 4096
 
-var eventCh = make(chan events.Event, eventChBufSize)
+var (
+	eventCh      = make(chan events.Event, eventChBufSize)
+	eventDropped atomic.Int64
+)
 
 // Events returns a read-only channel of events from native observers.
 func Events() <-chan events.Event { return eventCh }
+
+// EventDropCount returns the number of events dropped due to channel congestion.
+func EventDropCount() int64 { return eventDropped.Load() }
 
 // ObserverConfig specifies which macOS event observers are active.
 type ObserverConfig struct {
@@ -94,23 +102,27 @@ func RemoveAXObserver(pid int) {
 	C.AXRemoveObserver(C.int(pid))
 }
 
+func trySend(evt events.Event) {
+	select {
+	case eventCh <- evt:
+	default:
+		eventDropped.Add(1)
+	}
+}
+
 //export goWorkspaceEvent
 func goWorkspaceEvent(kind C.int, appName, bundleID *C.char, pid C.int,
 	volPath, volName *C.char,
 ) {
 	_, _ = volPath, volName
-	evt := events.Event{
+	trySend(events.Event{
 		ID:       uuid.NewString(),
 		Kind:     kindFromInt(int(kind)),
 		AppName:  C.GoString(appName),
 		BundleID: C.GoString(bundleID),
 		PID:      int(pid),
 		At:       time.Now(),
-	}
-	select {
-	case eventCh <- evt:
-	default:
-	}
+	})
 }
 
 //export goWorkspaceChangeEvent
@@ -129,15 +141,12 @@ func goWorkspaceChangeEvent(kind C.int, windowCount C.int, infoJSON *C.char) {
 			evt.Extra["info"] = jsonStr
 		}
 	}
-	select {
-	case eventCh <- evt:
-	default:
-	}
+	trySend(evt)
 }
 
 //export goAXEvent
 func goAXEvent(kind C.int, appName, bundleID *C.char, pid C.int, windowTitle *C.char) {
-	evt := events.Event{
+	trySend(events.Event{
 		ID:          uuid.NewString(),
 		Kind:        kindFromInt(int(kind)),
 		AppName:     C.GoString(appName),
@@ -145,30 +154,32 @@ func goAXEvent(kind C.int, appName, bundleID *C.char, pid C.int, windowTitle *C.
 		PID:         int(pid),
 		WindowTitle: C.GoString(windowTitle),
 		At:          time.Now(),
-	}
-	select {
-	case eventCh <- evt:
-	default:
-	}
+	})
 }
 
 func kindFromInt(kindInt int) events.EventKind {
-	kindMap := map[int]events.EventKind{
-		0:  events.AppActivate,
-		2:  events.AppLaunch,
-		3:  events.AppQuit,
-		30: events.WindowFocus,
-		31: events.WindowTitleChange,
-		32: events.WindowCreated,
-		33: events.WindowClosed,
-		34: events.WindowResizing,
-		70: events.WorkspaceChanged,
+	switch kindInt {
+	case int(C.MIMI_KIND_APP_ACTIVATE):
+		return events.AppActivate
+	case int(C.MIMI_KIND_APP_LAUNCH):
+		return events.AppLaunch
+	case int(C.MIMI_KIND_APP_QUIT):
+		return events.AppQuit
+	case int(C.MIMI_KIND_WINDOW_FOCUS):
+		return events.WindowFocus
+	case int(C.MIMI_KIND_WINDOW_TITLE_CHANGE):
+		return events.WindowTitleChange
+	case int(C.MIMI_KIND_WINDOW_CREATED):
+		return events.WindowCreated
+	case int(C.MIMI_KIND_WINDOW_CLOSED):
+		return events.WindowClosed
+	case int(C.MIMI_KIND_WINDOW_RESIZING):
+		return events.WindowResizing
+	case int(C.MIMI_KIND_WORKSPACE_CHANGED):
+		return events.WorkspaceChanged
+	default:
+		return events.EventKind("unknown")
 	}
-	if k, ok := kindMap[kindInt]; ok {
-		return k
-	}
-
-	return events.EventKind("unknown")
 }
 
 func boolToInt(b bool) C.int {

--- a/internal/native/eventkinds.h
+++ b/internal/native/eventkinds.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Event kind constants — single source of truth for both Go (bridge.go)
+// and Obj-C (workspace.m, axobserver.m). Keep in sync with events/types.go.
+
+#define MIMI_KIND_APP_ACTIVATE 0
+#define MIMI_KIND_APP_DEACTIVATE 1
+#define MIMI_KIND_APP_LAUNCH 2
+#define MIMI_KIND_APP_QUIT 3
+#define MIMI_KIND_APP_HIDE 4
+#define MIMI_KIND_APP_UNHIDE 5
+
+#define MIMI_KIND_WILL_SLEEP 10
+#define MIMI_KIND_DID_WAKE 11
+#define MIMI_KIND_SESSION_RESIGN 12
+#define MIMI_KIND_SESSION_BECOME 13
+#define MIMI_KIND_WILL_POWER_OFF 14
+
+#define MIMI_KIND_VOLUME_MOUNT 20
+#define MIMI_KIND_VOLUME_UNMOUNT 21
+
+#define MIMI_KIND_APPEARANCE_CHANGED 42
+
+#define MIMI_KIND_WINDOW_FOCUS 30
+#define MIMI_KIND_WINDOW_TITLE_CHANGE 31
+#define MIMI_KIND_WINDOW_CREATED 32
+#define MIMI_KIND_WINDOW_CLOSED 33
+#define MIMI_KIND_WINDOW_RESIZING 34
+
+#define MIMI_KIND_WORKSPACE_CHANGED 70

--- a/internal/native/workspace.m
+++ b/internal/native/workspace.m
@@ -1,6 +1,7 @@
 #import "workspace.h"
 
 #include "_cgo_export.h"
+#import "eventkinds.h"
 
 #import <Cocoa/Cocoa.h>
 #include <CoreGraphics/CoreGraphics.h>
@@ -115,29 +116,29 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 	NSMutableDictionary *tempNotifToKind = [NSMutableDictionary dictionary];
 
 	if (appLifecycle) {
-		tempNotifToKind[NSWorkspaceDidActivateApplicationNotification] = @(0);
-		tempNotifToKind[NSWorkspaceDidDeactivateApplicationNotification] = @(1);
-		tempNotifToKind[NSWorkspaceDidLaunchApplicationNotification] = @(2);
-		tempNotifToKind[NSWorkspaceDidTerminateApplicationNotification] = @(3);
-		tempNotifToKind[NSWorkspaceDidHideApplicationNotification] = @(4);
-		tempNotifToKind[NSWorkspaceDidUnhideApplicationNotification] = @(5);
+		tempNotifToKind[NSWorkspaceDidActivateApplicationNotification] = @(MIMI_KIND_APP_ACTIVATE);
+		tempNotifToKind[NSWorkspaceDidDeactivateApplicationNotification] = @(MIMI_KIND_APP_DEACTIVATE);
+		tempNotifToKind[NSWorkspaceDidLaunchApplicationNotification] = @(MIMI_KIND_APP_LAUNCH);
+		tempNotifToKind[NSWorkspaceDidTerminateApplicationNotification] = @(MIMI_KIND_APP_QUIT);
+		tempNotifToKind[NSWorkspaceDidHideApplicationNotification] = @(MIMI_KIND_APP_HIDE);
+		tempNotifToKind[NSWorkspaceDidUnhideApplicationNotification] = @(MIMI_KIND_APP_UNHIDE);
 	}
 
 	if (systemState) {
-		tempNotifToKind[NSWorkspaceWillSleepNotification] = @(10);
-		tempNotifToKind[NSWorkspaceDidWakeNotification] = @(11);
-		tempNotifToKind[NSWorkspaceSessionDidResignActiveNotification] = @(12);
-		tempNotifToKind[NSWorkspaceSessionDidBecomeActiveNotification] = @(13);
-		tempNotifToKind[NSWorkspaceWillPowerOffNotification] = @(14);
+		tempNotifToKind[NSWorkspaceWillSleepNotification] = @(MIMI_KIND_WILL_SLEEP);
+		tempNotifToKind[NSWorkspaceDidWakeNotification] = @(MIMI_KIND_DID_WAKE);
+		tempNotifToKind[NSWorkspaceSessionDidResignActiveNotification] = @(MIMI_KIND_SESSION_RESIGN);
+		tempNotifToKind[NSWorkspaceSessionDidBecomeActiveNotification] = @(MIMI_KIND_SESSION_BECOME);
+		tempNotifToKind[NSWorkspaceWillPowerOffNotification] = @(MIMI_KIND_WILL_POWER_OFF);
 	}
 
 	if (volume) {
-		tempNotifToKind[NSWorkspaceDidMountNotification] = @(20);
-		tempNotifToKind[NSWorkspaceDidUnmountNotification] = @(21);
+		tempNotifToKind[NSWorkspaceDidMountNotification] = @(MIMI_KIND_VOLUME_MOUNT);
+		tempNotifToKind[NSWorkspaceDidUnmountNotification] = @(MIMI_KIND_VOLUME_UNMOUNT);
 	}
 
 	if (workspace) {
-		tempNotifToKind[NSWorkspaceActiveSpaceDidChangeNotification] = @(70);
+		tempNotifToKind[NSWorkspaceActiveSpaceDidChangeNotification] = @(MIMI_KIND_WORKSPACE_CHANGED);
 	}
 
 	self.notifToKind = tempNotifToKind;
@@ -156,7 +157,7 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 
 	if (workspace) {
 		self.lastWindowIDs = [self currentWindowIDs];
-		self.spacePollTimer = [NSTimer scheduledTimerWithTimeInterval:0.2
+		self.spacePollTimer = [NSTimer scheduledTimerWithTimeInterval:2.0
 		                                                       target:self
 		                                                     selector:@selector(checkSpaceChange:)
 		                                                     userInfo:nil
@@ -171,11 +172,11 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 	}
 	self.lastWindowIDs = currentIDs;
 	NSString *infoJSON = [self windowInfoJSON];
-	goWorkspaceChangeEvent(70, (int)[currentIDs count], (char *)[infoJSON UTF8String]);
+	goWorkspaceChangeEvent(MIMI_KIND_WORKSPACE_CHANGED, (int)[currentIDs count], (char *)[infoJSON UTF8String]);
 }
 
 - (void)appearanceChanged:(NSNotification *)note {
-	goWorkspaceEvent(42, "", "", 0, "", "");
+	goWorkspaceEvent(MIMI_KIND_APPEARANCE_CHANGED, "", "", 0, "", "");
 }
 
 - (int)kindForNotificationName:(NSString *)name {
@@ -185,7 +186,7 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 
 - (void)handleNotification:(NSNotification *)note {
 	int kind = [self kindForNotificationName:note.name];
-	if (kind == 70) {
+	if (kind == MIMI_KIND_WORKSPACE_CHANGED) {
 		NSSet *windows = [self currentWindowIDs];
 		self.lastWindowIDs = windows;
 		NSString *infoJSON = [self windowInfoJSON];

--- a/internal/observe/router.go
+++ b/internal/observe/router.go
@@ -107,13 +107,23 @@ func (r *Router) debounceResize(evt events.Event) {
 	}
 
 	if rState, ok := r.timers[key]; ok {
-		rState.timer.Stop()
-		rState.evt = evt
-		rState.timer.Reset(resizeDebounceDuration)
+		if rState.timer.Stop() {
+			rState.evt = evt
+			rState.timer.Reset(resizeDebounceDuration)
 
-		return
+			return
+		}
+
+		// Timer already fired — create a fresh entry to avoid resetting
+		// an AfterFunc timer whose callback may still be running.
+		delete(r.timers, key)
 	}
 
+	rState := r.newDebounceEntry(key, evt)
+	r.timers[key] = rState
+}
+
+func (r *Router) newDebounceEntry(key string, evt events.Event) *resizeState {
 	rState := &resizeState{evt: evt}
 	rState.timer = time.AfterFunc(resizeDebounceDuration, func() {
 		r.mu.Lock()
@@ -148,7 +158,8 @@ func (r *Router) debounceResize(evt events.Event) {
 		)
 		r.bus.Publish(resizeEvt)
 	})
-	r.timers[key] = rState
+
+	return rState
 }
 
 func (r *Router) cancelTimersForPID(pid int) {

--- a/internal/paths/doc.go
+++ b/internal/paths/doc.go
@@ -1,0 +1,2 @@
+// Package paths provides utilities for path manipulation.
+package paths

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,19 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandHome expands a leading ~ to the current user's home directory.
+// If path does not start with ~, it is returned unchanged.
+func ExpandHome(path string) string {
+	if strings.HasPrefix(path, "~") {
+		home, _ := os.UserHomeDir()
+
+		return filepath.Join(home, path[1:])
+	}
+
+	return path
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR provides 3 categories of improvemnts:

- **Performance** — Reduced a polling timer from 200ms to 2s (it was a fallback; the real notification was already in place). Increased event channel capacity 16x and added overflow tracking so drops are no longer silent. Fixed a timer reuse race that could cause concurrent callback execution.

- **Code Quality** — Consolidated 5 duplicate path-expansion helpers into a shared utility. Unified event kind constants across Go and Objective-C into a single header so both sides always stay in sync. Replaced a TOCTOU-prone stat-then-write with an atomic exclusive-create flag.

- **Maintainability** — Split a 130-line daemon startup function into 6 focused, testable pieces that are easier to reason about independently.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
