### PR TITLE
refactor(action): move directional window focus scoring into a pure module

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,6 +15,7 @@ Both paths use native macOS APIs via CGO. No SIP disable is required.
 ```
 mimi action <subcommand>
   → internal/action
+  → internal/geometry (pure window geometry, no macOS)
   → internal/window / internal/space
   → internal/native (Objective-C + SkyLight)
 ```

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -49,6 +49,7 @@ mimi/
 │   ├── daemon/         # Daemon lifecycle
 │   ├── errors/         # Structured error types
 │   ├── events/         # Event types + pub-sub bus
+│   ├── geometry/       # Pure window geometry (no dependencies)
 │   ├── hooks/          # Hook registry + executor
 │   ├── logging/        # Structured logging
 │   ├── native/         # Objective-C + CGO bridge

--- a/internal/action/perform.go
+++ b/internal/action/perform.go
@@ -1,9 +1,8 @@
 package action
 
 import (
-	"math"
-
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
 	"github.com/y3owk1n/mimi/internal/permissions"
 	"github.com/y3owk1n/mimi/internal/space"
 	"github.com/y3owk1n/mimi/internal/window"
@@ -44,14 +43,16 @@ func FocusWindow(backward bool, direction string) error {
 	defer window.ReleaseAll(windows)
 
 	if direction != "" {
-		if focusedIndex < 0 {
-			return derrors.New(
-				derrors.CodeActionFailed,
-				"current window not found; cannot determine spatial navigation target",
+		dir, ok := directionFromFlag(direction)
+		if !ok {
+			return derrors.Newf(
+				derrors.CodeInvalidInput,
+				"unknown direction %q (use up, down, left, or right)",
+				direction,
 			)
 		}
 
-		return focusDirectional(windows, focusedIndex, direction)
+		return focusDirectional(windows, focusedIndex, dir)
 	}
 
 	var targetIndex int
@@ -80,117 +81,59 @@ func FocusWindow(backward bool, direction string) error {
 	return nil
 }
 
-type winInfo struct {
-	el                       *window.Element
-	cx, cy                   float64
-	left, top, right, bottom float64
+// directionFromFlag maps a focus_window direction flag onto the geometry
+// direction it navigates in.
+func directionFromFlag(flag string) (geometry.Direction, bool) {
+	switch flag {
+	case "up":
+		return geometry.Up, true
+	case "down":
+		return geometry.Down, true
+	case "left":
+		return geometry.Left, true
+	case "right":
+		return geometry.Right, true
+	default:
+		return 0, false
+	}
 }
 
-func focusDirectional(windows []*window.Element, currentIndex int, direction string) error {
-	infos := make([]winInfo, 0, len(windows))
-	currentInfoIndex := -1
+// focusDirectional moves focus to the window nearest windows[currentIndex] in
+// the given direction. currentIndex may be -1 when no window is focused.
+func focusDirectional(
+	windows []*window.Element,
+	currentIndex int,
+	dir geometry.Direction,
+) error {
+	// A window whose frame cannot be read stays nil, which keeps every index
+	// here an index into windows.
+	frames := make([]*geometry.Rect, len(windows))
 
-	for idx, win := range windows {
+	for index, win := range windows {
 		posX, posY, winW, winH, err := win.GetFrame()
 		if err != nil {
 			continue
 		}
 
-		if idx == currentIndex {
-			currentInfoIndex = len(infos)
-		}
-
-		infos = append(infos, winInfo{
-			el:     win,
-			cx:     posX + winW/2,
-			cy:     posY + winH/2,
-			left:   posX,
-			top:    posY,
-			right:  posX + winW,
-			bottom: posY + winH,
-		})
+		frames[index] = &geometry.Rect{X: posX, Y: posY, W: winW, H: winH}
 	}
 
-	if currentInfoIndex < 0 {
+	if currentIndex < 0 || currentIndex >= len(frames) || frames[currentIndex] == nil {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"current window not found; cannot determine spatial navigation target",
 		)
 	}
 
-	cur := infos[currentInfoIndex]
-
-	var best *winInfo
-
-	bestScore := math.MaxFloat64
-
-	for idx, cand := range infos {
-		if idx == currentInfoIndex {
-			continue
-		}
-
-		deltaX := cand.cx - cur.cx
-		deltaY := cand.cy - cur.cy
-
-		var (
-			priDist, secDist float64
-			overlap          bool
-		)
-
-		switch direction {
-		case "left":
-			if deltaX >= 0 {
-				continue
-			}
-
-			priDist = -deltaX
-			secDist = math.Abs(deltaY)
-			overlap = cur.top < cand.bottom && cur.bottom > cand.top
-		case "right":
-			if deltaX <= 0 {
-				continue
-			}
-
-			priDist = deltaX
-			secDist = math.Abs(deltaY)
-			overlap = cur.top < cand.bottom && cur.bottom > cand.top
-		case "up":
-			if deltaY >= 0 {
-				continue
-			}
-
-			priDist = -deltaY
-			secDist = math.Abs(deltaX)
-			overlap = cur.left < cand.right && cur.right > cand.left
-		case "down":
-			if deltaY <= 0 {
-				continue
-			}
-
-			priDist = deltaY
-			secDist = math.Abs(deltaX)
-			overlap = cur.left < cand.right && cur.right > cand.left
-		}
-
-		score := priDist
-		if !overlap {
-			score += secDist
-		}
-
-		if best == nil || score < bestScore {
-			best = &infos[idx]
-			bestScore = score
-		}
-	}
-
-	if best == nil {
+	target, found := geometry.Nearest(frames, currentIndex, dir)
+	if !found {
 		return derrors.New(
 			derrors.CodeActionFailed,
 			"no window found in that direction",
 		)
 	}
 
-	return best.el.Activate()
+	return windows[target].Activate()
 }
 
 // FocusSpace focuses the Mission Control space at the given 1-based index.

--- a/internal/baseline/geometry_baseline_test.go
+++ b/internal/baseline/geometry_baseline_test.go
@@ -1,0 +1,76 @@
+package baseline_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/baseline"
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// TestNearest_ReproducesTheRecordedFocusTargets replays every recorded
+// focus_window arrangement through the pure geometry and checks it picks the
+// window macOS actually focused. This is the equivalence oracle for the
+// extraction: it lives here, next to the recording, so internal/geometry stays
+// free of every import outside the standard library.
+func TestNearest_ReproducesTheRecordedFocusTargets(t *testing.T) {
+	recording, err := baseline.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(recording.Focus) == 0 {
+		t.Fatal("the recording holds no focus cases")
+	}
+
+	for _, focus := range recording.Focus {
+		t.Run(focus.Direction, func(t *testing.T) {
+			dir, ok := directionOf(focus.Direction)
+			if !ok {
+				t.Fatalf("the recording holds an unknown direction %q", focus.Direction)
+			}
+
+			frames := make([]*geometry.Rect, 0, len(focus.Arrangement))
+
+			for _, rect := range focus.Arrangement {
+				frames = append(frames, &geometry.Rect{X: rect.X, Y: rect.Y, W: rect.W, H: rect.H})
+			}
+
+			got, found := geometry.Nearest(frames, focus.Current, dir)
+			if !found {
+				t.Fatalf(
+					"Nearest(%s) found no window, macOS focused %d (%s)",
+					focus.Direction,
+					focus.Want,
+					focus.Arrangement[focus.Want],
+				)
+			}
+
+			if got != focus.Want {
+				t.Errorf(
+					"Nearest(%s) = %d (%s), macOS focused %d (%s)",
+					focus.Direction,
+					got,
+					focus.Arrangement[got],
+					focus.Want,
+					focus.Arrangement[focus.Want],
+				)
+			}
+		})
+	}
+}
+
+// directionOf maps a recorded direction name onto the geometry direction.
+func directionOf(name string) (geometry.Direction, bool) {
+	switch name {
+	case "up":
+		return geometry.Up, true
+	case "down":
+		return geometry.Down, true
+	case "left":
+		return geometry.Left, true
+	case "right":
+		return geometry.Right, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/geometry/doc.go
+++ b/internal/geometry/doc.go
@@ -1,0 +1,2 @@
+// Package geometry holds the pure window geometry the action layer applies.
+package geometry

--- a/internal/geometry/nearest.go
+++ b/internal/geometry/nearest.go
@@ -1,0 +1,127 @@
+package geometry
+
+import "math"
+
+// Direction is one of the four axes directional window focus navigates along.
+type Direction uint8
+
+// The directions directional focus navigates in. Up and Left move towards
+// smaller coordinates, Down and Right towards larger ones.
+const (
+	Up Direction = iota //nolint:varnamelen // the directions read best as their plain names
+	Down
+	Left
+	Right
+)
+
+// Nearest returns the index of the window nearest to frames[current] in the
+// given direction, and whether one was found.
+//
+// A nil entry marks a frame that could not be read; it is never a candidate,
+// and a nil at current reports not found. The returned index is an index into
+// frames, so callers never have to map it back onto a filtered list.
+func Nearest(frames []*Rect, current int, dir Direction) (int, bool) {
+	if current < 0 || current >= len(frames) || frames[current] == nil {
+		return 0, false
+	}
+
+	cur := *frames[current]
+	best := candidate{index: -1}
+
+	for index, frame := range frames {
+		if index == current || frame == nil {
+			continue
+		}
+
+		score, ok := scoreOf(cur, *frame, dir)
+		if !ok {
+			continue
+		}
+
+		next := candidate{index: index, rect: *frame, score: score}
+		if best.index < 0 || next.beats(best) {
+			best = next
+		}
+	}
+
+	if best.index < 0 {
+		return 0, false
+	}
+
+	return best.index, true
+}
+
+// candidate is one window scored against the one focus is navigating from.
+type candidate struct {
+	index int
+	rect  Rect
+	score float64
+}
+
+// beats reports whether c is a better target than other. Equal scores resolve
+// to the topmost window, then the leftmost; a candidate that ties on all three
+// loses, which leaves the lowest index holding the win.
+func (c candidate) beats(other candidate) bool {
+	if c.score != other.score {
+		return c.score < other.score
+	}
+
+	if c.rect.Y != other.rect.Y {
+		return c.rect.Y < other.rect.Y
+	}
+
+	return c.rect.X < other.rect.X
+}
+
+// scoreOf scores one candidate against the current window: the distance
+// between their centers along the requested axis, plus the distance across it
+// unless the two windows overlap on that perpendicular axis. Lower is nearer.
+// It reports false when the candidate does not lie in the requested direction.
+func scoreOf(cur, cand Rect, dir Direction) (float64, bool) {
+	deltaX := cand.CenterX() - cur.CenterX()
+	deltaY := cand.CenterY() - cur.CenterY()
+
+	var (
+		primary, secondary float64
+		overlap            bool
+	)
+
+	switch dir {
+	case Left:
+		if deltaX >= 0 {
+			return 0, false
+		}
+
+		primary, secondary = -deltaX, math.Abs(deltaY)
+		overlap = cur.Y < cand.Bottom() && cur.Bottom() > cand.Y
+	case Right:
+		if deltaX <= 0 {
+			return 0, false
+		}
+
+		primary, secondary = deltaX, math.Abs(deltaY)
+		overlap = cur.Y < cand.Bottom() && cur.Bottom() > cand.Y
+	case Up:
+		if deltaY >= 0 {
+			return 0, false
+		}
+
+		primary, secondary = -deltaY, math.Abs(deltaX)
+		overlap = cur.X < cand.Right() && cur.Right() > cand.X
+	case Down:
+		if deltaY <= 0 {
+			return 0, false
+		}
+
+		primary, secondary = deltaY, math.Abs(deltaX)
+		overlap = cur.X < cand.Right() && cur.Right() > cand.X
+	default:
+		return 0, false
+	}
+
+	if overlap {
+		return primary, true
+	}
+
+	return primary + secondary, true
+}

--- a/internal/geometry/nearest_test.go
+++ b/internal/geometry/nearest_test.go
@@ -1,0 +1,212 @@
+package geometry_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+func TestNearest_BreaksTiesOnTopThenLeftThenIndex(t *testing.T) {
+	current := &geometry.Rect{X: 0, Y: 0, W: 100, H: 100}
+
+	tests := []struct {
+		name   string
+		frames []*geometry.Rect
+		dir    geometry.Direction
+		want   int
+	}{
+		{
+			// Both score 200; the higher one wins even though it comes last.
+			name: "equal scores resolve to the topmost window",
+			frames: []*geometry.Rect{
+				current,
+				{X: 200, Y: 50, W: 100, H: 100},
+				{X: 200, Y: -50, W: 100, H: 100},
+			},
+			dir:  geometry.Right,
+			want: 2,
+		},
+		{
+			// Both score 300 and share a top edge; the leftmost one wins.
+			name: "equal scores at the same top resolve to the leftmost window",
+			frames: []*geometry.Rect{
+				current,
+				{X: 100, Y: 200, W: 100, H: 100},
+				{X: -100, Y: 200, W: 100, H: 100},
+			},
+			dir:  geometry.Down,
+			want: 2,
+		},
+		{
+			// Identical windows: the lowest index wins.
+			name: "identical windows resolve to the lowest index",
+			frames: []*geometry.Rect{
+				current,
+				{X: 200, Y: 0, W: 100, H: 100},
+				{X: 200, Y: 0, W: 100, H: 100},
+			},
+			dir:  geometry.Right,
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := geometry.Nearest(tt.frames, 0, tt.dir)
+			if !ok || got != tt.want {
+				t.Errorf("Nearest() = %d, %v; want %d, true", got, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestNearest_PrefersAnOverlappingWindowOverACloserOffsetOne(t *testing.T) {
+	// In every row the offset window is the closer one along the direction of
+	// travel, but it does not overlap the current window on the perpendicular
+	// axis, so it pays its 300 points of sideways distance and loses to the
+	// aligned window 200 points away.
+	tests := []struct {
+		name    string
+		dir     geometry.Direction
+		offset  *geometry.Rect
+		aligned *geometry.Rect
+	}{
+		{
+			name:    "up",
+			dir:     geometry.Up,
+			offset:  &geometry.Rect{X: 300, Y: -10, W: 100, H: 100},
+			aligned: &geometry.Rect{X: 0, Y: -200, W: 100, H: 100},
+		},
+		{
+			name:    "down",
+			dir:     geometry.Down,
+			offset:  &geometry.Rect{X: 300, Y: 110, W: 100, H: 100},
+			aligned: &geometry.Rect{X: 0, Y: 200, W: 100, H: 100},
+		},
+		{
+			name:    "left",
+			dir:     geometry.Left,
+			offset:  &geometry.Rect{X: -10, Y: 300, W: 100, H: 100},
+			aligned: &geometry.Rect{X: -200, Y: 0, W: 100, H: 100},
+		},
+		{
+			name:    "right",
+			dir:     geometry.Right,
+			offset:  &geometry.Rect{X: 110, Y: 300, W: 100, H: 100},
+			aligned: &geometry.Rect{X: 200, Y: 0, W: 100, H: 100},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			current := &geometry.Rect{X: 0, Y: 0, W: 100, H: 100}
+			frames := []*geometry.Rect{testCase.offset, testCase.aligned, current}
+
+			got, ok := geometry.Nearest(frames, 2, testCase.dir)
+			if !ok || got != 1 {
+				t.Errorf("Nearest(%s) = %d, %v; want 1, true", testCase.name, got, ok)
+			}
+		})
+	}
+}
+
+// grid is a 3x3 arrangement of 100x100 windows 200 points apart, in the (y, x)
+// order the native layer enumerates windows in. Index 4 is the middle cell.
+func grid() []*geometry.Rect {
+	frames := make([]*geometry.Rect, 0, 9)
+
+	for row := range 3 {
+		for col := range 3 {
+			frames = append(frames, &geometry.Rect{
+				X: float64(col) * 200,
+				Y: float64(row) * 200,
+				W: 100,
+				H: 100,
+			})
+		}
+	}
+
+	return frames
+}
+
+func TestNearest_PicksTheNeighborInTheRequestedDirection(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  geometry.Direction
+		want int
+	}{
+		{"up", geometry.Up, 1},
+		{"down", geometry.Down, 7},
+		{"left", geometry.Left, 3},
+		{"right", geometry.Right, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := geometry.Nearest(grid(), 4, tt.dir)
+			if !ok || got != tt.want {
+				t.Errorf("Nearest(%s) = %d, %v; want %d, true", tt.name, got, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestNearest_ReportsNotFoundWhenNothingLiesInTheDirection(t *testing.T) {
+	tests := []struct {
+		name    string
+		current int
+		dir     geometry.Direction
+	}{
+		{"nothing above the top row", 1, geometry.Up},
+		{"nothing below the bottom row", 7, geometry.Down},
+		{"nothing left of the first column", 3, geometry.Left},
+		{"nothing right of the last column", 5, geometry.Right},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := geometry.Nearest(grid(), tt.current, tt.dir)
+			if ok {
+				t.Errorf("Nearest() = %d, true; want not found", got)
+			}
+		})
+	}
+}
+
+func TestNearest_SkipsUnreadableFrames(t *testing.T) {
+	frames := grid()
+	// The window directly above the middle cell cannot be read, so focus
+	// falls to the next best one in that direction rather than shifting
+	// every index below it.
+	frames[1] = nil
+
+	got, ok := geometry.Nearest(frames, 4, geometry.Up)
+	if !ok || got != 0 {
+		t.Errorf("Nearest(up) = %d, %v; want 0, true", got, ok)
+	}
+}
+
+func TestNearest_ReportsNotFoundWhenTheCurrentFrameIsUnusable(t *testing.T) {
+	frames := grid()
+	frames[4] = nil
+
+	tests := []struct {
+		name    string
+		frames  []*geometry.Rect
+		current int
+	}{
+		{"the current frame could not be read", frames, 4},
+		{"there is no current window", grid(), -1},
+		{"the current index is past the end", grid(), 9},
+		{"there are no windows at all", nil, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := geometry.Nearest(tt.frames, tt.current, geometry.Right)
+			if ok {
+				t.Errorf("Nearest() = %d, true; want not found", got)
+			}
+		})
+	}
+}

--- a/internal/geometry/rect.go
+++ b/internal/geometry/rect.go
@@ -1,0 +1,33 @@
+package geometry
+
+// Rect is a rectangle in points: an origin plus a size.
+//
+// Window rectangles use the Accessibility coordinate system — y-down, origin at
+// the primary display's top-left — which is the system every frame the action
+// layer reads from or writes to a window is expressed in.
+type Rect struct {
+	X float64
+	Y float64
+	W float64
+	H float64
+}
+
+// Right returns the x coordinate of the rectangle's right edge.
+func (r Rect) Right() float64 {
+	return r.X + r.W
+}
+
+// Bottom returns the y coordinate of the rectangle's bottom edge.
+func (r Rect) Bottom() float64 {
+	return r.Y + r.H
+}
+
+// CenterX returns the x coordinate of the rectangle's center.
+func (r Rect) CenterX() float64 {
+	return r.X + r.W/2
+}
+
+// CenterY returns the y coordinate of the rectangle's center.
+func (r Rect) CenterY() float64 {
+	return r.Y + r.H/2
+}


### PR DESCRIPTION
## Description

This PR reworks how `mimi action focus_window --up/--down/--left/--right` picks
its target. The rule a user sees is unchanged — focus moves to the nearest
window along the requested direction, with a window that lines up on the other
axis preferred over one that is closer but off to the side — but the arithmetic
now lives in its own dependency-free module instead of being tangled up with the
Accessibility calls that read each window's frame.

Two rough edges go with it. Windows whose frame macOS refuses to report no
longer shift the positions of the windows after them, so navigation can no
longer land on the wrong neighbour when one window on the space is unreadable.
And when two windows are equally good targets, the higher one wins, then the
leftmost, then the one macOS listed first — previously that fell out of the
order the windows happened to arrive in.

The one deliberate behaviour change is unreachable from the CLI: an unrecognised
direction now reports an invalid-input error instead of focusing an arbitrary
window. Argument parsing already rejects anything but the four directions, so no
invocation can reach it.

## Related Issues

Closes #62

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**No config, command, flag or hook surface changes.** The four direction flags,
their error messages for "no window found in that direction" and "current window
not found", and the exit codes behind them are all as they were.

**How equivalence was checked.** The recorded macOS baseline from #61 is the
oracle. A unit test replays every recorded arrangement through the new scoring
and asserts it picks the window macOS actually focused; it lives next to the
recording rather than in the new module, so that module's own test tree stays
free of every import outside the standard library. The integration recorder also
ran here against a live session and passed in all four directions, unchanged.

**Tie-breaking.** Making the rule explicit is a no-op against today's input: the
native layer already returns windows sorted by top edge, then left edge, then
process id, so "topmost, then leftmost, then first listed" picks exactly what
first-in-the-list picked. It stops the sort being an unwritten precondition held
three modules away in Objective-C.

**Known limitation.** The caller still has to check the current window's frame
before asking for a target, because a single "found nothing" answer cannot say
whether the current window was unreadable or whether there was simply nothing in
that direction — those are two different errors for the user. The duplicated
error *text* is gone; the guard is not.
