### PR TITLE
feat: add `next/prev` cycle with wrapping to space related commands

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -24,7 +24,11 @@ Examples:
   mimi action focus_window
   mimi action focus_window --backward
   mimi action space 1
-  mimi action move_window_to_space 2`,
+  mimi action space next
+  mimi action space prev
+  mimi action move_window_to_space 2
+  mimi action move_window_to_space next
+  mimi action move_window_to_space prev`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		return derrors.New(
 			derrors.CodeInvalidInput,
@@ -68,13 +72,18 @@ current space are included.`,
 
 func buildSpaceCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "space <number>",
-		Short: "Focus a Mission Control space by 1-based index",
-		Long: `Focus a Mission Control space by its 1-based index.
+		Use:   "space <number|next|prev>",
+		Short: "Focus a Mission Control space by index or cycle next/prev",
+		Long: `Focus a Mission Control space by its 1-based index, or cycle to the next or
+previous space.
 
 Spaces are enumerated in Mission Control ordering across all connected
 displays. Index 1 is the first space (typically the leftmost on the
 primary display), index 2 the second, and so on.
+
+The "next" and "prev" keywords cycle through spaces with wrapping — "next"
+on the last space wraps to space 1, and "prev" on space 1 wraps to the
+last space.
 
 macOS does not provide a public API to activate a space, so mimi
 synthesizes a high-velocity horizontal dock swipe gesture to fast-forward
@@ -83,8 +92,9 @@ destination sits on a different display, the cursor is warped to its
 center first so the gesture is attributed to the correct screen.
 
 Examples:
-  mimi action space 1     Focus the first Mission Control space
-  mimi action space 3     Focus the third`,
+  mimi action space 1        Focus the first Mission Control space
+  mimi action space next     Cycle to the next space (with wrap)
+  mimi action space prev     Cycle to the previous space (with wrap)`,
 		Args: validateActionSpaceArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runAction(string(action.NameSpace), []string{strings.TrimSpace(args[0])})
@@ -94,19 +104,25 @@ Examples:
 
 func buildMoveWindowToSpaceCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "move_window_to_space <number>",
-		Short: "Move current focused window to a Mission Control space by 1-based index",
-		Long: `Move the currently focused window to a Mission Control space by its 1-based index.
+		Use:   "move_window_to_space <number|next|prev>",
+		Short: "Move current focused window to a Mission Control space by index or cycle next/prev",
+		Long: `Move the currently focused window to a Mission Control space by its 1-based
+index, or cycle to the next or previous space.
 
 Spaces are enumerated in Mission Control ordering across all connected
 displays. Index 1 is the first space, index 2 the second, and so on.
+
+The "next" and "prev" keywords cycle through spaces with wrapping — "next"
+on the last space wraps to space 1, and "prev" on space 1 wraps to the
+last space.
 
 This command uses private APIs (SkyLight) to move the window instantly
 without scripting additions or disabling SIP on macOS.
 
 Examples:
-  mimi action move_window_to_space 2     Move current window to space 2
-  mimi action move_window_to_space 4     Move current window to space 4`,
+  mimi action move_window_to_space 2        Move current window to space 2
+  mimi action move_window_to_space next     Move window to next space (with wrap)
+  mimi action move_window_to_space prev     Move window to previous space (with wrap)`,
 		Args: validateActionMoveWindowToSpaceArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runAction(
@@ -118,10 +134,44 @@ Examples:
 }
 
 func validateActionSpaceArgs(_ *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"space requires exactly one positional argument: a 1-based number, \"next\", or \"prev\" (e.g., mimi action space 1, mimi action space next)",
+		)
+	}
+
+	raw := strings.TrimSpace(args[0])
+	if raw == "" {
+		return derrors.New(derrors.CodeInvalidInput, "space argument cannot be empty")
+	}
+
+	keywords := map[string]bool{"next": true, "prev": true, "previous": true}
+	if keywords[raw] {
+		return nil
+	}
+
 	return validateActionIndexArgs(args, "space")
 }
 
 func validateActionMoveWindowToSpaceArgs(_ *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"move_window_to_space requires exactly one positional argument: a 1-based number, \"next\", or \"prev\" (e.g., mimi action move_window_to_space 1, mimi action move_window_to_space next)",
+		)
+	}
+
+	raw := strings.TrimSpace(args[0])
+	if raw == "" {
+		return derrors.New(derrors.CodeInvalidInput, "space argument cannot be empty")
+	}
+
+	keywords := map[string]bool{"next": true, "prev": true, "previous": true}
+	if keywords[raw] {
+		return nil
+	}
+
 	return validateActionIndexArgs(args, "move_window_to_space")
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -32,7 +32,11 @@ These commands run directly in the CLI process when the daemon is not running. W
 mimi action focus_window
 mimi action focus_window --backward
 mimi action space 1
+mimi action space next
+mimi action space prev
 mimi action move_window_to_space 2
+mimi action move_window_to_space next
+mimi action move_window_to_space prev
 ```
 
 ### `mimi action focus_window`
@@ -43,13 +47,13 @@ Cycle keyboard focus through all focusable windows on the current space.
 | ------------ | ------------------------------------------------ |
 | `--backward` | Cycle to the previous window instead of the next |
 
-### `mimi action space <number>`
+### `mimi action space <number|next|prev>`
 
-Focus a Mission Control space by its 1-based index. Uses a synthetic dock-swipe gesture (no public macOS API exists for direct space switching).
+Focus a Mission Control space by its 1-based index, or cycle to the next/previous space with wrapping. Uses a synthetic dock-swipe gesture (no public macOS API exists for direct space switching).
 
-### `mimi action move_window_to_space <number>`
+### `mimi action move_window_to_space <number|next|prev>`
 
-Move the frontmost window to a space by its 1-based index. Uses private SkyLight APIs; does not require disabling SIP.
+Move the frontmost window to a space by its 1-based index, or cycle to the next/previous space with wrapping. Uses private SkyLight APIs; does not require disabling SIP.
 
 ---
 

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/space"
 )
 
 // Name identifies a supported action subcommand.
@@ -51,30 +52,59 @@ func parseFocusWindowArgs(rawArgs []string) (parsedFocusWindowArgs, error) {
 	return parsed, nil
 }
 
-func parseIndexArg(args []string, actionName string) (int, error) {
+type spaceArg struct {
+	index     int
+	direction int // +1 for next, -1 for prev; 0 means absolute index
+}
+
+func parseSpaceArg(args []string) (spaceArg, error) {
 	if len(args) != 1 {
-		return 0, derrors.Newf(
+		return spaceArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
-			"%s requires exactly one positional argument: the 1-based space number",
-			actionName,
+			"space requires exactly one argument: a 1-based number, \"next\", or \"prev\"",
 		)
 	}
 
 	raw := strings.TrimSpace(args[0])
 	if raw == "" {
-		return 0, derrors.New(derrors.CodeInvalidInput, "space number cannot be empty")
+		return spaceArg{}, derrors.New(derrors.CodeInvalidInput, "space argument cannot be empty")
+	}
+
+	switch raw {
+	case "next":
+		return spaceArg{direction: 1}, nil
+	case "prev", "previous":
+		return spaceArg{direction: -1}, nil
 	}
 
 	index, parseErr := strconv.Atoi(raw)
 	if parseErr != nil || index < 1 {
-		return 0, derrors.Newf(
+		return spaceArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
-			"space number must be a positive integer, got %s",
+			"space must be a positive integer, \"next\", or \"prev\", got %q",
 			raw,
 		)
 	}
 
-	return index, nil
+	return spaceArg{index: index}, nil
+}
+
+func (s spaceArg) resolve() (int, error) {
+	if s.direction != 0 {
+		current, err := space.ActiveIndex()
+		if err != nil {
+			return 0, err
+		}
+
+		count := space.Count()
+		if count == 0 {
+			return 0, derrors.New(derrors.CodeActionFailed, "no Mission Control spaces found")
+		}
+
+		return ((current - 1 + s.direction + count) % count) + 1, nil
+	}
+
+	return s.index, nil
 }
 
 // Execute runs a named action with the given arguments.
@@ -88,14 +118,24 @@ func Execute(name string, args []string) error {
 
 		return FocusWindow(parsed.useBackward)
 	case NameSpace:
-		index, err := parseIndexArg(args, string(NameSpace))
+		parsed, err := parseSpaceArg(args)
+		if err != nil {
+			return err
+		}
+
+		index, err := parsed.resolve()
 		if err != nil {
 			return err
 		}
 
 		return FocusSpace(index)
 	case NameMoveWindowToSpace:
-		index, err := parseIndexArg(args, string(NameMoveWindowToSpace))
+		parsed, err := parseSpaceArg(args)
+		if err != nil {
+			return err
+		}
+
+		index, err := parsed.resolve()
 		if err != nil {
 			return err
 		}

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -48,13 +48,88 @@ func TestExecute_InvalidAction(t *testing.T) {
 func TestExecute_SpaceValidation(t *testing.T) {
 	t.Parallel()
 
-	err := action.Execute("space", []string{"0"})
-	if err == nil {
-		t.Fatal("Execute(space 0) expected error")
+	tests := []struct {
+		name string
+		arg  string
+		code derrors.Code
+	}{
+		{name: "zero", arg: "0", code: derrors.CodeInvalidInput},
+		{name: "negative", arg: "-1", code: derrors.CodeInvalidInput},
+		{name: "non-numeric", arg: "foo", code: derrors.CodeInvalidInput},
+		{name: "empty", arg: "", code: derrors.CodeInvalidInput},
 	}
 
-	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
-		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := action.Execute("space", []string{testCase.arg})
+			if err == nil {
+				t.Fatalf("Execute(space %q) expected error", testCase.arg)
+			}
+
+			if !derrors.IsCode(err, testCase.code) {
+				t.Fatalf("Execute(space %q) got code %v, want %v", testCase.arg, err, testCase.code)
+			}
+		})
+	}
+}
+
+func TestExecute_SpaceNextPrev(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		arg  string
+	}{
+		{name: "next", arg: "next"},
+		{name: "prev", arg: "prev"},
+		{name: "previous", arg: "previous"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := action.Execute("space", []string{testCase.arg})
+
+			if derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Fatalf(
+					"Execute(space %q) got unexpected CodeInvalidInput; keyword should be recognized: %v",
+					testCase.arg,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestExecute_MoveWindowToSpaceNextPrev(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		arg  string
+	}{
+		{name: "next", arg: "next"},
+		{name: "prev", arg: "prev"},
+		{name: "previous", arg: "previous"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := action.Execute("move_window_to_space", []string{testCase.arg})
+
+			if derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Fatalf(
+					"Execute(move_window_to_space %q) got unexpected CodeInvalidInput; keyword should be recognized: %v",
+					testCase.arg,
+					err,
+				)
+			}
+		})
 	}
 }
 

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -26,6 +26,7 @@ bool MimiIsMissionControlActive(void);
 int MimiCountMissionControlSpaces(void);
 uint64_t MimiMissionControlSpaceID(int index);
 uint32_t MimiSpaceDisplayID(uint64_t sid);
+uint64_t MimiActiveSpaceID(void);
 int MimiFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid);
 int MimiMoveWindowToSpace(void *windowElement, uint64_t spaceID);
 

--- a/internal/space/space.go
+++ b/internal/space/space.go
@@ -57,6 +57,31 @@ func Count() int {
 	return int(C.MimiCountMissionControlSpaces())
 }
 
+// ActiveIndex returns the 1-based index of the currently active space.
+func ActiveIndex() (int, error) {
+	count := Count()
+	if count == 0 {
+		return 0, derrors.New(
+			derrors.CodeActionFailed,
+			"failed to enumerate Mission Control spaces",
+		)
+	}
+
+	activeID := uint64(C.MimiActiveSpaceID())
+	if activeID == 0 {
+		return 0, derrors.New(derrors.CodeActionFailed, "failed to resolve active space ID")
+	}
+
+	for i := 1; i <= count; i++ {
+		sid := uint64(C.MimiMissionControlSpaceID(C.int(i)))
+		if sid == activeID {
+			return i, nil
+		}
+	}
+
+	return 0, derrors.New(derrors.CodeActionFailed, "active space not found in space enumeration")
+}
+
 // MoveWindow moves the frontmost window to the space at the given 1-based index.
 func MoveWindow(index int) error {
 	count := int(C.MimiCountMissionControlSpaces())


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR extends the space related command from `<number>` to relative cycling.

```bash
mimi action space 3
mimi action space next
mimi action space prev

mimi action move_window_to_space 3
mimi action move_window_to_space next
mimi action move_window_to_space prev
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #30

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
