### PR TITLE
fix: proper `resize_window` coordinate conversion

### DIFF
--- a/internal/action/perform.go
+++ b/internal/action/perform.go
@@ -136,22 +136,24 @@ func ResizeWindow(args parsedResizeWindowArgs) error {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get window frame")
 	}
 
-	// Get screen frames to get the screen height for coordinate conversion
-	//nolint:dogsled // We need screenH but not the other frame values from full screen frame
-	_, _, _, screenH, err := window.ScreenFrame(curX, curY)
-	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get screen frame")
-	}
-
+	// Get the visible frame of the screen containing the window (in NSScreen y-up coords)
 	screenX, screenY, screenWidth, screenHeight, err := window.ScreenVisibleFrame(curX, curY)
 	if err != nil {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get screen frame")
 	}
 
-	// AX uses y-down (top-left origin). NSScreen uses y-up (bottom-left origin).
-	// Convert visible frame from y-up to y-down:
-	//   y-down top-left = (screenX, screenH - screenY - screenHeight), same w,h
-	syd := screenH - screenY - screenHeight
+	// Get the primary screen height for AX ↔ NSScreen coordinate conversion.
+	// AX uses y-down (top-left origin at the primary screen's top). NSScreen uses
+	// y-up (bottom-left origin at the primary screen's bottom). The primary screen's
+	// height is the constant that relates the two systems.
+	primaryH, err := window.PrimaryScreenHeight()
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get primary screen height")
+	}
+
+	// Convert the visible frame's top edge from NSScreen y-up to AX y-down:
+	//   y-down top = primaryScreenHeight - visibleFrameY - visibleFrameHeight
+	syd := primaryH - screenY - screenHeight
 
 	// Determine if margins should be applied
 	useMargins := window.TiledWindowMarginsEnabled()

--- a/internal/native/screen.m
+++ b/internal/native/screen.m
@@ -68,9 +68,14 @@ bool MimiIsMissionControlActive(void) { return detectMissionControlActive(); }
 
 double *MimiGetScreenFrameForPoint(double x, double y) {
 	@autoreleasepool {
-		NSScreen *targetScreen = nil;
-		CGPoint pt = CGPointMake(x, y);
+		NSScreen *primary = [NSScreen mainScreen];
+		CGFloat primaryHeight = [primary frame].size.height;
 
+		// Input (x, y) is in AX coordinates (y-down, origin at top-left of primary).
+		// Convert to NSScreen coordinates (y-up, origin at bottom-left of primary).
+		CGPoint pt = CGPointMake(x, primaryHeight - y);
+
+		NSScreen *targetScreen = nil;
 		for (NSScreen *screen in [NSScreen screens]) {
 			if (NSPointInRect(pt, [screen frame])) {
 				targetScreen = screen;
@@ -79,7 +84,7 @@ double *MimiGetScreenFrameForPoint(double x, double y) {
 		}
 
 		if (!targetScreen) {
-			targetScreen = [NSScreen mainScreen];
+			targetScreen = primary;
 		}
 
 		NSRect frame = [targetScreen frame];
@@ -98,9 +103,14 @@ double *MimiGetScreenFrameForPoint(double x, double y) {
 
 double *MimiGetScreenVisibleFrameForPoint(double x, double y) {
 	@autoreleasepool {
-		NSScreen *targetScreen = nil;
-		CGPoint pt = CGPointMake(x, y);
+		NSScreen *primary = [NSScreen mainScreen];
+		CGFloat primaryHeight = [primary frame].size.height;
 
+		// Input (x, y) is in AX coordinates (y-down, origin at top-left of primary).
+		// Convert to NSScreen coordinates (y-up, origin at bottom-left of primary).
+		CGPoint pt = CGPointMake(x, primaryHeight - y);
+
+		NSScreen *targetScreen = nil;
 		for (NSScreen *screen in [NSScreen screens]) {
 			if (NSPointInRect(pt, [screen frame])) {
 				targetScreen = screen;
@@ -109,7 +119,7 @@ double *MimiGetScreenVisibleFrameForPoint(double x, double y) {
 		}
 
 		if (!targetScreen) {
-			targetScreen = [NSScreen mainScreen];
+			targetScreen = primary;
 		}
 
 		NSRect frame = [targetScreen visibleFrame];

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -169,6 +169,17 @@ func (e *Element) SetFrame(posX, posY, width, height float64) error {
 	return nil
 }
 
+// PrimaryScreenHeight returns the height of the primary display (the one with the menu bar).
+// This is needed to convert between AX (y-down) and NSScreen (y-up) coordinate systems.
+func PrimaryScreenHeight() (float64, error) {
+	_, _, _, h, err := ScreenFrame(0, 0) //nolint:dogsled
+	if err != nil {
+		return 0, err
+	}
+
+	return h, nil
+}
+
 // ScreenFrame returns the full frame [x, y, w, h] of the screen containing (x, y).
 func ScreenFrame(xCoord, yCoord float64) (float64, float64, float64, float64, error) {
 	frame := C.MimiGetScreenFrameForPoint(C.double(xCoord), C.double(yCoord))


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes `resize_window` positioning being offset on extended displays.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

Closes #38

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
