### PR TITLE
fix(action,space): add inter-swipe delays and more fixes

### DIFF
--- a/internal/native/space.m
+++ b/internal/native/space.m
@@ -338,15 +338,23 @@ int MimiFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid) {
 	if (count == 0) {
 		// Already on the correct local space on the target display. Make sure
 		// the menu bar is on the right display when crossing displays.
+		mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay);
+
 		if (focusDisplay) {
 			mimiSetActiveMenuBarDisplay(new_did);
 			if (mimiDisplaySpaceID(new_did) != new_sid) {
-				CGPostMouseEvent(point, false, 1, true);
-				CGPostMouseEvent(point, false, 1, false);
+				CGEventRef clickDown = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, point, 0);
+				if (clickDown) {
+					CGEventPost(kCGHIDEventTap, clickDown);
+					CFRelease(clickDown);
+				}
+				CGEventRef clickUp = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp, point, 0);
+				if (clickUp) {
+					CGEventPost(kCGHIDEventTap, clickUp);
+					CFRelease(clickUp);
+				}
 			}
 		}
-
-		mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay);
 
 		return 1;
 	}
@@ -369,19 +377,28 @@ int MimiFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid) {
 		CGEventPost(kCGSessionEventTap, event);
 		CGEventSetIntegerValueField(event, kMimiCGEventGesturePhase, kMimiCGSGesturePhaseEnded);
 		CGEventPost(kCGSessionEventTap, event);
+		mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay);
 	}
 
 	CFRelease(event);
 
+	mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay * (CFTimeInterval)count + kMimiSpaceGestureProcessingDelay);
+
 	if (focusDisplay) {
 		mimiSetActiveMenuBarDisplay(new_did);
 		if (mimiDisplaySpaceID(new_did) != new_sid) {
-			CGPostMouseEvent(point, false, 1, true);
-			CGPostMouseEvent(point, false, 1, false);
+			CGEventRef clickDown = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, point, 0);
+			if (clickDown) {
+				CGEventPost(kCGHIDEventTap, clickDown);
+				CFRelease(clickDown);
+			}
+			CGEventRef clickUp = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp, point, 0);
+			if (clickUp) {
+				CGEventPost(kCGHIDEventTap, clickUp);
+				CFRelease(clickUp);
+			}
 		}
 	}
-
-	mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay * (CFTimeInterval)count + kMimiSpaceGestureProcessingDelay);
 
 	return 1;
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

When switching spaces across monitors where one display has many spaces and the other has few (e.g. 9 on primary, 1 on extended), MimiFocusSpaceUsingGesture could cause a system-wide input freeze after 3-4 switches — cursor moves but clicks and keyboard input stop working entirely.

Fixes:

- Add mimiPumpRunLoop(30ms) after each swipe iteration so the Dock can process each gesture before the next arrives.
- Move the final run loop pump before the space-change check so gestures are processed before querying the resulting space.
- Replace CGPostMouseEvent with CGEventCreateMouseEvent + CGEventPost(kCGHIDEventTap, ...) in both fallback paths.
- Apply the same pump-before-check restructuring to the count==0 branch for consistency.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

N/A

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

<!-- For UI changes, add before/after screenshots or a short recording. Delete this section if not applicable. -->

N/A

## Additional Context

<!-- Anything else reviewers should know? Design decisions, trade-offs, alternative approaches considered? Delete this section if not applicable. -->

N/A
