### PR TITLE
fix: show restart prompt after granting accessibility permission

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -156,7 +156,7 @@ func setupObservers(cfg *config.Config, logger *zap.SugaredLogger) (*native.Obse
 		accessibilityPrompt = func() bool {
 			choice := permissions.ShowAccessibilityStartupAlert()
 
-			return choice != permissions.AccessibilityStartupQuit
+			return choice == permissions.AccessibilityStartupGranted
 		}
 	}
 

--- a/internal/permissions/check.go
+++ b/internal/permissions/check.go
@@ -30,6 +30,8 @@ const (
 	AccessibilityStartupGranted AccessibilityStartupChoice = 1
 	// AccessibilityStartupQuit indicates the user chose to quit.
 	AccessibilityStartupQuit AccessibilityStartupChoice = 2
+	// AccessibilityStartupRestartRequired indicates user needs to restart the app after granting permission.
+	AccessibilityStartupRestartRequired AccessibilityStartupChoice = 3
 )
 
 // CheckResult holds the results of a permissions check.

--- a/internal/permissions/permissions.m
+++ b/internal/permissions/permissions.m
@@ -92,7 +92,28 @@ int MimiShowAccessibilityPermissionStartupAlert(void) {
 				if (response == NSAlertFirstButtonReturn) {
 					MimiRequestAccessibilityPermissions();
 				} else if (response == NSAlertSecondButtonReturn) {
-					return 1;
+					if (MimiCheckAccessibilityPermissions() == 1) {
+						return 1;
+					}
+
+					NSAlert *restartAlert = [[NSAlert alloc] init];
+					restartAlert.messageText = @"Mimi Restart Required";
+					restartAlert.informativeText =
+					    @"macOS requires restarting Mimi for Accessibility permissions to take effect.\n\n"
+					     "Mimi will now quit. Please relaunch the application.";
+					restartAlert.alertStyle = NSAlertStyleInformational;
+					[restartAlert addButtonWithTitle:@"Quit Mimi"];
+
+					[[restartAlert window] setLevel:NSFloatingWindowLevel];
+					[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+					[[restartAlert window] center];
+					[[restartAlert window] makeKeyAndOrderFront:nil];
+					[NSApp activateIgnoringOtherApps:YES];
+
+					[restartAlert runModal];
+					[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+					return 3;
 				} else if (response == NSAlertThirdButtonReturn) {
 					return 2;
 				}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR implements a "Mimi Restart Required" dialog when the user grants Accessibility permission. Mimi needs to be restarted for the permission to take effect — the app now quits cleanly after the alert so the user can relaunch.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #31

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
