### PR TITLE
chore(build): vet the integration tier and run each test once in the gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,9 @@ Space switching and window-to-space moves ride undocumented private APIs and syn
 just build          # build bin/mimi
 just fmt            # format Go (golangci-lint) + Objective-C (clang-format)
 just lint           # golangci-lint run
-just vet            # go vet ./...
-just test           # unit + integration
-just test-unit      # unit only
+just vet            # go vet, untagged and integration builds
+just test           # unit + integration, one pass, each test once
+just test-unit      # unit tier only
 just bundle         # build build/Mimi.app
 just genman         # generate man pages
 ```

--- a/docs/testing/TESTING_PATTERNS.md
+++ b/docs/testing/TESTING_PATTERNS.md
@@ -19,6 +19,11 @@ func TestService_Method_EdgeCase(t *testing.T)
 | Unit        | `just test-unit`        | Business logic, algorithms, config validation with mocks                        |
 | Integration | `just test-integration` | Real macOS APIs, file system (tagged `//go:build integration`)                   |
 
+A build tag adds files to a build, it never narrows the build to them, so the
+`integration` build already contains the unit tier: `just test-integration`
+enables the integration tier on top of the unit tests rather than running the
+tagged tests alone.
+
 ## When to Use Each Type
 
 | Scenario           | Test Type   | Example                            |
@@ -116,6 +121,13 @@ than against a reading of the old code.
 
 ## Test Commands
 
-- `just test-unit` — Runs unit tests
-- `just test-integration` — Runs integration tests (`-tags=integration`)
+- `just test` — Runs every test exactly once: the one tagged pass, since it
+  already covers both tiers
+- `just test-unit` — Runs the unit tier alone, no Accessibility grant needed
+- `just test-integration` — Runs every test with the integration tier enabled
+  (`-tags=integration`)
 - `just test-race` — Runs all tests with race detection
+
+`just vet` vets both builds — untagged and `-tags=integration` — so a mistake in
+a `*_integration_test.go` file is caught even on a machine that cannot run the
+tier.

--- a/justfile
+++ b/justfile
@@ -60,30 +60,42 @@ bundle: release
     @echo "✓ Bundle complete: build/Mimi.app"
 
 # Run tests
+#
+# A build tag adds files to a build, it never narrows the build to them, so the
+# `integration` build already contains every unit test. `test` therefore runs
+# the tagged pass alone: one pass, both tiers, each test exactly once. This
+# holds only while nothing carries a negated constraint — a `//go:build
+# !integration` file would drop out of that pass and stop being run at all.
+#
+# Only the running of the tier is skipped without an Accessibility grant. The
+# tagged files still compile here and are still vetted by `just vet`.
 
-# Run all tests (unit + integration)
-test: test-unit test-integration
-    @echo "Running all tests..."
+# Run every test once (unit tier + integration tier)
+test: test-integration
+    @echo "✓ All tests complete"
 
-# Run unit tests
+# Run the unit tier alone — no Accessibility grant needed
 test-unit:
     @echo "Running unit tests..."
     go test -v ./...
 
+# Run every test with the integration tier enabled
 test-integration:
-    @echo "Running integration tests..."
+    @echo "Running tests with the integration tier enabled..."
     go test -tags=integration -v ./...
 
-test-race: test-race-unit test-race-integration
-    @echo "Running tests with race detection..."
+# Run every test once under the race detector (unit tier + integration tier)
+test-race: test-race-integration
+    @echo "✓ All race-detected tests complete"
 
+# Run the unit tier alone under the race detector
 test-race-unit:
     @echo "Running unit tests with race detection..."
     go test -race -v ./...
 
-# Run integration tests with race detection
+# Run every test with the integration tier enabled, under the race detector
 test-race-integration:
-    @echo "Running integration tests with race detection..."
+    @echo "Running tests with the integration tier enabled, with race detection..."
     go test -tags=integration -race -v ./...
 
 test-all: test test-race
@@ -143,10 +155,15 @@ lint:
     echo "Skipping Objective-C linting due to header issues"
     @echo "✓ Lint complete"
 
+# Two passes: the tagged build is the only one that sees `//go:build
+# integration` files at all, and the untagged build is the one everything
+# else — `just build`, `just test-unit`, every editor — compiles under.
+
 # Vet
 vet:
     @echo "Vetting code..."
     go vet ./...
+    go vet -tags=integration ./...
     @echo "✓ Vet complete"
 
 # Download dependencies


### PR DESCRIPTION
## Description

This PR fixes two defects in the gate recipes contributors and CI run.

`just vet` only ever vetted the untagged build, so the files behind the `integration` build tag were vetted by nothing — a mistake in one of them showed up only when someone happened to run that tier. It now vets both builds, because neither is a superset of the other.

`just test` ran the unit tests twice. It depended on the unit pass and then the integration pass, but a build tag adds files to a build rather than narrowing the build to them, so every untagged test ran in both. The integration build already contains the unit tier, so `just test` is now that single pass — same coverage, each test exactly once. `just test-race` had the same shape and gets the same treatment, which takes `just test-all` (what CI runs) from four passes to two. `just test-unit` and `just test-integration` are unchanged and still work standalone.

The one thing this depends on: it stays true only while no file carries a negated constraint such as `//go:build !integration`, which would drop out of the single pass. Nothing in the repo does today, and the justfile now says so where someone adding one would read it.

## Related Issues

Closes #68

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, this changes which builds the gate runs, not the code under test
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Verified rather than assumed: with a deliberate `Fatalf` format error added to an integration-tagged file, `go vet ./...` stayed silent and `go vet -tags=integration ./...` reported it. `internal/baseline` holds the only tagged files in the repo, all four with a bare `//go:build integration`, and no file anywhere carries a negated build constraint.

CI covers exactly what it covered before. The integration tier still skips itself without an Accessibility grant, as on CI, but the tagged files are still compiled by the test pass and now vetted by the vet job.

Measured locally with a cold test cache, Accessibility granted so the integration tier really runs:

| | before | after |
| --- | --- | --- |
| `just fmt && just lint && just vet && just test && just build` | 27.3s | 24.0s |
| `just test` | 25.0s | 12.0–19.5s |

The remaining spread is the recorded-baseline integration test, which varies between roughly 11s and 19s depending on how quickly windows settle. The saving is the removed unit pass — a flat ~7s from `just test`, and roughly another ~8s from `just test-race`, both of which CI pays through `just test-all`.

Docs touched are the two lines the change makes untrue: the command list in `AGENTS.md` and the test-command section of `docs/testing/TESTING_PATTERNS.md`, which now states the build-tag semantics once so the next reader does not re-derive them.
