### PR TITLE
test(action,window): record baseline window geometry in the integration tier

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -44,6 +44,7 @@ mimi/
 ├── cmd/
 │   └── mimi/           # Application entry points
 ├── internal/
+│   ├── baseline/       # Recorded macOS window behavior (test oracle)
 │   ├── config/         # Configuration management
 │   ├── daemon/         # Daemon lifecycle
 │   ├── errors/         # Structured error types

--- a/docs/testing/TESTING_PATTERNS.md
+++ b/docs/testing/TESTING_PATTERNS.md
@@ -82,6 +82,38 @@ func TestWorkspaceObserver(t *testing.T) {
 }
 ```
 
+### Recorded window baseline
+
+`internal/baseline` holds `window_baseline.json`: the frames macOS actually
+produces for every `resize_window` preset, anchor and margin state, and the
+window `focus_window` picks in each direction. The integration recorder in that
+package drives the real actions to produce it.
+
+Two properties matter when changing it:
+
+- **It only ever drives windows it opened itself.** The recorder launches its
+  own throwaway TextEdit instance and matches windows by process ID. Any step
+  that would otherwise reach a window it did not create skips instead.
+- **It skips, never fails, on a machine that cannot run it** — no Accessibility
+  permission (CI), a locked screen, or a display other than the one the
+  recording was captured on.
+
+The recorder must launch its helper application before the first window
+enumeration. `NSWorkspace` refreshes its running-application list from the run
+loop, which a test binary never spins, so an application launched after that
+list is first read stays invisible to the action layer for the rest of the
+process.
+
+Re-record after changing a case, or to capture the baseline on your own display:
+
+```bash
+MIMI_RECORD_BASELINE=1 go test -tags=integration -run TestWindowBaseline_ResizeAndFocus ./internal/baseline
+```
+
+Unit tests consume the same recording through `baseline.Load`, so a pure
+reimplementation of the geometry can be checked against observed behavior rather
+than against a reading of the old code.
+
 ## Test Commands
 
 - `just test-unit` — Runs unit tests

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -1,0 +1,136 @@
+package baseline
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// FileName is the name of the recording file inside this package's directory.
+// The integration recorder writes it; Load reads the copy embedded at build time.
+const FileName = "window_baseline.json"
+
+//go:embed window_baseline.json
+var recordingJSON []byte
+
+// Rect is a window or screen rectangle in points. Resize inputs and outputs use
+// the Accessibility coordinate system (y-down, origin at the primary display's
+// top-left); Display.Visible uses the NSScreen one (y-up). The field set matches
+// the geometry rectangle the action layer works in, so the two convert directly.
+type Rect struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+	W float64 `json:"w"`
+	H float64 `json:"h"`
+}
+
+// String renders the rectangle as "x,y wxh" for assertion messages.
+func (r Rect) String() string {
+	return fmt.Sprintf("%g,%g %gx%g", r.X, r.Y, r.W, r.H)
+}
+
+// Display is everything the action layer had to ask macOS about the screen when
+// the recording was made. A recording is only replayable against a display that
+// reports the same values, which is why the whole set is stored.
+type Display struct {
+	// Visible is the screen's visible frame in NSScreen y-up coordinates.
+	Visible Rect `json:"visible"`
+	// PrimaryHeight is the primary display's height, the constant relating the
+	// y-up and y-down coordinate systems.
+	PrimaryHeight float64 `json:"primaryHeight"`
+	// MarginsEnabled is the system tiled-window-margins setting.
+	MarginsEnabled bool `json:"marginsEnabled"`
+	// MarginSize is the system tiled-window margin, in points.
+	MarginSize float64 `json:"marginSize"`
+}
+
+// ResizeCase is one recorded resize_window invocation: the flags, the frame the
+// window started from, and the frame macOS ended up with.
+//
+// Args holds the command line as a user would type it, which is what the
+// recorder ran. A test of the geometry alone has to put those flags through the
+// action layer's argument parsing first — the recording deliberately does not
+// store a parsed form, because the shape of that form is not settled.
+type ResizeCase struct {
+	Name  string   `json:"name"`
+	Args  []string `json:"args"`
+	Start Rect     `json:"start"`
+	Want  Rect     `json:"want"`
+}
+
+// FocusCase is one recorded focus_window invocation. Arrangement holds the
+// frames of the recorder's own windows in the order the action layer enumerates
+// them; Current and Want are indices into it.
+//
+// The live run scored these against every window on the space, not just these.
+// The recorder only runs a case once it has established that no other window
+// can score better than its own, so dropping them cannot change which window
+// wins, and replaying Arrangement on its own reproduces Want.
+type FocusCase struct {
+	Direction   string `json:"direction"`
+	Arrangement []Rect `json:"arrangement"`
+	Current     int    `json:"current"`
+	Want        int    `json:"want"`
+}
+
+// Recording is the whole baseline: the display it was captured on, plus every
+// recorded case.
+type Recording struct {
+	Display Display      `json:"display"`
+	Resize  []ResizeCase `json:"resize"`
+	Focus   []FocusCase  `json:"focus"`
+}
+
+// ResizeCase returns the recorded resize case with the given name.
+func (r Recording) ResizeCase(name string) (ResizeCase, bool) {
+	for _, rec := range r.Resize {
+		if rec.Name == name {
+			return rec, true
+		}
+	}
+
+	return ResizeCase{}, false
+}
+
+// FocusCase returns the recorded focus case for the given direction.
+func (r Recording) FocusCase(direction string) (FocusCase, bool) {
+	for _, rec := range r.Focus {
+		if rec.Direction == direction {
+			return rec, true
+		}
+	}
+
+	return FocusCase{}, false
+}
+
+// Load returns the recording embedded at build time.
+func Load() (Recording, error) {
+	var rec Recording
+
+	err := json.Unmarshal(recordingJSON, &rec)
+	if err != nil {
+		return Recording{}, derrors.Wrapf(
+			err,
+			derrors.CodeSerializationFailed,
+			"failed to decode the embedded window baseline",
+		)
+	}
+
+	return rec, nil
+}
+
+// Encode renders a recording as the indented JSON the recording file stores.
+func Encode(rec Recording) ([]byte, error) {
+	data, err := json.MarshalIndent(rec, "", "\t")
+	if err != nil {
+		return nil, derrors.Wrapf(
+			err,
+			derrors.CodeSerializationFailed,
+			"failed to encode the window baseline",
+		)
+	}
+
+	return append(data, '\n'), nil
+}

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -1,0 +1,141 @@
+package baseline_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/baseline"
+)
+
+// The counts the recorder covers: ten presets in two margin states plus one
+// system-default case, nine anchors in two margin states, ten explicit-flag
+// combinations, and four focus directions.
+const (
+	wantResizeCases = 10*2 + 1 + 9*2 + 10
+	wantFocusCases  = 4
+)
+
+func TestLoad_ReturnsRecordedCases(t *testing.T) {
+	recording, err := baseline.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(recording.Resize) != wantResizeCases {
+		t.Errorf("Load() returned %d resize cases, want %d", len(recording.Resize), wantResizeCases)
+	}
+
+	if len(recording.Focus) != wantFocusCases {
+		t.Errorf("Load() returned %d focus cases, want %d", len(recording.Focus), wantFocusCases)
+	}
+
+	if recording.Display.Visible.W <= 0 || recording.Display.Visible.H <= 0 {
+		t.Errorf("Load() returned an empty visible frame %s", recording.Display.Visible)
+	}
+}
+
+func TestLoad_CasesAreUsableAsFixtures(t *testing.T) {
+	recording, err := baseline.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	seen := map[string]bool{}
+
+	for _, resize := range recording.Resize {
+		if resize.Name == "" {
+			t.Error("a resize case has no name")
+		}
+
+		if seen[resize.Name] {
+			t.Errorf("resize case %q is recorded twice", resize.Name)
+		}
+
+		seen[resize.Name] = true
+
+		if len(resize.Args) == 0 {
+			t.Errorf("resize case %q has no args", resize.Name)
+		}
+
+		if resize.Want.W <= 0 || resize.Want.H <= 0 {
+			t.Errorf("resize case %q recorded an empty frame %s", resize.Name, resize.Want)
+		}
+	}
+
+	for _, focus := range recording.Focus {
+		if len(focus.Arrangement) == 0 {
+			t.Errorf("focus case %q recorded no arrangement", focus.Direction)
+		}
+
+		if focus.Current < 0 || focus.Current >= len(focus.Arrangement) {
+			t.Errorf(
+				"focus case %q has current index %d out of range",
+				focus.Direction,
+				focus.Current,
+			)
+		}
+
+		if focus.Want < 0 || focus.Want >= len(focus.Arrangement) {
+			t.Errorf("focus case %q has target index %d out of range", focus.Direction, focus.Want)
+		}
+
+		if focus.Want == focus.Current {
+			t.Errorf("focus case %q did not move focus", focus.Direction)
+		}
+	}
+}
+
+func TestRecording_LookupsFindRecordedCases(t *testing.T) {
+	recording, err := baseline.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(recording.Resize) == 0 || len(recording.Focus) == 0 {
+		t.Fatal("the recording holds no cases to look up")
+	}
+
+	first := recording.Resize[0]
+
+	gotResize, found := recording.ResizeCase(first.Name)
+	if !found || gotResize.Name != first.Name {
+		t.Errorf("ResizeCase(%q) = %v, %v; want the recorded case", first.Name, gotResize, found)
+	}
+
+	_, found = recording.ResizeCase("no-such-case")
+	if found {
+		t.Error("ResizeCase() found a case that was never recorded")
+	}
+
+	firstFocus := recording.Focus[0]
+
+	gotFocus, found := recording.FocusCase(firstFocus.Direction)
+	if !found || gotFocus.Direction != firstFocus.Direction {
+		t.Errorf(
+			"FocusCase(%q) = %v, %v; want the recorded case",
+			firstFocus.Direction,
+			gotFocus,
+			found,
+		)
+	}
+
+	_, found = recording.FocusCase("no-such-direction")
+	if found {
+		t.Error("FocusCase() found a case that was never recorded")
+	}
+}
+
+func TestEncode_RoundTripsThroughJSON(t *testing.T) {
+	recording, err := baseline.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	data, err := baseline.Encode(recording)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Error("Encode() did not end the recording with a newline")
+	}
+}

--- a/internal/baseline/doc.go
+++ b/internal/baseline/doc.go
@@ -1,0 +1,2 @@
+// Package baseline holds recorded macOS window behavior used as a test oracle.
+package baseline

--- a/internal/baseline/focus_integration_test.go
+++ b/internal/baseline/focus_integration_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+package baseline_test
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/baseline"
+	"github.com/y3owk1n/mimi/internal/window"
+)
+
+// focusDirections is every direction focus_window navigates in.
+var focusDirections = []string{dirUp, dirDown, dirLeft, dirRight}
+
+// spaceSnapshot is one reading of the active space, split into the windows the
+// recorder created and the ones it did not.
+type spaceSnapshot struct {
+	// order holds indices into harness.windows in the order the action layer
+	// enumerates them.
+	order []int
+	// frames holds the frame of each window in order.
+	frames []baseline.Rect
+	// foreign holds the readable frames of every other window on the space.
+	foreign []baseline.Rect
+	// focused indexes order, or -1 when the focused window is not one of the
+	// recorder's own.
+	focused int
+}
+
+// runFocusCases arranges the recorder's own windows in a grid and drives
+// focus_window in each direction across it.
+func (h *harness) runFocusCases(
+	t *testing.T,
+	recorded baseline.Recording,
+	record bool,
+) []baseline.FocusCase {
+	t.Helper()
+
+	observed := make([]baseline.FocusCase, 0, len(focusDirections))
+
+	for _, dir := range focusDirections {
+		t.Run(dir, func(t *testing.T) {
+			got := h.runFocus(t, h.arrangeGrid(t, dir), dir)
+
+			if record {
+				observed = append(observed, got)
+
+				return
+			}
+
+			want, ok := recorded.FocusCase(got.Direction)
+			if !ok {
+				t.Fatalf("no recorded baseline for this direction; re-record with %s=1", recordEnv)
+			}
+
+			if !slices.Equal(want.Arrangement, got.Arrangement) {
+				t.Fatalf(
+					"the windows settled at %v but the baseline was recorded from %v; re-record with %s=1",
+					got.Arrangement,
+					want.Arrangement,
+					recordEnv,
+				)
+			}
+
+			if got.Current != want.Current {
+				t.Fatalf(
+					"navigation started from window %d but the baseline started from %d",
+					got.Current,
+					want.Current,
+				)
+			}
+
+			if got.Want != want.Want {
+				t.Errorf(
+					"focus_window --%s moved focus to window %d (%s), baseline says %d (%s)",
+					dir,
+					got.Want,
+					got.Arrangement[got.Want],
+					want.Want,
+					want.Arrangement[want.Want],
+				)
+			}
+		})
+	}
+
+	return observed
+}
+
+// runFocus drives one focus_window direction, skipping rather than running when
+// a window the recorder did not create could be the one that gets focused.
+func (h *harness) runFocus(t *testing.T, center *window.Element, dir string) baseline.FocusCase {
+	t.Helper()
+
+	bringToFront(t, center)
+
+	before := h.snapshotSpace(t)
+	if len(before.order) != windowCount {
+		t.Skipf(
+			"only %d of the recorder's %d windows are readable on the active space",
+			len(before.order),
+			windowCount,
+		)
+	}
+
+	if before.focused < 0 {
+		t.Skip(
+			"the focused window is not one the recorder created; refusing to navigate away from somebody else's window",
+		)
+	}
+
+	own, others := focusReach(dir, before.frames[before.focused], before.frames, before.foreign)
+	if own >= others {
+		t.Skipf(
+			"one of the %d windows the recorder did not create could be focused %s from here (its reach %.0f is inside the recorder's own %.0f); refusing to touch it",
+			len(before.foreign),
+			dir,
+			others,
+			own,
+		)
+	}
+
+	err := action.Execute(string(action.NameFocusWindow), []string{"--" + dir})
+	if err != nil {
+		t.Fatalf("focus_window --%s failed: %v", dir, err)
+	}
+
+	after := h.waitForFocusChange(t, before, dir)
+	if !slices.Equal(after.order, before.order) {
+		t.Fatalf("the window arrangement changed while focus_window --%s ran", dir)
+	}
+
+	if after.focused < 0 {
+		t.Fatalf("focus_window --%s left focus on a window the recorder did not create", dir)
+	}
+
+	return baseline.FocusCase{
+		Direction:   dir,
+		Arrangement: before.frames,
+		Current:     before.focused,
+		Want:        after.focused,
+	}
+}
+
+// arrangeGrid parks the recorder's own windows in a 3x3 grid oriented for the
+// given direction and returns the window in the middle, which the direction
+// navigates away from.
+func (h *harness) arrangeGrid(t *testing.T, dir string) *window.Element {
+	t.Helper()
+
+	stepX, stepY := gridSteps(dir)
+	positions := make([]baseline.Rect, 0, windowCount)
+
+	for row := range gridSide {
+		for col := range gridSide {
+			centerX := h.visible.X + gridOriginX + float64(col-1)*stepX
+			centerY := h.top + gridOriginY + float64(row-1)*stepY
+
+			positions = append(positions, baseline.Rect{
+				X: centerX - gridWidth/2,
+				Y: centerY - gridHeight/2,
+				W: gridWidth,
+				H: gridHeight,
+			})
+		}
+	}
+
+	// The middle cell of the grid.
+	const middleIndex = gridSide * gridSide / 2
+
+	if len(positions) != len(h.windows) {
+		t.Fatalf(
+			"the grid needs %d windows, the recorder opened %d",
+			len(positions),
+			len(h.windows),
+		)
+	}
+
+	for index, target := range h.windows {
+		placeWindow(t, target, positions[index])
+	}
+
+	return h.windows[middleIndex]
+}
+
+// gridSteps returns the step between neighboring window centers for a
+// direction: the tight step along the direction of travel, the wide step
+// across it.
+func gridSteps(dir string) (float64, float64) {
+	if dir == dirUp || dir == dirDown {
+		return gridWide, gridTight
+	}
+
+	return gridTight, gridWide
+}
+
+// waitForFocusChange reads the active space until focus has moved off the
+// window navigation started from. focus_window reports an error when it finds
+// no window in the requested direction, so a successful call always moves it.
+func (h *harness) waitForFocusChange(
+	t *testing.T,
+	before spaceSnapshot,
+	dir string,
+) spaceSnapshot {
+	t.Helper()
+
+	deadline := time.Now().Add(focusTimeout)
+
+	for {
+		after := h.snapshotSpace(t)
+		if after.focused != before.focused {
+			return after
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("focus_window --%s reported success but focus did not move", dir)
+		}
+
+		time.Sleep(settleInterval)
+	}
+}
+
+// snapshotSpace reads every focusable window on the active space, splitting the
+// recorder's own windows from the rest. Windows whose frame cannot be read are
+// dropped, exactly as the action layer drops them.
+func (h *harness) snapshotSpace(t *testing.T) spaceSnapshot {
+	t.Helper()
+
+	all, focusedIndex := enumerateFocused(t)
+	defer window.ReleaseAll(all)
+
+	snap := spaceSnapshot{focused: -1}
+
+	for index, element := range all {
+		posX, posY, width, height, err := element.GetFrame()
+		if err != nil {
+			continue
+		}
+
+		rect := baseline.Rect{X: posX, Y: posY, W: width, H: height}
+
+		owned := indexOfElement(h.windows, element)
+		if owned < 0 {
+			snap.foreign = append(snap.foreign, rect)
+
+			continue
+		}
+
+		if index == focusedIndex {
+			snap.focused = len(snap.order)
+		}
+
+		snap.order = append(snap.order, owned)
+		snap.frames = append(snap.frames, rect)
+	}
+
+	return snap
+}

--- a/internal/baseline/harness_integration_test.go
+++ b/internal/baseline/harness_integration_test.go
@@ -1,0 +1,220 @@
+//go:build integration
+
+package baseline_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/baseline"
+	"github.com/y3owk1n/mimi/internal/window"
+)
+
+// How long macOS is given to agree with what the recorder asked for.
+const (
+	focusTimeout   = 5 * time.Second
+	settleTimeout  = 3 * time.Second
+	pollInterval   = 250 * time.Millisecond
+	settleInterval = 60 * time.Millisecond
+)
+
+// harness owns the windows the recorder created and nothing else. Ownership is
+// decided by process ID: the helper runs as its own process, so every window it
+// owns is one the recorder opened and no window it does not own can be reached.
+type harness struct {
+	pids    map[int]bool
+	windows []*window.Element
+	visible baseline.Rect
+	top     float64
+}
+
+// newHarness waits for the helper's windows and registers their teardown. It
+// skips the test rather than falling back to pre-existing windows.
+func newHarness(t *testing.T, display baseline.Display, pids map[int]bool) *harness {
+	t.Helper()
+
+	fixture := &harness{
+		pids:    pids,
+		visible: display.Visible,
+		top:     display.PrimaryHeight - display.Visible.Y - display.Visible.H,
+	}
+
+	fixture.windows = fixture.waitForWindows(t)
+	t.Cleanup(func() { window.ReleaseAll(fixture.windows) })
+
+	return fixture
+}
+
+// waitForWindows waits until the helper's windows show up in the active space's
+// window list, and returns exactly those.
+func (h *harness) waitForWindows(t *testing.T) []*window.Element {
+	t.Helper()
+
+	deadline := time.Now().Add(launchTimeout)
+
+	for {
+		all, _ := enumerateFocused(t)
+
+		var (
+			mine   []*window.Element
+			others []*window.Element
+		)
+
+		for _, candidate := range all {
+			if h.owns(candidate) {
+				mine = append(mine, candidate)
+
+				continue
+			}
+
+			others = append(others, candidate)
+		}
+
+		window.ReleaseAll(others)
+
+		if len(mine) == windowCount {
+			return mine
+		}
+
+		window.ReleaseAll(mine)
+
+		if time.Now().After(deadline) {
+			t.Skipf(
+				"the helper's %d windows did not appear on the active space within %s (a locked screen or a session without a desktop will do this); refusing to record against windows this test did not create",
+				windowCount,
+				launchTimeout,
+			)
+		}
+
+		time.Sleep(pollInterval)
+	}
+}
+
+// owns reports whether the window belongs to the helper instance the recorder
+// started. A window whose process cannot be read is never treated as owned.
+func (h *harness) owns(candidate *window.Element) bool {
+	pid, err := candidate.PID()
+	if err != nil {
+		return false
+	}
+
+	return h.pids[pid]
+}
+
+// enumerateFocused returns the focusable windows on the active space along with
+// the index of the focused one.
+func enumerateFocused(t *testing.T) ([]*window.Element, int) {
+	t.Helper()
+
+	windows, focused, err := window.AllFocusableOnActiveSpaceWithFocused()
+	if err != nil {
+		t.Fatalf("failed to enumerate windows on the active space: %v", err)
+	}
+
+	return windows, focused
+}
+
+// indexOfElement returns the position of target within set, or -1.
+func indexOfElement(set []*window.Element, target *window.Element) int {
+	for index, element := range set {
+		if element.Equal(target) {
+			return index
+		}
+	}
+
+	return -1
+}
+
+// bringToFront activates one of the recorder's own windows and confirms macOS
+// agrees before any action runs, so an action that operates on "the frontmost
+// window" can only ever reach a window this test created.
+func bringToFront(t *testing.T, target *window.Element) {
+	t.Helper()
+
+	deadline := time.Now().Add(focusTimeout)
+	activated := false
+
+	for {
+		if isFrontmost(target) {
+			return
+		}
+
+		// Only ask once; the rest of the loop waits for macOS to agree.
+		if !activated {
+			err := target.Activate()
+			if err != nil {
+				t.Skipf("cannot activate the recorder's own window: %v", err)
+			}
+
+			activated = true
+		}
+
+		if time.Now().After(deadline) {
+			t.Skipf(
+				"the recorder's own window did not become frontmost within %s; refusing to drive a window this test did not create",
+				focusTimeout,
+			)
+		}
+
+		time.Sleep(settleInterval)
+	}
+}
+
+// isFrontmost reports whether macOS considers the given window the frontmost
+// one, which is the window every "frontmost window" action resolves to.
+func isFrontmost(target *window.Element) bool {
+	front := window.Frontmost()
+	if front == nil {
+		return false
+	}
+
+	defer front.Release()
+
+	return front.Equal(target)
+}
+
+// placeWindow moves one of the recorder's windows and returns the frame macOS
+// settled on, which may differ from the request when the app clamps it.
+func placeWindow(t *testing.T, target *window.Element, frame baseline.Rect) baseline.Rect {
+	t.Helper()
+
+	err := target.SetFrame(frame.X, frame.Y, frame.W, frame.H)
+	if err != nil {
+		t.Fatalf("failed to place the recorder's own window: %v", err)
+	}
+
+	return settledFrame(t, target)
+}
+
+// settledFrame reads a window frame until two consecutive reads agree, so a
+// recording never captures a frame mid-flight.
+func settledFrame(t *testing.T, target *window.Element) baseline.Rect {
+	t.Helper()
+
+	var (
+		previous baseline.Rect
+		seen     bool
+	)
+
+	deadline := time.Now().Add(settleTimeout)
+
+	for {
+		posX, posY, width, height, err := target.GetFrame()
+		if err != nil {
+			t.Fatalf("failed to read the recorder's own window frame: %v", err)
+		}
+
+		current := baseline.Rect{X: posX, Y: posY, W: width, H: height}
+		if seen && current == previous {
+			return current
+		}
+
+		previous, seen = current, true
+
+		if time.Now().After(deadline) {
+			return current
+		}
+
+		time.Sleep(settleInterval)
+	}
+}

--- a/internal/baseline/helper_integration_test.go
+++ b/internal/baseline/helper_integration_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package baseline_test
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The recorder never touches a window it did not open, so it opens its own: a
+// throwaway TextEdit instance holding one document per window it needs. This
+// file owns that process — starting it, identifying it, and stopping it — and
+// nothing about the windows themselves.
+const (
+	// helperApp is opened with -n, so it is always a fresh instance and never
+	// the copy the person at the keyboard may already be using.
+	helperApp = "TextEdit"
+	// windowCount is one document per cell of the focus grid.
+	windowCount = gridSide * gridSide
+
+	launchTimeout = 45 * time.Second
+	quitTimeout   = 10 * time.Second
+)
+
+// launchHelper starts a fresh helper instance holding windowCount documents,
+// registers a cleanup that terminates exactly the processes it started, and
+// returns their process IDs.
+//
+// It has to run before the first window enumeration. NSWorkspace only refreshes
+// its running-application list from the run loop, which a test binary never
+// spins, so an application launched after that list is first read stays
+// invisible to the action layer for the rest of the process.
+func launchHelper(t *testing.T) map[int]bool {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	const openFlags = 3
+
+	args := make([]string, 0, openFlags+windowCount)
+	args = append(args, "-n", "-a", helperApp)
+
+	for index := range windowCount {
+		path := filepath.Join(dir, fmt.Sprintf("mimi-baseline-%d.txt", index))
+
+		err := os.WriteFile(path, []byte("mimi window baseline\n"), 0o600)
+		if err != nil {
+			t.Skipf("cannot write the helper document: %v", err)
+		}
+
+		args = append(args, path)
+	}
+
+	before := helperPIDs(t)
+
+	out, err := exec.CommandContext(t.Context(), "open", args...).CombinedOutput()
+	if err != nil {
+		t.Skipf("cannot launch %s: %v: %s", helperApp, err, strings.TrimSpace(string(out)))
+	}
+
+	// The cleanup closes over started so that it stops exactly the processes
+	// this launch produced, and never a helper somebody else opened meanwhile.
+	started := map[int]bool{}
+	t.Cleanup(func() { terminateHelper(t, started) })
+
+	waitForHelperProcess(t, before, started)
+
+	return started
+}
+
+// waitForHelperProcess waits for the helper instance to exist as a process,
+// which it can do without reading the window list, and records what it saw into
+// started.
+//
+// It polls from the moment the launch returns, so the only processes it can
+// attribute to this launch are ones that appeared within a few milliseconds of
+// it. Anything that shows up later is left alone — leaking a helper window is a
+// nuisance, signaling somebody else's editor is not.
+func waitForHelperProcess(t *testing.T, before, started map[int]bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(launchTimeout)
+
+	for {
+		maps.Copy(started, helperPIDsSince(t, before))
+
+		if len(started) > 0 {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Skipf("%s did not start within %s", helperApp, launchTimeout)
+		}
+
+		time.Sleep(settleInterval)
+	}
+}
+
+// terminateHelper stops the helper processes the launch confirmed, and only
+// those. It runs as a cleanup, after t.Context is already canceled, so it uses
+// its own context.
+func terminateHelper(t *testing.T, started map[int]bool) {
+	t.Helper()
+
+	targets := slices.Collect(maps.Keys(started))
+
+	signalHelpers(t, targets, syscall.SIGTERM)
+
+	deadline := time.Now().Add(quitTimeout)
+	for time.Now().Before(deadline) {
+		if !anyRunning(t, targets) {
+			return
+		}
+
+		time.Sleep(settleInterval)
+	}
+
+	signalHelpers(t, targets, syscall.SIGKILL)
+}
+
+// signalHelpers sends sig to each of the given helper processes.
+func signalHelpers(t *testing.T, pids []int, sig syscall.Signal) {
+	t.Helper()
+
+	for _, pid := range pids {
+		process, err := os.FindProcess(pid)
+		if err != nil {
+			continue
+		}
+
+		err = process.Signal(sig)
+		if err != nil {
+			t.Logf("could not stop helper pid %d: %v", pid, err)
+		}
+	}
+}
+
+// anyRunning reports whether any of the given helper processes is still alive.
+func anyRunning(t *testing.T, pids []int) bool {
+	t.Helper()
+
+	running := helperPIDs(t)
+	for _, pid := range pids {
+		if running[pid] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// helperPIDsSince returns the running helper processes that were not in before.
+func helperPIDsSince(t *testing.T, before map[int]bool) map[int]bool {
+	t.Helper()
+
+	since := map[int]bool{}
+
+	for pid := range helperPIDs(t) {
+		if !before[pid] {
+			since[pid] = true
+		}
+	}
+
+	return since
+}
+
+// helperPIDs returns the process IDs of every running helper instance. It uses
+// its own context because it is also called from cleanup.
+func helperPIDs(t *testing.T) map[int]bool {
+	t.Helper()
+
+	pids := map[int]bool{}
+
+	out, err := exec.CommandContext(context.Background(), "pgrep", "-x", helperApp).Output()
+	if err != nil {
+		return pids
+	}
+
+	for field := range strings.FieldsSeq(string(out)) {
+		pid, convErr := strconv.Atoi(field)
+		if convErr == nil {
+			pids[pid] = true
+		}
+	}
+
+	return pids
+}

--- a/internal/baseline/window_baseline.json
+++ b/internal/baseline/window_baseline.json
@@ -1,0 +1,1313 @@
+{
+	"display": {
+		"visible": {
+			"x": 0,
+			"y": 0,
+			"w": 1920,
+			"h": 1050
+		},
+		"primaryHeight": 1080,
+		"marginsEnabled": true,
+		"marginSize": 8
+	},
+	"resize": [
+		{
+			"name": "preset/left-half/margin",
+			"args": [
+				"left-half",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 38,
+				"w": 948,
+				"h": 1034
+			}
+		},
+		{
+			"name": "preset/left-half/no-margin",
+			"args": [
+				"left-half",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 30,
+				"w": 960,
+				"h": 1050
+			}
+		},
+		{
+			"name": "preset/right-half/margin",
+			"args": [
+				"right-half",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 964,
+				"y": 38,
+				"w": 948,
+				"h": 1034
+			}
+		},
+		{
+			"name": "preset/right-half/no-margin",
+			"args": [
+				"right-half",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 960,
+				"y": 30,
+				"w": 960,
+				"h": 1050
+			}
+		},
+		{
+			"name": "preset/top-half/margin",
+			"args": [
+				"top-half",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 38,
+				"w": 1904,
+				"h": 513
+			}
+		},
+		{
+			"name": "preset/top-half/no-margin",
+			"args": [
+				"top-half",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 30,
+				"w": 1920,
+				"h": 525
+			}
+		},
+		{
+			"name": "preset/bottom-half/margin",
+			"args": [
+				"bottom-half",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 559,
+				"w": 1904,
+				"h": 513
+			}
+		},
+		{
+			"name": "preset/bottom-half/no-margin",
+			"args": [
+				"bottom-half",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 555,
+				"w": 1920,
+				"h": 525
+			}
+		},
+		{
+			"name": "preset/top-left/margin",
+			"args": [
+				"top-left",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 38,
+				"w": 948,
+				"h": 513
+			}
+		},
+		{
+			"name": "preset/top-left/no-margin",
+			"args": [
+				"top-left",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 30,
+				"w": 960,
+				"h": 525
+			}
+		},
+		{
+			"name": "preset/top-right/margin",
+			"args": [
+				"top-right",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 964,
+				"y": 38,
+				"w": 948,
+				"h": 513
+			}
+		},
+		{
+			"name": "preset/top-right/no-margin",
+			"args": [
+				"top-right",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 960,
+				"y": 30,
+				"w": 960,
+				"h": 525
+			}
+		},
+		{
+			"name": "preset/bottom-left/margin",
+			"args": [
+				"bottom-left",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 559,
+				"w": 948,
+				"h": 513
+			}
+		},
+		{
+			"name": "preset/bottom-left/no-margin",
+			"args": [
+				"bottom-left",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 555,
+				"w": 960,
+				"h": 525
+			}
+		},
+		{
+			"name": "preset/bottom-right/margin",
+			"args": [
+				"bottom-right",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 964,
+				"y": 559,
+				"w": 948,
+				"h": 513
+			}
+		},
+		{
+			"name": "preset/bottom-right/no-margin",
+			"args": [
+				"bottom-right",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 960,
+				"y": 555,
+				"w": 960,
+				"h": 525
+			}
+		},
+		{
+			"name": "preset/center/margin",
+			"args": [
+				"center",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 388,
+				"y": 139,
+				"w": 1144,
+				"h": 832
+			}
+		},
+		{
+			"name": "preset/center/no-margin",
+			"args": [
+				"center",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 384,
+				"y": 135,
+				"w": 1152,
+				"h": 840
+			}
+		},
+		{
+			"name": "preset/fill/margin",
+			"args": [
+				"fill",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 38,
+				"w": 1904,
+				"h": 1034
+			}
+		},
+		{
+			"name": "preset/fill/no-margin",
+			"args": [
+				"fill",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 30,
+				"w": 1920,
+				"h": 1050
+			}
+		},
+		{
+			"name": "preset/left-half/system-default",
+			"args": [
+				"left-half"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 38,
+				"w": 948,
+				"h": 1034
+			}
+		},
+		{
+			"name": "anchor/tl/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"tl",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 38,
+				"w": 788,
+				"h": 588
+			}
+		},
+		{
+			"name": "anchor/tl/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"tl",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 30,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "anchor/tc/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"tc",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 564,
+				"y": 38,
+				"w": 792,
+				"h": 588
+			}
+		},
+		{
+			"name": "anchor/tc/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"tc",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 560,
+				"y": 30,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "anchor/tr/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"tr",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 1124,
+				"y": 38,
+				"w": 788,
+				"h": 588
+			}
+		},
+		{
+			"name": "anchor/tr/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"tr",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 1120,
+				"y": 30,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "anchor/cl/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"cl",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 259,
+				"w": 788,
+				"h": 592
+			}
+		},
+		{
+			"name": "anchor/cl/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"cl",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 255,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "anchor/cc/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"cc",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 564,
+				"y": 259,
+				"w": 792,
+				"h": 592
+			}
+		},
+		{
+			"name": "anchor/cc/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"cc",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 560,
+				"y": 255,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "anchor/cr/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"cr",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 1124,
+				"y": 259,
+				"w": 788,
+				"h": 592
+			}
+		},
+		{
+			"name": "anchor/cr/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"cr",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 1120,
+				"y": 255,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "anchor/bl/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"bl",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 484,
+				"w": 788,
+				"h": 588
+			}
+		},
+		{
+			"name": "anchor/bl/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"bl",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 0,
+				"y": 480,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "anchor/bc/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"bc",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 564,
+				"y": 484,
+				"w": 792,
+				"h": 588
+			}
+		},
+		{
+			"name": "anchor/bc/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"bc",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 560,
+				"y": 480,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "anchor/br/margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"br",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 1124,
+				"y": 484,
+				"w": 788,
+				"h": 588
+			}
+		},
+		{
+			"name": "anchor/br/no-margin",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--anchor",
+				"br",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 1120,
+				"y": 480,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "explicit/width-height",
+			"args": [
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 560,
+				"y": 255,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "explicit/width-only",
+			"args": [
+				"--width",
+				"800",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 560,
+				"y": 305,
+				"w": 800,
+				"h": 500
+			}
+		},
+		{
+			"name": "explicit/height-only",
+			"args": [
+				"--height",
+				"600",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 610,
+				"y": 255,
+				"w": 700,
+				"h": 600
+			}
+		},
+		{
+			"name": "explicit/percent",
+			"args": [
+				"--width-percent",
+				"45",
+				"--height-percent",
+				"55",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 528,
+				"y": 267,
+				"w": 864,
+				"h": 577
+			}
+		},
+		{
+			"name": "explicit/percent-margin",
+			"args": [
+				"--width-percent",
+				"45",
+				"--height-percent",
+				"55",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 532,
+				"y": 271,
+				"w": 856,
+				"h": 569
+			}
+		},
+		{
+			"name": "explicit/position",
+			"args": [
+				"--x",
+				"100",
+				"--y",
+				"230",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 100,
+				"y": 230,
+				"w": 700,
+				"h": 500
+			}
+		},
+		{
+			"name": "explicit/position-size",
+			"args": [
+				"--x",
+				"100",
+				"--y",
+				"230",
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 100,
+				"y": 230,
+				"w": 800,
+				"h": 600
+			}
+		},
+		{
+			"name": "explicit/position-size-margin",
+			"args": [
+				"--x",
+				"100",
+				"--y",
+				"230",
+				"--width",
+				"800",
+				"--height",
+				"600",
+				"--margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 104,
+				"y": 234,
+				"w": 792,
+				"h": 592
+			}
+		},
+		{
+			"name": "explicit/preset-with-anchor",
+			"args": [
+				"left-half",
+				"--anchor",
+				"br",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 0,
+				"y": 30,
+				"w": 960,
+				"h": 1050
+			}
+		},
+		{
+			"name": "explicit/preset-with-width",
+			"args": [
+				"left-half",
+				"--width",
+				"800",
+				"--no-margin"
+			],
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 0,
+				"y": 30,
+				"w": 800,
+				"h": 1050
+			}
+		}
+	],
+	"focus": [
+		{
+			"direction": "up",
+			"arrangement": [
+				{
+					"x": 80,
+					"y": 366,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 366,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 680,
+					"y": 366,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 80,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 680,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 80,
+					"y": 374,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 374,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 680,
+					"y": 374,
+					"w": 240,
+					"h": 160
+				}
+			],
+			"current": 4,
+			"want": 1
+		},
+		{
+			"direction": "down",
+			"arrangement": [
+				{
+					"x": 80,
+					"y": 366,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 366,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 680,
+					"y": 366,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 80,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 680,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 80,
+					"y": 374,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 374,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 680,
+					"y": 374,
+					"w": 240,
+					"h": 160
+				}
+			],
+			"current": 4,
+			"want": 7
+		},
+		{
+			"direction": "left",
+			"arrangement": [
+				{
+					"x": 376,
+					"y": 70,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 70,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 384,
+					"y": 70,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 376,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 384,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 376,
+					"y": 670,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 670,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 384,
+					"y": 670,
+					"w": 240,
+					"h": 160
+				}
+			],
+			"current": 4,
+			"want": 3
+		},
+		{
+			"direction": "right",
+			"arrangement": [
+				{
+					"x": 376,
+					"y": 70,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 70,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 384,
+					"y": 70,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 376,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 384,
+					"y": 370,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 376,
+					"y": 670,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 380,
+					"y": 670,
+					"w": 240,
+					"h": 160
+				},
+				{
+					"x": 384,
+					"y": 670,
+					"w": 240,
+					"h": 160
+				}
+			],
+			"current": 4,
+			"want": 5
+		}
+	]
+}

--- a/internal/baseline/window_integration_test.go
+++ b/internal/baseline/window_integration_test.go
@@ -1,0 +1,540 @@
+//go:build integration
+
+// Recorder for the window baseline in window_baseline.json.
+//
+// It drives the real actions against real windows and records the frames macOS
+// actually produces, so that the pure geometry these actions are being factored
+// into can be checked against observed behavior rather than against a reading
+// of the old code.
+//
+// Two rules shape the whole file. It only ever touches windows it opened
+// itself — every step that would otherwise reach somebody else's window skips
+// instead. And it degrades to a skip, never a failure, whenever the machine
+// cannot support it: no Accessibility permission, a display the recording was
+// not captured on, or a screen too small for the fixed arrangement.
+//
+// Re-record with:
+//
+//	MIMI_RECORD_BASELINE=1 go test -tags=integration -run TestWindowBaseline_ResizeAndFocus ./internal/baseline
+package baseline_test
+
+import (
+	"math"
+	"os"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/baseline"
+	"github.com/y3owk1n/mimi/internal/permissions"
+	"github.com/y3owk1n/mimi/internal/window"
+)
+
+// recordEnv re-records the baseline instead of asserting against it.
+const recordEnv = "MIMI_RECORD_BASELINE"
+
+// Every geometry below is expressed relative to the visible frame, so the same
+// arrangement can be re-recorded on a different display.
+const (
+	// The frame every resize case starts from.
+	startOffsetX = 300
+	startOffsetY = 150
+	startWidth   = 700
+	startHeight  = 500
+
+	// The size the anchor and explicit-flag cases ask for.
+	fixedWidth  = 800
+	fixedHeight = 600
+
+	// The position the explicit --x/--y cases ask for.
+	explicitOffsetX = 100
+	explicitOffsetY = 200
+
+	// The 3x3 grid the focus cases navigate, given as the middle window's
+	// center offset from the visible frame's top-left corner, the step between
+	// neighboring centers, and the window size. The grid is rebuilt for each
+	// direction, rotated so that the tight step runs along the direction of
+	// travel.
+	//
+	// The tight step is a few points, which is what lets the test run at all on
+	// a machine somebody is using: focus_window measures distance between
+	// window centers, so the recorder's own windows have to be nearer to each
+	// other than any window it did not create.
+	//
+	// The wide step exceeds the window size, so across the direction of travel
+	// the diagonal neighbors do not overlap the current window while the
+	// aligned one does. That is what makes the overlap bonus, rather than a
+	// tie, decide each direction. None of this costs coverage: the scoring
+	// compares distances and has no thresholds, so a grid four points across
+	// exercises it exactly as one four hundred points across would.
+	gridOriginX = 500
+	gridOriginY = 420
+	gridTight   = 4
+	gridWide    = 300
+	gridWidth   = 240
+	gridHeight  = 160
+	gridSide    = 3
+
+	// The smallest visible frame every arrangement fits inside.
+	minVisibleWidth  = 1000
+	minVisibleHeight = 850
+)
+
+// The four spatial directions focus_window supports.
+const (
+	dirUp    = "up"
+	dirDown  = "down"
+	dirLeft  = "left"
+	dirRight = "right"
+)
+
+// The resize_window flags and preset name the cases are built from.
+const (
+	flagWidth         = "--width"
+	flagHeight        = "--height"
+	flagWidthPercent  = "--width-percent"
+	flagHeightPercent = "--height-percent"
+	flagAnchor        = "--anchor"
+	flagX             = "--x"
+	flagY             = "--y"
+	flagMargin        = "--margin"
+	flagNoMargin      = "--no-margin"
+
+	presetLeftHalf = "left-half"
+)
+
+// resizeSpec is one resize_window invocation the baseline covers.
+type resizeSpec struct {
+	name string
+	args []string
+}
+
+func TestWindowBaseline_ResizeAndFocus(t *testing.T) {
+	if !permissions.Check().Accessibility {
+		t.Skip(
+			"Accessibility permission is not granted; window baselines can neither be recorded nor replayed",
+		)
+	}
+
+	recorded, err := baseline.Load()
+	if err != nil {
+		t.Fatalf("failed to load the recorded window baseline: %v", err)
+	}
+
+	live := liveDisplay(t)
+	recording := recorded
+	recording.Display = live
+	record := os.Getenv(recordEnv) == "1"
+
+	if !record && recorded.Display != live {
+		t.Skipf(
+			"the baseline was recorded on a different display (recorded %+v, live %+v); re-record with %s=1",
+			recorded.Display,
+			live,
+			recordEnv,
+		)
+	}
+
+	if live.Visible.W < minVisibleWidth || live.Visible.H < minVisibleHeight {
+		t.Skipf(
+			"the visible frame %s is smaller than the %dx%d the baseline arrangement needs",
+			live.Visible,
+			minVisibleWidth,
+			minVisibleHeight,
+		)
+	}
+
+	// The helper has to start before the first window enumeration; see
+	// launchHelper. Everything above this line only reads screens and files.
+	fixture := newHarness(t, live, launchHelper(t))
+
+	var resizeCount, focusCount int
+
+	t.Run("resize_window", func(t *testing.T) {
+		observed := fixture.runResizeCases(t, recorded, record)
+		recording.Resize = observed
+		resizeCount = len(observed)
+	})
+
+	t.Run("focus_window", func(t *testing.T) {
+		observed := fixture.runFocusCases(t, recorded, record)
+		recording.Focus = observed
+		focusCount = len(observed)
+	})
+
+	if !record {
+		return
+	}
+
+	// A partial recording is worse than none: its display would describe frames
+	// that were never captured against it. Write only a complete one.
+	if resizeCount != len(fixture.resizeSpecs()) || focusCount != len(focusDirections) {
+		t.Errorf(
+			"recording captured %d of %d resize and %d of %d focus cases; %s was left unchanged",
+			resizeCount,
+			len(fixture.resizeSpecs()),
+			focusCount,
+			len(focusDirections),
+			baseline.FileName,
+		)
+
+		return
+	}
+
+	writeRecording(t, recording)
+}
+
+// liveDisplay reads everything the action layer asks macOS about the screen.
+func liveDisplay(t *testing.T) baseline.Display {
+	t.Helper()
+
+	visX, visY, visW, visH, err := window.ScreenVisibleFrame(0, 0)
+	if err != nil {
+		t.Skipf("cannot read the screen's visible frame: %v", err)
+	}
+
+	primaryH, err := window.PrimaryScreenHeight()
+	if err != nil {
+		t.Skipf("cannot read the primary screen height: %v", err)
+	}
+
+	return baseline.Display{
+		Visible:        baseline.Rect{X: visX, Y: visY, W: visW, H: visH},
+		PrimaryHeight:  primaryH,
+		MarginsEnabled: window.TiledWindowMarginsEnabled(),
+		MarginSize:     window.TiledWindowMarginSize(),
+	}
+}
+
+// runResizeCases drives every resize_window case and either records the frames
+// macOS produced or asserts them against the recording.
+func (h *harness) runResizeCases(
+	t *testing.T,
+	recorded baseline.Recording,
+	record bool,
+) []baseline.ResizeCase {
+	t.Helper()
+
+	specs := h.resizeSpecs()
+	observed := make([]baseline.ResizeCase, 0, len(specs))
+
+	if !record && len(recorded.Resize) != len(specs) {
+		t.Errorf(
+			"the recording holds %d resize cases but the recorder covers %d; re-record with %s=1",
+			len(recorded.Resize),
+			len(specs),
+			recordEnv,
+		)
+	}
+
+	for _, spec := range specs {
+		start, got := h.runResize(t, spec.args)
+		observed = append(observed, baseline.ResizeCase{
+			Name:  spec.name,
+			Args:  spec.args,
+			Start: start,
+			Want:  got,
+		})
+
+		if record {
+			continue
+		}
+
+		t.Run(spec.name, func(t *testing.T) {
+			want, ok := recorded.ResizeCase(spec.name)
+			if !ok {
+				t.Fatalf("no recorded baseline for this case; re-record with %s=1", recordEnv)
+			}
+
+			if !slices.Equal(want.Args, spec.args) {
+				t.Fatalf(
+					"the recording covers args %v but the recorder ran %v; re-record with %s=1",
+					want.Args,
+					spec.args,
+					recordEnv,
+				)
+			}
+
+			if start != want.Start {
+				t.Fatalf(
+					"the window started at %s but the baseline was recorded from %s; re-record with %s=1",
+					start,
+					want.Start,
+					recordEnv,
+				)
+			}
+
+			if got != want.Want {
+				t.Errorf(
+					"resize_window %v produced %s, baseline says %s",
+					spec.args,
+					got,
+					want.Want,
+				)
+			}
+		})
+	}
+
+	return observed
+}
+
+// runResize parks the recorder's own window at the shared start frame, runs one
+// resize_window invocation against it and reports the frames either side.
+func (h *harness) runResize(t *testing.T, args []string) (baseline.Rect, baseline.Rect) {
+	t.Helper()
+
+	target := h.windows[0]
+
+	start := placeWindow(t, target, baseline.Rect{
+		X: h.visible.X + startOffsetX,
+		Y: h.top + startOffsetY,
+		W: startWidth,
+		H: startHeight,
+	})
+
+	// resize_window resolves the frontmost window itself, so the recorder's own
+	// window has to be frontmost before it runs. That check narrows the window
+	// in which the action could reach somebody else's window, but the action
+	// re-reads the frontmost window and nothing can close the gap entirely, so
+	// the check is repeated afterwards to turn a focus steal into a failure
+	// rather than a silently wrong recording.
+	bringToFront(t, target)
+
+	err := action.Execute(string(action.NameResizeWindow), args)
+	if err != nil {
+		t.Fatalf("resize_window %v failed: %v", args, err)
+	}
+
+	if !isFrontmost(target) {
+		t.Fatalf(
+			"focus moved off the recorder's own window while resize_window %v ran",
+			args,
+		)
+	}
+
+	return start, settledFrame(t, target)
+}
+
+// resizeSpecs enumerates every resize_window invocation the baseline covers:
+// all ten presets in both margin states, all nine anchors in both margin
+// states, and the explicit-flag combinations.
+func (h *harness) resizeSpecs() []resizeSpec {
+	presets := []string{
+		presetLeftHalf, "right-half", "top-half", "bottom-half",
+		"top-left", "top-right", "bottom-left", "bottom-right",
+		"center", "fill",
+	}
+	anchors := []string{"tl", "tc", "tr", "cl", "cc", "cr", "bl", "bc", "br"}
+
+	// The system-default preset case plus the ten explicit-flag cases.
+	const extraCases = 11
+
+	specs := make([]resizeSpec, 0, len(presets)*2+len(anchors)*2+extraCases)
+
+	for _, preset := range presets {
+		specs = append(specs,
+			resizeSpec{name: "preset/" + preset + "/margin", args: []string{preset, flagMargin}},
+			resizeSpec{
+				name: "preset/" + preset + "/no-margin",
+				args: []string{preset, flagNoMargin},
+			},
+		)
+	}
+
+	// The one case that exercises the system margin setting rather than a flag.
+	specs = append(
+		specs,
+		resizeSpec{name: "preset/left-half/system-default", args: []string{presetLeftHalf}},
+	)
+
+	width := strconv.Itoa(fixedWidth)
+	height := strconv.Itoa(fixedHeight)
+
+	for _, anchor := range anchors {
+		sized := []string{flagWidth, width, flagHeight, height, flagAnchor, anchor}
+		specs = append(specs,
+			resizeSpec{
+				name: "anchor/" + anchor + "/margin",
+				args: append(slices.Clone(sized), flagMargin),
+			},
+			resizeSpec{
+				name: "anchor/" + anchor + "/no-margin",
+				args: append(slices.Clone(sized), flagNoMargin),
+			},
+		)
+	}
+
+	posX := strconv.Itoa(int(h.visible.X) + explicitOffsetX)
+	posY := strconv.Itoa(int(h.top) + explicitOffsetY)
+
+	return append(specs,
+		resizeSpec{
+			name: "explicit/width-height",
+			args: []string{flagWidth, width, flagHeight, height, flagNoMargin},
+		},
+		resizeSpec{
+			name: "explicit/width-only",
+			args: []string{flagWidth, width, flagNoMargin},
+		},
+		resizeSpec{
+			name: "explicit/height-only",
+			args: []string{flagHeight, height, flagNoMargin},
+		},
+		resizeSpec{
+			name: "explicit/percent",
+			args: []string{flagWidthPercent, "45", flagHeightPercent, "55", flagNoMargin},
+		},
+		resizeSpec{
+			name: "explicit/percent-margin",
+			args: []string{flagWidthPercent, "45", flagHeightPercent, "55", flagMargin},
+		},
+		resizeSpec{
+			name: "explicit/position",
+			args: []string{flagX, posX, flagY, posY, flagNoMargin},
+		},
+		resizeSpec{
+			name: "explicit/position-size",
+			args: []string{
+				flagX, posX, flagY, posY,
+				flagWidth, width, flagHeight, height, flagNoMargin,
+			},
+		},
+		resizeSpec{
+			name: "explicit/position-size-margin",
+			args: []string{
+				flagX, posX, flagY, posY,
+				flagWidth, width, flagHeight, height, flagMargin,
+			},
+		},
+		resizeSpec{
+			name: "explicit/preset-with-anchor",
+			args: []string{presetLeftHalf, flagAnchor, "br", flagNoMargin},
+		},
+		resizeSpec{
+			name: "explicit/preset-with-width",
+			args: []string{presetLeftHalf, flagWidth, width, flagNoMargin},
+		},
+	)
+}
+
+// writeRecording replaces the recording file next to this test.
+func writeRecording(t *testing.T, recording baseline.Recording) {
+	t.Helper()
+
+	data, err := baseline.Encode(recording)
+	if err != nil {
+		t.Fatalf("failed to encode the window baseline: %v", err)
+	}
+
+	err = os.WriteFile(baseline.FileName, data, 0o644) //nolint:gosec // a tracked repo file
+	if err != nil {
+		t.Fatalf("failed to write %s: %v", baseline.FileName, err)
+	}
+
+	t.Logf(
+		"recorded %d resize and %d focus baselines into %s",
+		len(recording.Resize),
+		len(recording.Focus),
+		baseline.FileName,
+	)
+}
+
+// candidate is how the action layer sees one window when navigating in a
+// direction: the distance along the requested axis, the distance across it,
+// and whether the two windows overlap on that other axis.
+type candidate struct {
+	primary   float64
+	secondary float64
+	overlaps  bool
+}
+
+// measure describes a candidate window relative to the current one, and reports
+// whether it lies in the requested direction at all.
+//
+// It mirrors the direction filter, the two distances, and the overlap test the
+// action layer applies — never which candidate wins, which is the fact the
+// baseline records.
+func measure(dir string, cur, cand baseline.Rect) (candidate, bool) {
+	deltaX := (cand.X + cand.W/2) - (cur.X + cur.W/2)
+	deltaY := (cand.Y + cand.H/2) - (cur.Y + cur.H/2)
+	acrossX := cur.X < cand.X+cand.W && cur.X+cur.W > cand.X
+	acrossY := cur.Y < cand.Y+cand.H && cur.Y+cur.H > cand.Y
+
+	switch dir {
+	case dirLeft:
+		if deltaX >= 0 {
+			return candidate{}, false
+		}
+
+		return candidate{primary: -deltaX, secondary: math.Abs(deltaY), overlaps: acrossY}, true
+	case dirRight:
+		if deltaX <= 0 {
+			return candidate{}, false
+		}
+
+		return candidate{primary: deltaX, secondary: math.Abs(deltaY), overlaps: acrossY}, true
+	case dirUp:
+		if deltaY >= 0 {
+			return candidate{}, false
+		}
+
+		return candidate{primary: -deltaY, secondary: math.Abs(deltaX), overlaps: acrossX}, true
+	case dirDown:
+		if deltaY <= 0 {
+			return candidate{}, false
+		}
+
+		return candidate{primary: deltaY, secondary: math.Abs(deltaX), overlaps: acrossX}, true
+	}
+
+	return candidate{}, false
+}
+
+// focusReach bounds the directional score on both sides: the worst score the
+// recorder's own windows can produce, and the best score any other window on
+// the space can produce. When the first is strictly smaller than the second,
+// focus_window cannot reach a window the recorder did not create.
+//
+// The action layer scores a candidate at the primary distance, plus the
+// secondary distance when the two windows do not overlap on the perpendicular
+// axis. The recorder's side ignores the overlap and takes the sum, which is an
+// upper bound however the overlap turns out; the other side applies the overlap
+// test, because a window across the screen at the same height is otherwise
+// indistinguishable from one directly below and the guard would never let the
+// test run.
+//
+// Neither side ever picks a winner among the recorder's own windows — that is
+// the fact the baseline records, and nothing here reproduces it.
+//
+// Either bound is math.MaxFloat64 when nothing lies in that direction.
+func focusReach(dir string, cur baseline.Rect, mine, foreign []baseline.Rect) (float64, float64) {
+	own := math.MaxFloat64
+
+	for _, rect := range mine {
+		measured, ok := measure(dir, cur, rect)
+		if ok && measured.primary+measured.secondary < own {
+			own = measured.primary + measured.secondary
+		}
+	}
+
+	others := math.MaxFloat64
+
+	for _, rect := range foreign {
+		measured, ok := measure(dir, cur, rect)
+		if !ok {
+			continue
+		}
+
+		score := measured.primary
+		if !measured.overlaps {
+			score += measured.secondary
+		}
+
+		if score < others {
+			others = score
+		}
+	}
+
+	return own, others
+}

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -17,6 +17,8 @@ void **MimiGetAllFocusableWindowsOnActiveSpace(int *count);
 void **MimiGetAllFocusableWindowsOnActiveSpaceWithFocused(int *count, int *focusedIndex);
 void *MimiGetFrontmostWindow(void);
 int MimiActivateWindow(void *window);
+/// Return the process identifier of the application owning the window, or 0.
+int MimiGetWindowPID(void *window);
 
 #pragma mark - Screen Functions
 

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -406,6 +406,17 @@ void **MimiGetAllFocusableWindowsOnActiveSpaceWithFocused(int *count, int *focus
 	}
 }
 
+int MimiGetWindowPID(void *window) {
+	if (!window)
+		return 0;
+
+	pid_t pid = 0;
+	if (AXUIElementGetPid((AXUIElementRef)window, &pid) != kAXErrorSuccess)
+		return 0;
+
+	return (int)pid;
+}
+
 double *MimiGetWindowFrame(void *window) {
 	if (!window)
 		return NULL;

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -122,6 +122,25 @@ func (e *Element) Equal(other *Element) bool {
 	return result == 1
 }
 
+// PID returns the process ID of the application that owns the window. It is how
+// a caller tells one application's windows from another's — the integration
+// baseline uses it to confirm it only ever drives windows it opened itself.
+func (e *Element) PID() (int, error) {
+	if e.ref == nil {
+		return 0, derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"cannot get window pid: element reference is nil",
+		)
+	}
+
+	pid := int(C.MimiGetWindowPID(e.ref)) //nolint:nlreturn // cgo call expansion
+	if pid <= 0 {
+		return 0, derrors.New(derrors.CodeAccessibilityFailed, "failed to get window pid")
+	}
+
+	return pid, nil
+}
+
 // GetFrame returns the window's position and size [x, y, w, h] in screen coordinates.
 func (e *Element) GetFrame() (float64, float64, float64, float64, error) {
 	if e.ref == nil {


### PR DESCRIPTION
## Description

This PR fills the integration test tier, which was documented but empty — `just test-integration` ran zero tests. It adds a recorder that drives the real window actions against real windows and stores the frames macOS actually produces: every resize preset in both margin states, every anchor in both margin states, the explicit size/position/percentage combinations, and the window directional focus picks in each of the four directions. Those recordings are stored as data rather than as literals inside assertions, so the geometry extraction that follows can be checked against what macOS really does rather than against somebody's reading of the current code.

The recorder only ever touches windows it opened itself. It launches its own throwaway TextEdit instance and identifies windows by process, and every step that would otherwise reach a window it did not open skips instead — including a guard that refuses to run a focus case when a window it did not create could be the one that gets focused. It also skips, rather than fails, on any machine that cannot support it: no Accessibility permission (which is why CI stays green), a locked screen, a screen too small for the arrangement, or a display other than the one the recording was captured on.

The deliberate limitation is that a recording is tied to the display it was captured on. On a different screen the integration test skips with a message telling you how to re-record; the recorded data is still readable and asserted by the unit tests either way.

## Related Issues

Closes #61

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Environment variables

The recorder reads one environment variable, and only in tests:

| Variable | Effect |
| --- | --- |
| `MIMI_RECORD_BASELINE=1` | Re-records the baseline from the current machine instead of asserting against it |

```bash
MIMI_RECORD_BASELINE=1 go test -tags=integration -run TestWindowBaseline_ResizeAndFocus ./internal/baseline
```

Nothing in the shipped binary reads it, and no config key, command, flag or hook variable changes.

## Additional Context

Three things worth knowing about why the recorder is shaped the way it is.

**Ownership is decided by process, so the accessibility wrapper now exposes a window's process ID.** That is the only production change in the diff. A set-difference of the window list before and after the launch would have been the obvious alternative, but it cannot work here — see the next point — and a process check is a stronger guarantee anyway.

**The helper application has to launch before the first window enumeration.** `NSWorkspace` refreshes its running-application list from the run loop, which a test binary never spins, so an application launched after that list is first read stays invisible to the action layer for the rest of the process. This costs nothing at runtime — the CLI is short-lived and the daemon spins a run loop — but it dictates the order of the recorder's setup, and it is commented and documented so the next person does not rediscover it the hard way.

**The focus arrangement is deliberately tiny.** Directional focus scores candidates by the distance between window centers, so on a machine somebody is actually using, the recorder's own windows have to be nearer to each other than any window it did not create — otherwise the safety guard refuses every direction. The windows therefore sit a few points apart along the direction of travel and a wide gap apart across it, which is what makes the overlap bonus rather than a tie decide each case. The scoring compares distances and has no thresholds, so a four-point grid exercises it exactly as a four-hundred-point one would.
