### PR TITLE
fix(action,space): activate destination display after cross-display window move

### DIFF
--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -42,5 +42,7 @@ uint32_t MimiSpaceDisplayID(uint64_t sid);
 uint64_t MimiActiveSpaceID(void);
 int MimiFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid);
 int MimiMoveWindowToSpace(void *windowElement, uint64_t spaceID);
+uint32_t MimiCursorDisplayID(void);
+void MimiActivateDisplay(uint32_t did);
 
 #endif  // ACCESSIBILITY_H

--- a/internal/native/space.m
+++ b/internal/native/space.m
@@ -455,6 +455,16 @@ static void *mimi_macho_find_symbol(const char *target_image, const char *target
 	return NULL;
 }
 
+#pragma mark - Public Display Helpers
+
+/// Return the display ID that currently contains the cursor.
+uint32_t MimiCursorDisplayID(void) { return mimiCursorDisplayID(); }
+
+/// Activate a display by setting it as the active menu bar display.
+/// This keeps WindowServer's event routing state coherent when windows
+/// are moved across displays.
+void MimiActivateDisplay(uint32_t did) { mimiSetActiveMenuBarDisplay(did); }
+
 #pragma mark - Window-to-Space Movement
 
 // Private SkyLight API — undocumented, unsupported, may break on any

--- a/internal/space/space.go
+++ b/internal/space/space.go
@@ -121,5 +121,10 @@ func MoveWindow(index int) error {
 		return derrors.New(derrors.CodeActionFailed, "failed to move window to space")
 	}
 
+	targetDid := uint32(C.MimiSpaceDisplayID(C.uint64_t(sid)))
+	if targetDid != 0 && targetDid != uint32(C.MimiCursorDisplayID()) {
+		C.MimiActivateDisplay(C.uint32_t(targetDid))
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

This PR fixes an issue where after multiple cross-display window move, the window server is corrupted.

The fix is to checks after each move whether the destination space is on a different display from the cursor's display. If so, we have to keep WindowServer's event routing state coherent.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
