### PR TITLE
feat(action): add directional to `focus_window`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | Move frontmost window to a space | `mimi action move_window_to_space <n\|next\|prev>`                        |
 | Cycle focus between windows      | `mimi action focus_window`                                                |
 | Cycle focus backward             | `mimi action focus_window --backward`                                     |
+| Focus window to the left         | `mimi action focus_window --left`                                         |
+| Focus window to the right        | `mimi action focus_window --right`                                        |
+| Focus window above               | `mimi action focus_window --up`                                           |
+| Focus window below               | `mimi action focus_window --down`                                         |
 | Tile window to a preset          | `mimi action resize_window <left-half\|right-half\|center\|fill>`         |
 | Center at specific size          | `mimi action resize_window center --width-percent 80 --height-percent 90` |
 | Resize to exact pixels           | `mimi action resize_window --width 1024 --height 768`                     |

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -48,20 +48,46 @@ var (
 )
 
 func buildFocusWindowCommand() *cobra.Command {
-	var backward bool
+	var (
+		backward   bool
+		focusUp    bool
+		focusDown  bool
+		focusLeft  bool
+		focusRight bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "focus_window",
-		Short: "Cycle focus through windows on the active space",
-		Long: `Cycle keyboard focus through all focusable windows on the current space.
+		Short: "Cycle or navigate focus through windows on the active space",
+		Long: `Cycle keyboard focus through all focusable windows on the current space,
+or move focus spatially with direction flags.
 
-Cycles forward through windows (or backward with --backward), wrapping at the
-end. Only windows that are focusable (not minimized, not hidden) and on the
+Cycles forward (or backward with --backward), wrapping at the end. Use
+--up, --down, --left, or --right to move focus to the nearest window
+in that direction based on screen position.
+
+Only windows that are focusable (not minimized, not hidden) and on the
 current space are included.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			args := []string{}
 			if backward {
 				args = append(args, "--backward")
+			}
+
+			if focusUp {
+				args = append(args, "--up")
+			}
+
+			if focusDown {
+				args = append(args, "--down")
+			}
+
+			if focusLeft {
+				args = append(args, "--left")
+			}
+
+			if focusRight {
+				args = append(args, "--right")
 			}
 
 			return runAction(string(action.NameFocusWindow), args)
@@ -70,6 +96,14 @@ current space are included.`,
 
 	cmd.Flags().
 		BoolVar(&backward, "backward", false, "Cycle to the previous window instead of the next one")
+	cmd.Flags().
+		BoolVar(&focusUp, "up", false, "Move focus to the nearest window above")
+	cmd.Flags().
+		BoolVar(&focusDown, "down", false, "Move focus to the nearest window below")
+	cmd.Flags().
+		BoolVar(&focusLeft, "left", false, "Move focus to the nearest window on the left")
+	cmd.Flags().
+		BoolVar(&focusRight, "right", false, "Move focus to the nearest window on the right")
 
 	return cmd
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -31,6 +31,10 @@ These commands run directly in the CLI process when the daemon is not running. W
 ```bash
 mimi action focus_window
 mimi action focus_window --backward
+mimi action focus_window --left
+mimi action focus_window --right
+mimi action focus_window --up
+mimi action focus_window --down
 mimi action space 1
 mimi action space next
 mimi action space prev
@@ -44,11 +48,15 @@ mimi action resize_window --width 1024 --height 768 --anchor cc
 
 ### `mimi action focus_window`
 
-Cycle keyboard focus through all focusable windows on the current space.
+Cycle keyboard focus through all focusable windows on the current space, or move focus spatially with direction flags.
 
-| Flag         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| `--backward` | Cycle to the previous window instead of the next |
+| Flag         | Description                                                      |
+| ------------ | ---------------------------------------------------------------- |
+| `--backward` | Cycle to the previous window instead of the next                 |
+| `--up`       | Move focus to the nearest window above the current one           |
+| `--down`     | Move focus to the nearest window below the current one           |
+| `--left`     | Move focus to the nearest window to the left of the current one  |
+| `--right`    | Move focus to the nearest window to the right of the current one |
 
 ### `mimi action space <number|next|prev>`
 

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -31,6 +31,7 @@ func IsKnownName(name string) bool {
 
 type parsedFocusWindowArgs struct {
 	useBackward bool
+	direction   string // "up", "down", "left", "right", or ""
 }
 
 func parseFocusWindowArgs(rawArgs []string) (parsedFocusWindowArgs, error) {
@@ -40,6 +41,15 @@ func parseFocusWindowArgs(rawArgs []string) (parsedFocusWindowArgs, error) {
 		switch arg {
 		case "--backward":
 			parsed.useBackward = true
+		case "--up", "--down", "--left", "--right":
+			if parsed.direction != "" {
+				return parsed, derrors.New(
+					derrors.CodeInvalidInput,
+					"only one direction flag allowed (--up, --down, --left, --right)",
+				)
+			}
+
+			parsed.direction = arg[2:]
 		default:
 			if strings.HasPrefix(arg, "--") {
 				return parsed, derrors.New(
@@ -48,6 +58,13 @@ func parseFocusWindowArgs(rawArgs []string) (parsedFocusWindowArgs, error) {
 				)
 			}
 		}
+	}
+
+	if parsed.direction != "" && parsed.useBackward {
+		return parsed, derrors.New(
+			derrors.CodeInvalidInput,
+			"--backward cannot be combined with a direction flag",
+		)
 	}
 
 	return parsed, nil
@@ -335,7 +352,7 @@ func Execute(name string, args []string) error {
 			return err
 		}
 
-		return FocusWindow(parsed.useBackward)
+		return FocusWindow(parsed.useBackward, parsed.direction)
 	case NameSpace:
 		parsed, err := parseSpaceArg(args)
 		if err != nil {

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -286,3 +286,66 @@ func TestExecute_FocusWindowInvalidFlag(t *testing.T) {
 		t.Fatalf("expected CodeInvalidInput, got %v", err)
 	}
 }
+
+func TestExecute_FocusWindowDirectionFlags(t *testing.T) {
+	t.Parallel()
+
+	dirs := []string{"--up", "--down", "--left", "--right"}
+
+	for _, dir := range dirs {
+		t.Run(dir, func(t *testing.T) {
+			t.Parallel()
+
+			err := action.Execute("focus_window", []string{dir})
+
+			if derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Fatalf(
+					"Execute(focus_window %s) got unexpected CodeInvalidInput: %v",
+					dir,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestExecute_FocusWindowBackwardAndDirectionMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	dirs := []string{"--up", "--down", "--left", "--right"}
+
+	for _, dir := range dirs {
+		t.Run(dir, func(t *testing.T) {
+			t.Parallel()
+
+			err := action.Execute("focus_window", []string{"--backward", dir})
+			if err == nil {
+				t.Fatalf(
+					"Execute(focus_window --backward %s) expected error for mutually exclusive flags",
+					dir,
+				)
+			}
+
+			if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Fatalf(
+					"Execute(focus_window --backward %s) expected CodeInvalidInput, got %v",
+					dir,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestExecute_FocusWindowOnlyOneDirectionAllowed(t *testing.T) {
+	t.Parallel()
+
+	err := action.Execute("focus_window", []string{"--up", "--down"})
+	if err == nil {
+		t.Fatal("Execute(focus_window --up --down) expected error for multiple direction flags")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}

--- a/internal/action/perform.go
+++ b/internal/action/perform.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"math"
+
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/permissions"
 	"github.com/y3owk1n/mimi/internal/space"
@@ -18,7 +20,10 @@ func ensureAccessibility() error {
 }
 
 // FocusWindow cycles keyboard focus through focusable windows on the active space.
-func FocusWindow(backward bool) error {
+// When direction is set ("up", "down", "left", "right"), it moves focus spatially
+// to the nearest window in that direction. Otherwise it cycles forward or backward
+// through the sorted window list.
+func FocusWindow(backward bool, direction string) error {
 	err := ensureAccessibility()
 	if err != nil {
 		return err
@@ -53,6 +58,10 @@ func FocusWindow(backward bool) error {
 		frontmost.Release()
 	}
 
+	if direction != "" {
+		return focusDirectional(windows, currentIndex, direction)
+	}
+
 	var targetIndex int
 	if backward {
 		targetIndex = currentIndex - 1
@@ -72,6 +81,119 @@ func FocusWindow(backward bool) error {
 	}
 
 	return nil
+}
+
+type winInfo struct {
+	el                       *window.Element
+	cx, cy                   float64
+	left, top, right, bottom float64
+}
+
+func focusDirectional(windows []*window.Element, currentIndex int, direction string) error {
+	infos := make([]winInfo, 0, len(windows))
+	currentInfoIndex := -1
+
+	for idx, win := range windows {
+		posX, posY, winW, winH, err := win.GetFrame()
+		if err != nil {
+			continue
+		}
+
+		if idx == currentIndex {
+			currentInfoIndex = len(infos)
+		}
+
+		infos = append(infos, winInfo{
+			el:     win,
+			cx:     posX + winW/2,
+			cy:     posY + winH/2,
+			left:   posX,
+			top:    posY,
+			right:  posX + winW,
+			bottom: posY + winH,
+		})
+	}
+
+	if currentInfoIndex < 0 {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"current window not found; cannot determine spatial navigation target",
+		)
+	}
+
+	cur := infos[currentInfoIndex]
+
+	var best *winInfo
+
+	bestScore := math.MaxFloat64
+
+	for idx, cand := range infos {
+		if idx == currentInfoIndex {
+			continue
+		}
+
+		deltaX := cand.cx - cur.cx
+		deltaY := cand.cy - cur.cy
+
+		var (
+			priDist, secDist float64
+			overlap          bool
+		)
+
+		switch direction {
+		case "left":
+			if deltaX >= 0 {
+				continue
+			}
+
+			priDist = -deltaX
+			secDist = math.Abs(deltaY)
+			overlap = cur.top < cand.bottom && cur.bottom > cand.top
+		case "right":
+			if deltaX <= 0 {
+				continue
+			}
+
+			priDist = deltaX
+			secDist = math.Abs(deltaY)
+			overlap = cur.top < cand.bottom && cur.bottom > cand.top
+		case "up":
+			if deltaY >= 0 {
+				continue
+			}
+
+			priDist = -deltaY
+			secDist = math.Abs(deltaX)
+			overlap = cur.left < cand.right && cur.right > cand.left
+		case "down":
+			if deltaY <= 0 {
+				continue
+			}
+
+			priDist = deltaY
+			secDist = math.Abs(deltaX)
+			overlap = cur.left < cand.right && cur.right > cand.left
+		}
+
+		score := priDist
+		if !overlap {
+			score += secDist
+		}
+
+		if best == nil || score < bestScore {
+			best = &infos[idx]
+			bestScore = score
+		}
+	}
+
+	if best == nil {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"no window found in that direction",
+		)
+	}
+
+	return best.el.Activate()
 }
 
 // FocusSpace focuses the Mission Control space at the given 1-based index.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR adds spatial directional navigation to `action focus_window` with four new flags:

- `--left` / `--right` — move focus to the nearest window horizontally
- `--up` / `--down` — move focus to the nearest window vertically

The algorithm uses center-based direction filtering with an overlap preference: windows overlapping on the perpendicular axis score better than non-overlapping ones at the same distance. Falls back to cycling (--backward / default forward) when no direction flag is given.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
