### PR TITLE
feat(cli): add `resize_window` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ If you like native Spaces and want to stay close to stock macOS — or you are t
 
 ## What you get
 
-| Mode               | When to use it                                                                                 |
-| :----------------- | :--------------------------------------------------------------------------------------------- |
+| Mode               | When to use it                                                                                                                                 |
+| :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------- |
 | **CLI actions**    | One-shot commands — bind to hotkeys, scripts, or Alfred/Raycast. Work without the daemon; route over IPC when it is running for lower latency. |
-| **Daemon + hooks** | React to window and space changes with shell commands (`on_window_*`, `on_workspace_changed`). |
-| **Menu bar**       | See the active space number, reload config, or quit — enabled by default when the daemon runs. |
+| **Daemon + hooks** | React to window and space changes with shell commands (`on_window_*`, `on_workspace_changed`).                                                 |
+| **Menu bar**       | See the active space number, reload config, or quit — enabled by default when the daemon runs.                                                 |
 
 ---
 
@@ -72,6 +72,8 @@ mimi action space 2                        # jump to space 2
 mimi action space next                     # cycle to next space
 mimi action move_window_to_space 3         # move frontmost window to space 3
 mimi action move_window_to_space prev      # move window to previous space
+mimi action resize_window left-half        # tile window to left half
+mimi action resize_window center           # center window
 ```
 
 Full command reference → [CLI Guide](docs/CLI.md)
@@ -111,13 +113,14 @@ Auto-start at login → [Installation Guide — launchd](docs/INSTALLATION.md#au
 
 ### Window & space actions
 
-| Action                           | Command                                                     |
-| :------------------------------- | :---------------------------------------------------------- |
-| Cycle window focus               | `mimi action focus_window`                                  |
-| Switch to a space                | `mimi action space <n\|next\|prev>`                          |
-| Move frontmost window to a space | `mimi action move_window_to_space <n\|next\|prev>`          |
+| Action                           | Command                                            |
+| :------------------------------- | :------------------------------------------------- |
+| Cycle window focus               | `mimi action focus_window`                         |
+| Switch to a space                | `mimi action space <n\|next\|prev>`                |
+| Move frontmost window to a space | `mimi action move_window_to_space <n\|next\|prev>` |
+| Resize and reposition window     | `mimi action resize_window <preset\|flags>`        |
 
-Space switching uses a synthetic dock-swipe gesture. Window moves use SkyLight for instant relocation without animation.
+Space switching uses a synthetic dock-swipe gesture. Window moves use SkyLight for instant relocation without animation. Window resizing supports presets (e.g., `left-half`, `center`, `fill`) and precise controls with custom sizing, positioning, and margin handling.
 
 ### Hooks (daemon)
 

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -17,7 +17,7 @@ var actionCmd = &cobra.Command{
 	Long: `Perform immediate window and space utility actions.
 
 Available subcommands:
-  Window control:   focus_window
+  Window control:   focus_window, resize_window
   Space control:    space, move_window_to_space
 
 Examples:
@@ -28,7 +28,10 @@ Examples:
   mimi action space prev
   mimi action move_window_to_space 2
   mimi action move_window_to_space next
-  mimi action move_window_to_space prev`,
+  mimi action move_window_to_space prev
+  mimi action resize_window left-half
+  mimi action resize_window --width 800 --height 600 --anchor cc
+  mimi action resize_window --width-percent 50 --height-percent 100 --anchor tl`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		return derrors.New(
 			derrors.CodeInvalidInput,
@@ -41,6 +44,7 @@ var (
 	actionFocusWindowCmd       = buildFocusWindowCommand()
 	actionSpaceCmd             = buildSpaceCommand()
 	actionMoveWindowToSpaceCmd = buildMoveWindowToSpaceCommand()
+	actionResizeWindowCmd      = buildResizeWindowCommand()
 )
 
 func buildFocusWindowCommand() *cobra.Command {
@@ -133,6 +137,140 @@ Examples:
 	}
 }
 
+func buildResizeWindowCommand() *cobra.Command {
+	var (
+		width     int
+		height    int
+		widthPct  float64
+		heightPct float64
+		xCoord    int
+		yCoord    int
+		anchor    string
+		useMargin bool
+		noMargin  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "resize_window [preset]",
+		Short: "Resize and reposition the frontmost window",
+		Long: `Resize and reposition the frontmost window using presets or custom flags.
+
+Presets provide quick tiling:
+  left-half      Fill the left half of the screen
+  right-half     Fill the right half of the screen
+  top-half       Fill the top half of the screen
+  bottom-half    Fill the bottom half of the screen
+  top-left       Fill the top-left quadrant
+  top-right      Fill the top-right quadrant
+  bottom-left    Fill the bottom-left quadrant
+  bottom-right   Fill the bottom-right quadrant
+  center         Center the window at 60% x 80% of screen
+  fill           Fill the entire screen (respecting margins)
+
+Custom flags allow precise control using an anchor system:
+  Anchors: tl (top-left), tc (top-center), tr (top-right),
+           cl (center-left), cc (center-center), cr (center-right),
+           bl (bottom-left), bc (bottom-center), br (bottom-right)
+
+  When --x or --y are specified, the window's anchor point is
+  placed at those absolute screen coordinates. When omitted, the
+  anchor point defaults to the corresponding screen edge or center.
+
+  The tiled window margins setting (com.apple.WindowManager
+  EnableTiledWindowMargins) is respected by default. Margins are
+  applied intelligently: full margin on screen-facing edges, half
+  margin on internal (split) edges so adjacent windows share a
+  single gap. Use --margin or --no-margin to override.
+
+Examples:
+  mimi action resize_window left-half
+  mimi action resize_window --width 800 --height 600 --anchor cc
+  mimi action resize_window --width-percent 50 --height-percent 100 --anchor tl
+  mimi action resize_window --width 1024 --height 768 --x 0 --y 0 --anchor tl
+  mimi action resize_window fill --no-margin
+  mimi action resize_window center --width-percent 80 --height-percent 90`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			cmdArgs := []string{}
+
+			if len(args) > 0 {
+				preset := strings.TrimSpace(args[0])
+				if action.IsResizePreset(preset) {
+					cmdArgs = append(cmdArgs, preset)
+				} else {
+					return derrors.Newf(
+						derrors.CodeInvalidInput,
+						"unknown preset %q (valid: left-half, right-half, top-half, bottom-half, top-left, top-right, bottom-left, bottom-right, center, fill)",
+						preset,
+					)
+				}
+			}
+
+			if width > 0 {
+				cmdArgs = append(cmdArgs, "--width", strconv.Itoa(width))
+			}
+
+			if height > 0 {
+				cmdArgs = append(cmdArgs, "--height", strconv.Itoa(height))
+			}
+
+			if widthPct > 0 {
+				cmdArgs = append(
+					cmdArgs,
+					"--width-percent",
+					strconv.FormatFloat(widthPct, 'f', -1, 64),
+				)
+			}
+
+			if heightPct > 0 {
+				cmdArgs = append(
+					cmdArgs,
+					"--height-percent",
+					strconv.FormatFloat(heightPct, 'f', -1, 64),
+				)
+			}
+
+			if cobraCmd.Flags().Changed("x") {
+				cmdArgs = append(cmdArgs, "--x", strconv.Itoa(xCoord))
+			}
+
+			if cobraCmd.Flags().Changed("y") {
+				cmdArgs = append(cmdArgs, "--y", strconv.Itoa(yCoord))
+			}
+
+			if cobraCmd.Flags().Changed("anchor") {
+				cmdArgs = append(cmdArgs, "--anchor", anchor)
+			}
+
+			if useMargin {
+				cmdArgs = append(cmdArgs, "--margin")
+			}
+
+			if noMargin {
+				cmdArgs = append(cmdArgs, "--no-margin")
+			}
+
+			return runAction(string(action.NameResizeWindow), cmdArgs)
+		},
+	}
+
+	cmd.Flags().IntVarP(&width, "width", "w", 0, "Absolute window width in points")
+	cmd.Flags().IntVar(&height, "height", 0, "Absolute window height in points")
+	cmd.Flags().Float64Var(&widthPct, "width-percent", 0, "Width as percentage of screen (0-100)")
+	cmd.Flags().
+		Float64Var(&heightPct, "height-percent", 0, "Height as percentage of screen (0-100)")
+	cmd.Flags().IntVar(&xCoord, "x", 0, "Absolute x position in screen coordinates")
+	cmd.Flags().IntVar(&yCoord, "y", 0, "Absolute y position in screen coordinates")
+	cmd.Flags().
+		StringVarP(&anchor, "anchor", "a", "", "Anchor point for positioning (tl, tc, tr, cl, cc, cr, bl, bc, br)")
+	cmd.Flags().
+		BoolVar(&useMargin, "margin", false, "Enable tiled window margins (overrides system setting)")
+	cmd.Flags().
+		BoolVar(&noMargin, "no-margin", false, "Disable tiled window margins (overrides system setting)")
+
+	return cmd
+}
+
 func validateActionSpaceArgs(_ *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return derrors.Newf(
@@ -206,4 +344,5 @@ func init() {
 	actionCmd.AddCommand(actionFocusWindowCmd)
 	actionCmd.AddCommand(actionSpaceCmd)
 	actionCmd.AddCommand(actionMoveWindowToSpaceCmd)
+	actionCmd.AddCommand(actionResizeWindowCmd)
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -16,10 +16,10 @@ mimi is a macOS window and space utility. Use `mimi action` for immediate comman
 
 ## Global Flags
 
-| Flag            | Shorthand | Default | Description           |
-| --------------- | --------- | ------- | --------------------- |
-| `--config, -c`  |           | auto    | Path to config file   |
-| `--verbose, -v` |           | `false` | Verbose output        |
+| Flag            | Shorthand | Default | Description            |
+| --------------- | --------- | ------- | ---------------------- |
+| `--config, -c`  |           | auto    | Path to config file    |
+| `--verbose, -v` |           | `false` | Verbose output         |
 | `--version`     |           |         | Print version and exit |
 
 ---
@@ -37,6 +37,9 @@ mimi action space prev
 mimi action move_window_to_space 2
 mimi action move_window_to_space next
 mimi action move_window_to_space prev
+mimi action resize_window left-half
+mimi action resize_window center --width-percent 80 --height-percent 90
+mimi action resize_window --width 1024 --height 768 --anchor cc
 ```
 
 ### `mimi action focus_window`
@@ -54,6 +57,82 @@ Focus a Mission Control space by its 1-based index, or cycle to the next/previou
 ### `mimi action move_window_to_space <number|next|prev>`
 
 Move the frontmost window to a space by its 1-based index, or cycle to the next/previous space with wrapping. Uses private SkyLight APIs; does not require disabling SIP.
+
+### `mimi action resize_window [preset] [flags]`
+
+Resize and reposition the frontmost window using presets or custom flags. Respects the macOS tiled window margins setting (`com.apple.WindowManager.EnableTiledWindowMargins`), applying full margins on screen-facing edges and half margins on internal (split) edges.
+
+**Presets** provide quick tiling layouts:
+
+| Preset         | Effect                               |
+| -------------- | ------------------------------------ |
+| `left-half`    | Fill the left half of the screen     |
+| `right-half`   | Fill the right half of the screen    |
+| `top-half`     | Fill the top half of the screen      |
+| `bottom-half`  | Fill the bottom half of the screen   |
+| `top-left`     | Fill the top-left quadrant           |
+| `top-right`    | Fill the top-right quadrant          |
+| `bottom-left`  | Fill the bottom-left quadrant        |
+| `bottom-right` | Fill the bottom-right quadrant       |
+| `center`       | Center window at 60% × 80% of screen |
+| `fill`         | Fill entire screen                   |
+
+**Custom sizing flags:**
+
+| Flag                     | Description                            |
+| ------------------------ | -------------------------------------- |
+| `--width, -w <pixels>`   | Absolute window width in points        |
+| `--height, -h <pixels>`  | Absolute window height in points       |
+| `--width-percent <pct>`  | Width as percentage of screen (0–100)  |
+| `--height-percent <pct>` | Height as percentage of screen (0–100) |
+
+**Positioning flags** (use anchors to align the window):
+
+| Flag           | Description              |
+| -------------- | ------------------------ |
+| `--x <pixels>` | Absolute X position      |
+| `--y <pixels>` | Absolute Y position      |
+| `--anchor, -a` | Anchor point (see below) |
+
+**Anchor system** places the window's anchor point at the computed or specified position. Valid anchors (use 2 letters: vertical + horizontal):
+
+```
+tl  tc  tr       (top-left, top-center, top-right)
+cl  cc  cr       (center-left, center-center, center-right)
+bl  bc  br       (bottom-left, bottom-center, bottom-right)
+```
+
+**Margin control:**
+
+| Flag          | Effect                                          |
+| ------------- | ----------------------------------------------- |
+| `--margin`    | Enable tiled margins (overrides system setting) |
+| `--no-margin` | Disable tiled margins                           |
+
+**Examples:**
+
+```bash
+# Presets
+mimi action resize_window left-half
+mimi action resize_window right-half
+mimi action resize_window top-left
+mimi action resize_window center
+
+# Fixed dimensions, centered
+mimi action resize_window --width 800 --height 600 --anchor cc
+
+# Percentage of screen, top-left
+mimi action resize_window --width-percent 50 --height-percent 75 --anchor tl
+
+# Absolute position, top-left anchor
+mimi action resize_window --width 1024 --height 768 --x 100 --y 50 --anchor tl
+
+# Override margins for a preset
+mimi action resize_window left-half --no-margin
+
+# Mix preset with custom size
+mimi action resize_window center --width-percent 80 --height-percent 90
+```
 
 ---
 

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -16,12 +16,13 @@ const (
 	NameFocusWindow       Name = "focus_window"
 	NameSpace             Name = "space"
 	NameMoveWindowToSpace Name = "move_window_to_space"
+	NameResizeWindow      Name = "resize_window"
 )
 
 // IsKnownName reports whether name is a supported action.
 func IsKnownName(name string) bool {
 	switch Name(name) {
-	case NameFocusWindow, NameSpace, NameMoveWindowToSpace:
+	case NameFocusWindow, NameSpace, NameMoveWindowToSpace, NameResizeWindow:
 		return true
 	default:
 		return false
@@ -107,6 +108,224 @@ func (s spaceArg) resolve() (int, error) {
 	return s.index, nil
 }
 
+// parsedResizeWindowArgs holds parsed flags for the resize_window action.
+type parsedResizeWindowArgs struct {
+	preset    string
+	width     int
+	height    int
+	widthPct  float64
+	heightPct float64
+	x         int
+	y         int
+	anchor    string
+	hasX      bool
+	hasY      bool
+	useMargin *bool // nil = system default
+}
+
+// validAnchors for window positioning.
+var validAnchors = map[string]bool{
+	"tl": true, "tc": true, "tr": true,
+	"cl": true, "cc": true, "cr": true,
+	"bl": true, "bc": true, "br": true,
+}
+
+// resizePresets maps preset names to dimension percentages and anchor.
+var resizePresets = map[string]struct {
+	widthPct  float64
+	heightPct float64
+	anchor    string
+}{
+	"left-half":    {50, 100, "tl"},
+	"right-half":   {50, 100, "tr"},
+	"top-half":     {100, 50, "tl"},
+	"bottom-half":  {100, 50, "bl"},
+	"top-left":     {50, 50, "tl"},
+	"top-right":    {50, 50, "tr"},
+	"bottom-left":  {50, 50, "bl"},
+	"bottom-right": {50, 50, "br"},
+	"center":       {60, 80, "cc"},
+	"fill":         {100, 100, "tl"},
+}
+
+// IsResizePreset reports whether s is a known resize window preset.
+func IsResizePreset(s string) bool {
+	_, ok := resizePresets[s]
+
+	return ok
+}
+
+func parseResizeWindowArgs(rawArgs []string) (parsedResizeWindowArgs, error) {
+	var parsed parsedResizeWindowArgs
+
+	parsed.anchor = "cc"
+
+	args := rawArgs
+
+	// Check for preset as first positional arg
+	if len(args) > 0 && IsResizePreset(args[0]) {
+		parsed.preset = args[0]
+		args = args[1:]
+	}
+
+	// Parse --flags
+	for argIndex := 0; argIndex < len(args); argIndex++ {
+		arg := args[argIndex]
+
+		switch arg {
+		case "--width", "-w":
+			if argIndex+1 >= len(args) {
+				return parsed, derrors.New(derrors.CodeInvalidInput, "--width requires a value")
+			}
+
+			width, err := strconv.Atoi(args[argIndex+1])
+			if err != nil || width < 0 {
+				return parsed, derrors.Newf(
+					derrors.CodeInvalidInput,
+					"invalid width: %q",
+					args[argIndex+1],
+				)
+			}
+
+			parsed.width = width
+			argIndex++
+		case "--height", "-h":
+			if argIndex+1 >= len(args) {
+				return parsed, derrors.New(derrors.CodeInvalidInput, "--height requires a value")
+			}
+
+			height, err := strconv.Atoi(args[argIndex+1])
+			if err != nil || height < 0 {
+				return parsed, derrors.Newf(
+					derrors.CodeInvalidInput,
+					"invalid height: %q",
+					args[argIndex+1],
+				)
+			}
+
+			parsed.height = height
+			argIndex++
+		case "--width-percent":
+			if argIndex+1 >= len(args) {
+				return parsed, derrors.New(
+					derrors.CodeInvalidInput,
+					"--width-percent requires a value",
+				)
+			}
+
+			widthPercent, err := strconv.ParseFloat(args[argIndex+1], 64)
+			if err != nil || widthPercent < 0 || widthPercent > 100 {
+				return parsed, derrors.Newf(
+					derrors.CodeInvalidInput,
+					"invalid width-percent: %q (0-100)",
+					args[argIndex+1],
+				)
+			}
+
+			parsed.widthPct = widthPercent
+			argIndex++
+		case "--height-percent":
+			if argIndex+1 >= len(args) {
+				return parsed, derrors.New(
+					derrors.CodeInvalidInput,
+					"--height-percent requires a value",
+				)
+			}
+
+			heightPercent, err := strconv.ParseFloat(args[argIndex+1], 64)
+			if err != nil || heightPercent < 0 || heightPercent > 100 {
+				return parsed, derrors.Newf(
+					derrors.CodeInvalidInput,
+					"invalid height-percent: %q (0-100)",
+					args[argIndex+1],
+				)
+			}
+
+			parsed.heightPct = heightPercent
+			argIndex++
+		case "--x":
+			if argIndex+1 >= len(args) {
+				return parsed, derrors.New(derrors.CodeInvalidInput, "--x requires a value")
+			}
+
+			xCoord, err := strconv.Atoi(args[argIndex+1])
+			if err != nil {
+				return parsed, derrors.Newf(
+					derrors.CodeInvalidInput,
+					"invalid x: %q",
+					args[argIndex+1],
+				)
+			}
+
+			parsed.x = xCoord
+			parsed.hasX = true
+			argIndex++
+		case "--y":
+			if argIndex+1 >= len(args) {
+				return parsed, derrors.New(derrors.CodeInvalidInput, "--y requires a value")
+			}
+
+			yCoord, err := strconv.Atoi(args[argIndex+1])
+			if err != nil {
+				return parsed, derrors.Newf(
+					derrors.CodeInvalidInput,
+					"invalid y: %q",
+					args[argIndex+1],
+				)
+			}
+
+			parsed.y = yCoord
+			parsed.hasY = true
+			argIndex++
+		case "--anchor", "-a":
+			if argIndex+1 >= len(args) {
+				return parsed, derrors.New(derrors.CodeInvalidInput, "--anchor requires a value")
+			}
+
+			anchorVal := args[argIndex+1]
+			if !validAnchors[anchorVal] {
+				return parsed, derrors.Newf(
+					derrors.CodeInvalidInput,
+					"invalid anchor: %q (use tl, tc, tr, cl, cc, cr, bl, bc, br)",
+					anchorVal,
+				)
+			}
+
+			parsed.anchor = anchorVal
+			argIndex++
+		case "--margin":
+			val := true
+			parsed.useMargin = &val
+		case "--no-margin":
+			val := false
+			parsed.useMargin = &val
+		default:
+			if strings.HasPrefix(arg, "--") {
+				return parsed, derrors.Newf(derrors.CodeInvalidInput, "unknown flag: %s", arg)
+			}
+
+			return parsed, derrors.Newf(derrors.CodeInvalidInput, "unexpected argument: %s", arg)
+		}
+	}
+
+	// If preset given, apply its values as defaults (can be overridden by explicit flags)
+	if parsed.preset != "" {
+		preset, ok := resizePresets[parsed.preset]
+		if ok {
+			parsed.anchor = preset.anchor
+			if parsed.widthPct == 0 && parsed.width == 0 {
+				parsed.widthPct = preset.widthPct
+			}
+
+			if parsed.heightPct == 0 && parsed.height == 0 {
+				parsed.heightPct = preset.heightPct
+			}
+		}
+	}
+
+	return parsed, nil
+}
+
 // Execute runs a named action with the given arguments.
 func Execute(name string, args []string) error {
 	switch Name(name) {
@@ -141,10 +360,17 @@ func Execute(name string, args []string) error {
 		}
 
 		return MoveWindowToSpace(index)
+	case NameResizeWindow:
+		parsed, err := parseResizeWindowArgs(args)
+		if err != nil {
+			return err
+		}
+
+		return ResizeWindow(parsed)
 	default:
 		return derrors.Newf(
 			derrors.CodeInvalidInput,
-			"unknown action %q (supported: focus_window, space, move_window_to_space)",
+			"unknown action %q (supported: focus_window, space, move_window_to_space, resize_window)",
 			name,
 		)
 	}

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -18,6 +18,7 @@ func TestIsKnownName(t *testing.T) {
 		{name: "focus_window", input: "focus_window", want: true},
 		{name: "space", input: "space", want: true},
 		{name: "move_window_to_space", input: "move_window_to_space", want: true},
+		{name: "resize_window", input: "resize_window", want: true},
 		{name: "unknown", input: "left_click", want: false},
 	}
 
@@ -130,6 +131,146 @@ func TestExecute_MoveWindowToSpaceNextPrev(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestIsResizePreset(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "left-half", input: "left-half", want: true},
+		{name: "right-half", input: "right-half", want: true},
+		{name: "top-half", input: "top-half", want: true},
+		{name: "bottom-half", input: "bottom-half", want: true},
+		{name: "top-left", input: "top-left", want: true},
+		{name: "top-right", input: "top-right", want: true},
+		{name: "bottom-left", input: "bottom-left", want: true},
+		{name: "bottom-right", input: "bottom-right", want: true},
+		{name: "center", input: "center", want: true},
+		{name: "fill", input: "fill", want: true},
+		{name: "unknown", input: "left-third", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := action.IsResizePreset(tc.input); got != tc.want {
+				t.Fatalf("IsResizePreset(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecute_ResizeWindowPresets(t *testing.T) {
+	t.Parallel()
+
+	presets := []string{
+		"left-half", "right-half", "top-half", "bottom-half",
+		"top-left", "top-right", "bottom-left", "bottom-right",
+		"center", "fill",
+	}
+
+	for _, preset := range presets {
+		t.Run(preset, func(t *testing.T) {
+			t.Parallel()
+
+			err := action.Execute("resize_window", []string{preset})
+
+			if derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Fatalf(
+					"Execute(resize_window %q) got unexpected CodeInvalidInput: %v",
+					preset,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestExecute_ResizeWindowInvalidAnchor(t *testing.T) {
+	t.Parallel()
+
+	err := action.Execute("resize_window", []string{"--anchor", "xx"})
+	if err == nil {
+		t.Fatal("Execute(resize_window --anchor xx) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+func TestExecute_ResizeWindowInvalidWidth(t *testing.T) {
+	t.Parallel()
+
+	err := action.Execute("resize_window", []string{"--width", "-100"})
+	if err == nil {
+		t.Fatal("Execute(resize_window --width -100) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+func TestExecute_ResizeWindowInvalidWidthPercent(t *testing.T) {
+	t.Parallel()
+
+	err := action.Execute("resize_window", []string{"--width-percent", "150"})
+	if err == nil {
+		t.Fatal("Execute(resize_window --width-percent 150) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+func TestExecute_ResizeWindowWithFlags(t *testing.T) {
+	t.Parallel()
+
+	// This should parse correctly (no CodeInvalidInput) even though execution
+	// will fail because there's no window open in the test environment.
+	err := action.Execute("resize_window", []string{
+		"--width", "800",
+		"--height", "600",
+		"--anchor", "cc",
+	})
+
+	if derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("Execute with valid flags got unexpected CodeInvalidInput: %v", err)
+	}
+}
+
+func TestExecute_ResizeWindowPresetWithOverride(t *testing.T) {
+	t.Parallel()
+
+	err := action.Execute("resize_window", []string{
+		"left-half",
+		"--width", "500",
+	})
+
+	if derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("Execute with preset and override got unexpected CodeInvalidInput: %v", err)
+	}
+}
+
+func TestExecute_ResizeWindowMarginFlags(t *testing.T) {
+	t.Parallel()
+
+	err := action.Execute("resize_window", []string{"left-half", "--margin"})
+	if derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("Execute with --margin got unexpected CodeInvalidInput: %v", err)
+	}
+
+	err = action.Execute("resize_window", []string{"left-half", "--no-margin"})
+	if derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("Execute with --no-margin got unexpected CodeInvalidInput: %v", err)
 	}
 }
 

--- a/internal/action/perform.go
+++ b/internal/action/perform.go
@@ -7,6 +7,12 @@ import (
 	"github.com/y3owk1n/mimi/internal/window"
 )
 
+const (
+	percentage100  = 100.0
+	divisionFactor = 2.0
+	marginDivisor  = 2
+)
+
 func ensureAccessibility() error {
 	return permissions.FriendlyError(permissions.Check())
 }
@@ -110,4 +116,134 @@ func MoveWindowToSpace(index int) error {
 	}
 
 	return nil
+}
+
+// ResizeWindow resizes and repositions the frontmost window according to the given args.
+func ResizeWindow(args parsedResizeWindowArgs) error {
+	err := ensureAccessibility()
+	if err != nil {
+		return err
+	}
+
+	win := window.Frontmost()
+	if win == nil {
+		return derrors.New(derrors.CodeActionFailed, "no active window found")
+	}
+	defer win.Release()
+
+	curX, curY, curW, curH, err := win.GetFrame()
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get window frame")
+	}
+
+	// Get screen frames to get the screen height for coordinate conversion
+	//nolint:dogsled // We need screenH but not the other frame values from full screen frame
+	_, _, _, screenH, err := window.ScreenFrame(curX, curY)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get screen frame")
+	}
+
+	screenX, screenY, screenWidth, screenHeight, err := window.ScreenVisibleFrame(curX, curY)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get screen frame")
+	}
+
+	// AX uses y-down (top-left origin). NSScreen uses y-up (bottom-left origin).
+	// Convert visible frame from y-up to y-down:
+	//   y-down top-left = (screenX, screenH - screenY - screenHeight), same w,h
+	syd := screenH - screenY - screenHeight
+
+	// Determine if margins should be applied
+	useMargins := window.TiledWindowMarginsEnabled()
+	if args.useMargin != nil {
+		useMargins = *args.useMargin
+	}
+
+	// Compute target dimensions from screen visible frame (in y-down)
+	newW := curW
+	switch {
+	case args.width > 0:
+		newW = float64(args.width)
+	case args.widthPct > 0:
+		newW = screenWidth * args.widthPct / percentage100
+	}
+
+	newH := curH
+	switch {
+	case args.height > 0:
+		newH = float64(args.height)
+	case args.heightPct > 0:
+		newH = screenHeight * args.heightPct / percentage100
+	}
+
+	// Compute target position from anchor (relative to visible frame in y-down)
+	vert := args.anchor[0]  // 't', 'c', 'b'
+	horiz := args.anchor[1] // 'l', 'c', 'r'
+
+	var targetX, targetY float64
+
+	if args.hasX {
+		targetX = float64(args.x)
+	} else {
+		switch horiz {
+		case 'l':
+			targetX = screenX
+		case 'c':
+			targetX = screenX + (screenWidth-newW)/divisionFactor
+		case 'r':
+			targetX = screenX + screenWidth - newW
+		}
+	}
+
+	if args.hasY {
+		targetY = float64(args.y)
+	} else {
+		switch vert {
+		case 't':
+			targetY = syd
+		case 'c':
+			targetY = syd + (screenHeight-newH)/divisionFactor
+		case 'b':
+			targetY = syd + screenHeight - newH
+		}
+	}
+
+	// Apply margins: full margin on edges that abut the visible frame boundary,
+	// half margin on internal edges (split between windows). This matches macOS
+	// behavior where the gap between two tiled windows is margin (not 2*margin).
+	if useMargins {
+		marginSize := window.TiledWindowMarginSize()
+
+		leftExt := targetX == screenX
+		rightExt := targetX+newW == screenX+screenWidth
+		topExt := targetY == syd
+		botExt := targetY+newH == syd+screenHeight
+
+		leftMargin := marginSize
+		if !leftExt {
+			leftMargin = marginSize / marginDivisor
+		}
+
+		rightMargin := marginSize
+		if !rightExt {
+			rightMargin = marginSize / marginDivisor
+		}
+
+		topMargin := marginSize
+		if !topExt {
+			topMargin = marginSize / marginDivisor
+		}
+
+		bottomMargin := marginSize
+		if !botExt {
+			bottomMargin = marginSize / marginDivisor
+		}
+
+		targetX += leftMargin
+		newW -= leftMargin + rightMargin
+		targetY += topMargin
+		newH -= topMargin + bottomMargin
+	}
+
+	return win.SetFrame(targetX, targetY, newW, newH)
 }

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -20,6 +20,18 @@ int MimiActivateWindow(void *window);
 #pragma mark - Screen Functions
 
 bool MimiIsMissionControlActive(void);
+double *MimiGetScreenFrameForPoint(double x, double y);
+double *MimiGetScreenVisibleFrameForPoint(double x, double y);
+
+#pragma mark - Window Frame Functions
+
+double *MimiGetWindowFrame(void *window);
+int MimiSetWindowFrame(void *window, double x, double y, double w, double h);
+
+#pragma mark - Tiling Margins
+
+bool MimiTiledWindowMarginsEnabled(void);
+double MimiTiledWindowMarginSize(void);
 
 #pragma mark - Space Functions
 

--- a/internal/native/screen.m
+++ b/internal/native/screen.m
@@ -65,3 +65,100 @@ static bool detectMissionControlActive(void) {
 }
 
 bool MimiIsMissionControlActive(void) { return detectMissionControlActive(); }
+
+double *MimiGetScreenFrameForPoint(double x, double y) {
+	@autoreleasepool {
+		NSScreen *targetScreen = nil;
+		CGPoint pt = CGPointMake(x, y);
+
+		for (NSScreen *screen in [NSScreen screens]) {
+			if (NSPointInRect(pt, [screen frame])) {
+				targetScreen = screen;
+				break;
+			}
+		}
+
+		if (!targetScreen) {
+			targetScreen = [NSScreen mainScreen];
+		}
+
+		NSRect frame = [targetScreen frame];
+		double *result = (double *)malloc(4 * sizeof(double));
+		if (!result)
+			return NULL;
+
+		result[0] = frame.origin.x;
+		result[1] = frame.origin.y;
+		result[2] = frame.size.width;
+		result[3] = frame.size.height;
+
+		return result;
+	}
+}
+
+double *MimiGetScreenVisibleFrameForPoint(double x, double y) {
+	@autoreleasepool {
+		NSScreen *targetScreen = nil;
+		CGPoint pt = CGPointMake(x, y);
+
+		for (NSScreen *screen in [NSScreen screens]) {
+			if (NSPointInRect(pt, [screen frame])) {
+				targetScreen = screen;
+				break;
+			}
+		}
+
+		if (!targetScreen) {
+			targetScreen = [NSScreen mainScreen];
+		}
+
+		NSRect frame = [targetScreen visibleFrame];
+		double *result = (double *)malloc(4 * sizeof(double));
+		if (!result)
+			return NULL;
+
+		result[0] = frame.origin.x;
+		result[1] = frame.origin.y;
+		result[2] = frame.size.width;
+		result[3] = frame.size.height;
+
+		return result;
+	}
+}
+
+bool MimiTiledWindowMarginsEnabled(void) {
+	@autoreleasepool {
+		// CFPreferences is the most reliable way to read other app's preferences
+		Boolean keyExists = false;
+		Boolean enabled = CFPreferencesGetAppBooleanValue(
+		    CFSTR("EnableTiledWindowMargins"), CFSTR("com.apple.WindowManager"), &keyExists);
+
+		if (keyExists) {
+			return (bool)enabled;
+		}
+
+		// Key does not exist — default to enabled (macOS 14+ behavior)
+		return true;
+	}
+}
+
+double MimiTiledWindowMarginSize(void) {
+	@autoreleasepool {
+		// macOS Sequoia (15+) added a configurable TiledWindowSpacing key.
+		CFPropertyListRef val =
+		    CFPreferencesCopyAppValue(CFSTR("TiledWindowSpacing"), CFSTR("com.apple.WindowManager"));
+		if (val) {
+			if (CFGetTypeID(val) == CFNumberGetTypeID()) {
+				double spacing = 0;
+				if (CFNumberGetValue((CFNumberRef)val, kCFNumberDoubleType, &spacing) && spacing > 0) {
+					CFRelease(val);
+					return spacing;
+				}
+			}
+			CFRelease(val);
+		}
+
+		// Default margin: 8px (macOS standard on both Sonoma and Sequoia)
+		return 8.0;
+	}
+}

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -324,6 +324,83 @@ void **MimiGetAllFocusableWindowsOnActiveSpace(int *count) {
 	}
 }
 
+double *MimiGetWindowFrame(void *window) {
+	if (!window)
+		return NULL;
+
+	@autoreleasepool {
+		AXUIElementRef axWindow = (AXUIElementRef)window;
+
+		double *result = (double *)malloc(4 * sizeof(double));
+		if (!result)
+			return NULL;
+
+		result[0] = 0;
+		result[1] = 0;
+		result[2] = 0;
+		result[3] = 0;
+
+		CFTypeRef positionValue = NULL;
+		AXError posError = AXUIElementCopyAttributeValue(axWindow, kAXPositionAttribute, &positionValue);
+		if (posError == kAXErrorSuccess && positionValue) {
+			CGPoint point;
+			if (AXValueGetValue((AXValueRef)positionValue, kAXValueCGPointType, &point)) {
+				result[0] = point.x;
+				result[1] = point.y;
+			}
+			CFRelease(positionValue);
+		}
+
+		CFTypeRef sizeValue = NULL;
+		AXError sizeError = AXUIElementCopyAttributeValue(axWindow, kAXSizeAttribute, &sizeValue);
+		if (sizeError == kAXErrorSuccess && sizeValue) {
+			CGSize size;
+			if (AXValueGetValue((AXValueRef)sizeValue, kAXValueCGSizeType, &size)) {
+				result[2] = size.width;
+				result[3] = size.height;
+			}
+			CFRelease(sizeValue);
+		}
+
+		return result;
+	}
+}
+
+int MimiSetWindowFrame(void *window, double x, double y, double w, double h) {
+	if (!window)
+		return 0;
+
+	@autoreleasepool {
+		AXUIElementRef axWindow = (AXUIElementRef)window;
+
+		// Set position first to avoid size changes shifting the window
+		CGPoint point = CGPointMake((CGFloat)x, (CGFloat)y);
+		AXValueRef positionValue = AXValueCreate(kAXValueCGPointType, &point);
+		if (!positionValue)
+			return 0;
+
+		AXError posError = AXUIElementSetAttributeValue(axWindow, kAXPositionAttribute, positionValue);
+
+		// Then set size
+		CGSize size = CGSizeMake((CGFloat)w, (CGFloat)h);
+		AXValueRef sizeValue = AXValueCreate(kAXValueCGSizeType, &size);
+		if (!sizeValue) {
+			CFRelease(positionValue);
+			return 0;
+		}
+
+		AXError sizeError = AXUIElementSetAttributeValue(axWindow, kAXSizeAttribute, sizeValue);
+
+		// Re-set position to correct any shifts caused by resize
+		AXUIElementSetAttributeValue(axWindow, kAXPositionAttribute, positionValue);
+
+		CFRelease(sizeValue);
+		CFRelease(positionValue);
+
+		return (posError == kAXErrorSuccess && sizeError == kAXErrorSuccess) ? 1 : 0;
+	}
+}
+
 int MimiActivateWindow(void *window) {
 	if (!window)
 		return 0;

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -111,6 +111,125 @@ func (e *Element) Equal(other *Element) bool {
 	return result == 1
 }
 
+// GetFrame returns the window's position and size [x, y, w, h] in screen coordinates.
+func (e *Element) GetFrame() (float64, float64, float64, float64, error) {
+	if e.ref == nil {
+		return 0, 0, 0, 0, derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"cannot get window frame: element reference is nil",
+		)
+	}
+
+	frame := C.MimiGetWindowFrame(e.ref) //nolint:nlreturn
+	if frame == nil {
+		return 0, 0, 0, 0, derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"failed to get window frame",
+		)
+	}
+
+	defer C.free(unsafe.Pointer(frame)) //nolint:nlreturn
+
+	frameArr := (*[4]C.double)(unsafe.Pointer(frame))
+
+	return float64(
+			frameArr[0],
+		), float64(
+			frameArr[1],
+		), float64(
+			frameArr[2],
+		), float64(
+			frameArr[3],
+		), nil
+}
+
+// SetFrame sets the window's position (x, y) and size (w, h) in screen coordinates.
+func (e *Element) SetFrame(posX, posY, width, height float64) error {
+	if e.ref == nil {
+		return derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"cannot set window frame: element reference is nil",
+		)
+	}
+
+	result := C.MimiSetWindowFrame(
+		e.ref,
+		C.double(posX),
+		C.double(posY),
+		C.double(width),
+		C.double(height), //nolint:nlreturn
+	)
+	if result == 0 {
+		return derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"failed to set window frame",
+		)
+	}
+
+	return nil
+}
+
+// ScreenFrame returns the full frame [x, y, w, h] of the screen containing (x, y).
+func ScreenFrame(xCoord, yCoord float64) (float64, float64, float64, float64, error) {
+	frame := C.MimiGetScreenFrameForPoint(C.double(xCoord), C.double(yCoord))
+	if frame == nil {
+		return 0, 0, 0, 0, derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"failed to get screen frame",
+		)
+	}
+
+	defer C.free(unsafe.Pointer(frame)) //nolint:nlreturn
+
+	frameArr := (*[4]C.double)(unsafe.Pointer(frame))
+
+	return float64(
+			frameArr[0],
+		), float64(
+			frameArr[1],
+		), float64(
+			frameArr[2],
+		), float64(
+			frameArr[3],
+		), nil
+}
+
+// ScreenVisibleFrame returns the visible frame [x, y, w, h] of the screen containing (x, y),
+// excluding the dock and menu bar.
+func ScreenVisibleFrame(xCoord, yCoord float64) (float64, float64, float64, float64, error) {
+	frame := C.MimiGetScreenVisibleFrameForPoint(C.double(xCoord), C.double(yCoord))
+	if frame == nil {
+		return 0, 0, 0, 0, derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"failed to get screen visible frame",
+		)
+	}
+
+	defer C.free(unsafe.Pointer(frame)) //nolint:nlreturn
+
+	frameArr := (*[4]C.double)(unsafe.Pointer(frame))
+
+	return float64(
+			frameArr[0],
+		), float64(
+			frameArr[1],
+		), float64(
+			frameArr[2],
+		), float64(
+			frameArr[3],
+		), nil
+}
+
+// TiledWindowMarginsEnabled reports whether the system tiled window margins setting is enabled.
+func TiledWindowMarginsEnabled() bool {
+	return bool(C.MimiTiledWindowMarginsEnabled())
+}
+
+// TiledWindowMarginSize returns the tiled window margin size in points.
+func TiledWindowMarginSize() float64 {
+	return float64(C.MimiTiledWindowMarginSize())
+}
+
 // MissionControlActive reports whether Mission Control is currently open.
 func MissionControlActive() bool {
 	return bool(C.MimiIsMissionControlActive())


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds a new `action resize_window` to our action cli, that provides extreme flexibility to tile the available window.

E.g:

```bash
# Presets
mimi action resize_window left-half
mimi action resize_window right-half
mimi action resize_window top-left
mimi action resize_window center

# Fixed dimensions, centered
mimi action resize_window --width 800 --height 600 --anchor cc

# Percentage of screen, top-left
mimi action resize_window --width-percent 50 --height-percent 75 --anchor tl

# Absolute position, top-left anchor
mimi action resize_window --width 1024 --height 768 --x 100 --y 50 --anchor tl

# Override margins for a preset
mimi action resize_window left-half --no-margin

# Mix preset with custom size
mimi action resize_window center --width-percent 80 --height-percent 90
```

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
