### PR TITLE
refactor(action,geometry): move window resize geometry into a pure module

### DIFF
--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -5,8 +5,12 @@ import (
 	"strings"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
 	"github.com/y3owk1n/mimi/internal/space"
 )
+
+// percentageWhole is the largest percentage a size flag accepts.
+const percentageWhole = 100.0
 
 // Name identifies a supported action subcommand.
 type Name string
@@ -125,63 +129,34 @@ func (s spaceArg) resolve() (int, error) {
 	return s.index, nil
 }
 
-// parsedResizeWindowArgs holds parsed flags for the resize_window action.
-type parsedResizeWindowArgs struct {
-	preset    string
-	width     int
-	height    int
-	widthPct  float64
-	heightPct float64
-	x         int
-	y         int
-	anchor    string
-	hasX      bool
-	hasY      bool
-	useMargin *bool // nil = system default
-}
-
-// validAnchors for window positioning.
-var validAnchors = map[string]bool{
-	"tl": true, "tc": true, "tr": true,
-	"cl": true, "cc": true, "cr": true,
-	"bl": true, "bc": true, "br": true,
-}
-
-// resizePresets maps preset names to dimension percentages and anchor.
-var resizePresets = map[string]struct {
-	widthPct  float64
-	heightPct float64
-	anchor    string
-}{
-	"left-half":    {50, 100, "tl"},
-	"right-half":   {50, 100, "tr"},
-	"top-half":     {100, 50, "tl"},
-	"bottom-half":  {100, 50, "bl"},
-	"top-left":     {50, 50, "tl"},
-	"top-right":    {50, 50, "tr"},
-	"bottom-left":  {50, 50, "bl"},
-	"bottom-right": {50, 50, "br"},
-	"center":       {60, 80, "cc"},
-	"fill":         {100, 100, "tl"},
-}
-
 // IsResizePreset reports whether s is a known resize window preset.
 func IsResizePreset(s string) bool {
-	_, ok := resizePresets[s]
-
-	return ok
+	return geometry.IsPreset(s)
 }
 
-func parseResizeWindowArgs(rawArgs []string) (parsedResizeWindowArgs, error) {
-	var parsed parsedResizeWindowArgs
-
-	parsed.anchor = "cc"
+// ParseResizeRequest turns resize_window's command line into the geometry
+// request it describes.
+//
+// The optional fields are pointers because their absence is a real input to
+// the geometry — an anchor nobody gave is what lets a preset supply one, and a
+// margin preference nobody expressed is what defers to the system setting.
+//
+// A zero --width or --width-percent keeps the window's current size rather
+// than collapsing it, which is the convention the CLI has always followed.
+func ParseResizeRequest(rawArgs []string) (geometry.Request, error) {
+	var (
+		req                         geometry.Request
+		width, height               float64
+		widthPercent, heightPercent float64
+		posX, posY                  float64
+		hasPosX, hasPosY            bool
+	)
 
 	args := rawArgs
 
 	// Check for preset as first positional arg
 	if len(args) > 0 && IsResizePreset(args[0]) {
-		parsed.preset = args[0]
+		req.Preset = args[0]
 		args = args[1:]
 	}
 
@@ -192,155 +167,163 @@ func parseResizeWindowArgs(rawArgs []string) (parsedResizeWindowArgs, error) {
 		switch arg {
 		case "--width", "-w":
 			if argIndex+1 >= len(args) {
-				return parsed, derrors.New(derrors.CodeInvalidInput, "--width requires a value")
+				return req, derrors.New(derrors.CodeInvalidInput, "--width requires a value")
 			}
 
-			width, err := strconv.Atoi(args[argIndex+1])
-			if err != nil || width < 0 {
-				return parsed, derrors.Newf(
+			points, err := strconv.Atoi(args[argIndex+1])
+			if err != nil || points < 0 {
+				return req, derrors.Newf(
 					derrors.CodeInvalidInput,
 					"invalid width: %q",
 					args[argIndex+1],
 				)
 			}
 
-			parsed.width = width
+			width = float64(points)
 			argIndex++
 		case "--height", "-h":
 			if argIndex+1 >= len(args) {
-				return parsed, derrors.New(derrors.CodeInvalidInput, "--height requires a value")
+				return req, derrors.New(derrors.CodeInvalidInput, "--height requires a value")
 			}
 
-			height, err := strconv.Atoi(args[argIndex+1])
-			if err != nil || height < 0 {
-				return parsed, derrors.Newf(
+			points, err := strconv.Atoi(args[argIndex+1])
+			if err != nil || points < 0 {
+				return req, derrors.Newf(
 					derrors.CodeInvalidInput,
 					"invalid height: %q",
 					args[argIndex+1],
 				)
 			}
 
-			parsed.height = height
+			height = float64(points)
 			argIndex++
 		case "--width-percent":
 			if argIndex+1 >= len(args) {
-				return parsed, derrors.New(
+				return req, derrors.New(
 					derrors.CodeInvalidInput,
 					"--width-percent requires a value",
 				)
 			}
 
-			widthPercent, err := strconv.ParseFloat(args[argIndex+1], 64)
-			if err != nil || widthPercent < 0 || widthPercent > 100 {
-				return parsed, derrors.Newf(
+			share, err := strconv.ParseFloat(args[argIndex+1], 64)
+			if err != nil || share < 0 || share > percentageWhole {
+				return req, derrors.Newf(
 					derrors.CodeInvalidInput,
 					"invalid width-percent: %q (0-100)",
 					args[argIndex+1],
 				)
 			}
 
-			parsed.widthPct = widthPercent
+			widthPercent = share
 			argIndex++
 		case "--height-percent":
 			if argIndex+1 >= len(args) {
-				return parsed, derrors.New(
+				return req, derrors.New(
 					derrors.CodeInvalidInput,
 					"--height-percent requires a value",
 				)
 			}
 
-			heightPercent, err := strconv.ParseFloat(args[argIndex+1], 64)
-			if err != nil || heightPercent < 0 || heightPercent > 100 {
-				return parsed, derrors.Newf(
+			share, err := strconv.ParseFloat(args[argIndex+1], 64)
+			if err != nil || share < 0 || share > percentageWhole {
+				return req, derrors.Newf(
 					derrors.CodeInvalidInput,
 					"invalid height-percent: %q (0-100)",
 					args[argIndex+1],
 				)
 			}
 
-			parsed.heightPct = heightPercent
+			heightPercent = share
 			argIndex++
 		case "--x":
 			if argIndex+1 >= len(args) {
-				return parsed, derrors.New(derrors.CodeInvalidInput, "--x requires a value")
+				return req, derrors.New(derrors.CodeInvalidInput, "--x requires a value")
 			}
 
-			xCoord, err := strconv.Atoi(args[argIndex+1])
+			coord, err := strconv.Atoi(args[argIndex+1])
 			if err != nil {
-				return parsed, derrors.Newf(
+				return req, derrors.Newf(
 					derrors.CodeInvalidInput,
 					"invalid x: %q",
 					args[argIndex+1],
 				)
 			}
 
-			parsed.x = xCoord
-			parsed.hasX = true
+			posX, hasPosX = float64(coord), true
 			argIndex++
 		case "--y":
 			if argIndex+1 >= len(args) {
-				return parsed, derrors.New(derrors.CodeInvalidInput, "--y requires a value")
+				return req, derrors.New(derrors.CodeInvalidInput, "--y requires a value")
 			}
 
-			yCoord, err := strconv.Atoi(args[argIndex+1])
+			coord, err := strconv.Atoi(args[argIndex+1])
 			if err != nil {
-				return parsed, derrors.Newf(
+				return req, derrors.Newf(
 					derrors.CodeInvalidInput,
 					"invalid y: %q",
 					args[argIndex+1],
 				)
 			}
 
-			parsed.y = yCoord
-			parsed.hasY = true
+			posY, hasPosY = float64(coord), true
 			argIndex++
 		case "--anchor", "-a":
 			if argIndex+1 >= len(args) {
-				return parsed, derrors.New(derrors.CodeInvalidInput, "--anchor requires a value")
+				return req, derrors.New(derrors.CodeInvalidInput, "--anchor requires a value")
 			}
 
-			anchorVal := args[argIndex+1]
-			if !validAnchors[anchorVal] {
-				return parsed, derrors.Newf(
+			anchor, ok := geometry.ParseAnchor(args[argIndex+1])
+			if !ok {
+				return req, derrors.Newf(
 					derrors.CodeInvalidInput,
 					"invalid anchor: %q (use tl, tc, tr, cl, cc, cr, bl, bc, br)",
-					anchorVal,
+					args[argIndex+1],
 				)
 			}
 
-			parsed.anchor = anchorVal
+			req.Anchor = &anchor
 			argIndex++
 		case "--margin":
-			val := true
-			parsed.useMargin = &val
+			useMargins := true
+			req.UseMargins = &useMargins
 		case "--no-margin":
-			val := false
-			parsed.useMargin = &val
+			useMargins := false
+			req.UseMargins = &useMargins
 		default:
 			if strings.HasPrefix(arg, "--") {
-				return parsed, derrors.Newf(derrors.CodeInvalidInput, "unknown flag: %s", arg)
+				return req, derrors.Newf(derrors.CodeInvalidInput, "unknown flag: %s", arg)
 			}
 
-			return parsed, derrors.Newf(derrors.CodeInvalidInput, "unexpected argument: %s", arg)
+			return req, derrors.Newf(derrors.CodeInvalidInput, "unexpected argument: %s", arg)
 		}
 	}
 
-	// If preset given, apply its values as defaults (can be overridden by explicit flags)
-	if parsed.preset != "" {
-		preset, ok := resizePresets[parsed.preset]
-		if ok {
-			parsed.anchor = preset.anchor
-			if parsed.widthPct == 0 && parsed.width == 0 {
-				parsed.widthPct = preset.widthPct
-			}
+	req.Width = dimensionOf(width, widthPercent)
+	req.Height = dimensionOf(height, heightPercent)
 
-			if parsed.heightPct == 0 && parsed.height == 0 {
-				parsed.heightPct = preset.heightPct
-			}
-		}
+	if hasPosX {
+		req.X = &posX
 	}
 
-	return parsed, nil
+	if hasPosY {
+		req.Y = &posY
+	}
+
+	return req, nil
+}
+
+// dimensionOf folds one axis's two size flags into the dimension they
+// describe. An absolute size wins over a percentage, and a zero of either
+// means the flag was never given, so the window keeps the size it has.
+func dimensionOf(points, percent float64) geometry.Dimension {
+	switch {
+	case points > 0:
+		return geometry.Absolute(points)
+	case percent > 0:
+		return geometry.Percent(percent)
+	default:
+		return geometry.Keep()
+	}
 }
 
 // Execute runs a named action with the given arguments.
@@ -378,12 +361,12 @@ func Execute(name string, args []string) error {
 
 		return MoveWindowToSpace(index)
 	case NameResizeWindow:
-		parsed, err := parseResizeWindowArgs(args)
+		req, err := ParseResizeRequest(args)
 		if err != nil {
 			return err
 		}
 
-		return ResizeWindow(parsed)
+		return ResizeWindow(req)
 	default:
 		return derrors.Newf(
 			derrors.CodeInvalidInput,

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -23,9 +23,13 @@ const (
 	presetCenter      = "center"
 	presetFill        = "fill"
 
-	flagWidth = "--width"
-	flagUp    = "--up"
-	flagDown  = "--down"
+	flagWidth         = "--width"
+	flagHeight        = "--height"
+	flagWidthPercent  = "--width-percent"
+	flagHeightPercent = "--height-percent"
+	flagAnchor        = "--anchor"
+	flagUp            = "--up"
+	flagDown          = "--down"
 )
 
 func TestIsKnownName(t *testing.T) {
@@ -216,7 +220,7 @@ func TestExecute_ResizeWindowPresets(t *testing.T) {
 func TestExecute_ResizeWindowInvalidAnchor(t *testing.T) {
 	t.Parallel()
 
-	err := action.Execute("resize_window", []string{"--anchor", "xx"})
+	err := action.Execute("resize_window", []string{flagAnchor, "xx"})
 	if err == nil {
 		t.Fatal("Execute(resize_window --anchor xx) expected error")
 	}
@@ -242,7 +246,7 @@ func TestExecute_ResizeWindowInvalidWidth(t *testing.T) {
 func TestExecute_ResizeWindowInvalidWidthPercent(t *testing.T) {
 	t.Parallel()
 
-	err := action.Execute("resize_window", []string{"--width-percent", "150"})
+	err := action.Execute("resize_window", []string{flagWidthPercent, "150"})
 	if err == nil {
 		t.Fatal("Execute(resize_window --width-percent 150) expected error")
 	}
@@ -259,8 +263,8 @@ func TestExecute_ResizeWindowWithFlags(t *testing.T) {
 	// will fail because there's no window open in the test environment.
 	err := action.Execute("resize_window", []string{
 		flagWidth, "800",
-		"--height", "600",
-		"--anchor", "cc",
+		flagHeight, "600",
+		flagAnchor, "cc",
 	})
 
 	if derrors.IsCode(err, derrors.CodeInvalidInput) {

--- a/internal/action/perform.go
+++ b/internal/action/perform.go
@@ -8,12 +8,6 @@ import (
 	"github.com/y3owk1n/mimi/internal/window"
 )
 
-const (
-	percentage100  = 100.0
-	divisionFactor = 2.0
-	marginDivisor  = 2
-)
-
 func ensureAccessibility() error {
 	return permissions.FriendlyError(permissions.Check())
 }
@@ -180,8 +174,11 @@ func MoveWindowToSpace(index int) error {
 	return nil
 }
 
-// ResizeWindow resizes and repositions the frontmost window according to the given args.
-func ResizeWindow(args parsedResizeWindowArgs) error {
+// ResizeWindow resizes and repositions the frontmost window to satisfy req.
+//
+// It reads the window and its screen from macOS, hands both to the pure
+// geometry, and writes back the frame it returns.
+func ResizeWindow(req geometry.Request) error {
 	err := ensureAccessibility()
 	if err != nil {
 		return err
@@ -198,116 +195,48 @@ func ResizeWindow(args parsedResizeWindowArgs) error {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get window frame")
 	}
 
-	// Get the visible frame of the screen containing the window (in NSScreen y-up coords)
-	screenX, screenY, screenWidth, screenHeight, err := window.ScreenVisibleFrame(curX, curY)
+	current := geometry.Rect{X: curX, Y: curY, W: curW, H: curH}
+
+	screen, err := screenAt(current)
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get screen frame")
+		return err
 	}
 
-	// Get the primary screen height for AX ↔ NSScreen coordinate conversion.
-	// AX uses y-down (top-left origin at the primary screen's top). NSScreen uses
-	// y-up (bottom-left origin at the primary screen's bottom). The primary screen's
-	// height is the constant that relates the two systems.
+	target := geometry.Resize(current, screen, req)
+
+	return win.SetFrame(target.X, target.Y, target.W, target.H)
+}
+
+// screenAt reads everything the geometry has to know about the display the
+// given window is on.
+func screenAt(current geometry.Rect) (geometry.Screen, error) {
+	// The visible frame of the screen containing the window, in NSScreen y-up
+	// coordinates.
+	visX, visY, visW, visH, err := window.ScreenVisibleFrame(current.X, current.Y)
+	if err != nil {
+		return geometry.Screen{}, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to get screen frame",
+		)
+	}
+
+	// The primary screen's height, which is the constant relating the y-up
+	// screen coordinates to the y-down window ones. Resize applies the
+	// conversion itself.
 	primaryH, err := window.PrimaryScreenHeight()
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get primary screen height")
+		return geometry.Screen{}, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to get primary screen height",
+		)
 	}
 
-	// Convert the visible frame's top edge from NSScreen y-up to AX y-down:
-	//   y-down top = primaryScreenHeight - visibleFrameY - visibleFrameHeight
-	syd := primaryH - screenY - screenHeight
-
-	// Determine if margins should be applied
-	useMargins := window.TiledWindowMarginsEnabled()
-	if args.useMargin != nil {
-		useMargins = *args.useMargin
-	}
-
-	// Compute target dimensions from screen visible frame (in y-down)
-	newW := curW
-	switch {
-	case args.width > 0:
-		newW = float64(args.width)
-	case args.widthPct > 0:
-		newW = screenWidth * args.widthPct / percentage100
-	}
-
-	newH := curH
-	switch {
-	case args.height > 0:
-		newH = float64(args.height)
-	case args.heightPct > 0:
-		newH = screenHeight * args.heightPct / percentage100
-	}
-
-	// Compute target position from anchor (relative to visible frame in y-down)
-	vert := args.anchor[0]  // 't', 'c', 'b'
-	horiz := args.anchor[1] // 'l', 'c', 'r'
-
-	var targetX, targetY float64
-
-	if args.hasX {
-		targetX = float64(args.x)
-	} else {
-		switch horiz {
-		case 'l':
-			targetX = screenX
-		case 'c':
-			targetX = screenX + (screenWidth-newW)/divisionFactor
-		case 'r':
-			targetX = screenX + screenWidth - newW
-		}
-	}
-
-	if args.hasY {
-		targetY = float64(args.y)
-	} else {
-		switch vert {
-		case 't':
-			targetY = syd
-		case 'c':
-			targetY = syd + (screenHeight-newH)/divisionFactor
-		case 'b':
-			targetY = syd + screenHeight - newH
-		}
-	}
-
-	// Apply margins: full margin on edges that abut the visible frame boundary,
-	// half margin on internal edges (split between windows). This matches macOS
-	// behavior where the gap between two tiled windows is margin (not 2*margin).
-	if useMargins {
-		marginSize := window.TiledWindowMarginSize()
-
-		leftExt := targetX == screenX
-		rightExt := targetX+newW == screenX+screenWidth
-		topExt := targetY == syd
-		botExt := targetY+newH == syd+screenHeight
-
-		leftMargin := marginSize
-		if !leftExt {
-			leftMargin = marginSize / marginDivisor
-		}
-
-		rightMargin := marginSize
-		if !rightExt {
-			rightMargin = marginSize / marginDivisor
-		}
-
-		topMargin := marginSize
-		if !topExt {
-			topMargin = marginSize / marginDivisor
-		}
-
-		bottomMargin := marginSize
-		if !botExt {
-			bottomMargin = marginSize / marginDivisor
-		}
-
-		targetX += leftMargin
-		newW -= leftMargin + rightMargin
-		targetY += topMargin
-		newH -= topMargin + bottomMargin
-	}
-
-	return win.SetFrame(targetX, targetY, newW, newH)
+	return geometry.Screen{
+		Visible:        geometry.Rect{X: visX, Y: visY, W: visW, H: visH},
+		PrimaryHeight:  primaryH,
+		MarginsEnabled: window.TiledWindowMarginsEnabled(),
+		MarginSize:     window.TiledWindowMarginSize(),
+	}, nil
 }

--- a/internal/action/resize_test.go
+++ b/internal/action/resize_test.go
@@ -1,0 +1,195 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// TestParseResizeRequest_MapsFlagsOntoTheGeometryRequest covers the flag
+// spellings whose meaning is decided here rather than in the geometry: which
+// of the three dimension kinds a size flag produces, and which of the optional
+// fields a flag makes explicit.
+func TestParseResizeRequest_MapsFlagsOntoTheGeometryRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want geometry.Request
+	}{
+		{
+			name: "no arguments ask for nothing",
+			args: nil,
+			want: geometry.Request{},
+		},
+		{
+			name: "a preset is taken from the first positional argument",
+			args: []string{presetLeftHalf},
+			want: geometry.Request{Preset: presetLeftHalf},
+		},
+		{
+			name: "absolute sizes",
+			args: []string{flagWidth, "800", flagHeight, "600"},
+			want: geometry.Request{
+				Width:  geometry.Absolute(800),
+				Height: geometry.Absolute(600),
+			},
+		},
+		{
+			name: "percentage sizes",
+			args: []string{flagWidthPercent, "45", flagHeightPercent, "55"},
+			want: geometry.Request{
+				Width:  geometry.Percent(45),
+				Height: geometry.Percent(55),
+			},
+		},
+		{
+			name: "an absolute size wins over a percentage one",
+			args: []string{flagWidth, "800", flagWidthPercent, "45"},
+			want: geometry.Request{Width: geometry.Absolute(800)},
+		},
+		{
+			name: "an explicit position",
+			args: []string{"--x", "100", "--y", "230"},
+			want: geometry.Request{X: new(100.0), Y: new(230.0)},
+		},
+		{
+			name: "a negative position is accepted, for displays left of the primary",
+			args: []string{"--x", "-1920"},
+			want: geometry.Request{X: new(-1920.0)},
+		},
+		{
+			name: "an anchor",
+			args: []string{flagAnchor, "br"},
+			want: geometry.Request{Anchor: new(geometry.BottomRight)},
+		},
+		{
+			name: "margins forced on",
+			args: []string{"--margin"},
+			want: geometry.Request{UseMargins: new(true)},
+		},
+		{
+			name: "margins forced off",
+			args: []string{"--no-margin"},
+			want: geometry.Request{UseMargins: new(false)},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := action.ParseResizeRequest(testCase.args)
+			if err != nil {
+				t.Fatalf("ParseResizeRequest(%v) error = %v", testCase.args, err)
+			}
+
+			assertRequest(t, got, testCase.want)
+		})
+	}
+}
+
+// TestParseResizeRequest_ZeroSizeKeepsTheCurrentOne pins the CLI convention
+// that a zero size flag means "not given": the window keeps the size it has,
+// or takes the one a preset or a percentage supplies.
+func TestParseResizeRequest_ZeroSizeKeepsTheCurrentOne(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want geometry.Request
+	}{
+		{
+			name: "a zero width keeps the current width",
+			args: []string{flagWidth, "0", flagHeight, "0"},
+			want: geometry.Request{Width: geometry.Keep(), Height: geometry.Keep()},
+		},
+		{
+			name: "a zero percentage keeps the current size too",
+			args: []string{flagWidthPercent, "0"},
+			want: geometry.Request{Width: geometry.Keep()},
+		},
+		{
+			name: "a zero width still leaves a percentage to apply",
+			args: []string{flagWidth, "0", flagWidthPercent, "45"},
+			want: geometry.Request{Width: geometry.Percent(45)},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := action.ParseResizeRequest(testCase.args)
+			if err != nil {
+				t.Fatalf("ParseResizeRequest(%v) error = %v", testCase.args, err)
+			}
+
+			assertRequest(t, got, testCase.want)
+		})
+	}
+}
+
+// TestParseResizeRequest_ZeroWidthLeavesTheWindowAsWide pins the same
+// convention end to end: a zero width reaches the geometry as a kept
+// dimension, so the frame it produces is as wide as the window already was.
+func TestParseResizeRequest_ZeroWidthLeavesTheWindowAsWide(t *testing.T) {
+	t.Parallel()
+
+	req, err := action.ParseResizeRequest([]string{flagWidth, "0"})
+	if err != nil {
+		t.Fatalf("ParseResizeRequest(--width 0) error = %v", err)
+	}
+
+	screen := geometry.Screen{
+		Visible:       geometry.Rect{X: 0, Y: 0, W: 1920, H: 1050},
+		PrimaryHeight: 1080,
+	}
+	current := geometry.Rect{X: 300, Y: 180, W: 700, H: 500}
+
+	if got := geometry.Resize(current, screen, req); got.W != current.W {
+		t.Errorf("Resize(--width 0) = %v, want the current width %v", got, current.W)
+	}
+}
+
+// assertRequest compares two requests field by field, following the pointers
+// the optional fields are expressed with.
+func assertRequest(t *testing.T, got, want geometry.Request) {
+	t.Helper()
+
+	if got.Preset != want.Preset {
+		t.Errorf("Preset = %q, want %q", got.Preset, want.Preset)
+	}
+
+	if got.Width != want.Width {
+		t.Errorf("Width = %+v, want %+v", got.Width, want.Width)
+	}
+
+	if got.Height != want.Height {
+		t.Errorf("Height = %+v, want %+v", got.Height, want.Height)
+	}
+
+	assertPointer(t, "X", got.X, want.X)
+	assertPointer(t, "Y", got.Y, want.Y)
+	assertPointer(t, "Anchor", got.Anchor, want.Anchor)
+	assertPointer(t, "UseMargins", got.UseMargins, want.UseMargins)
+}
+
+// assertPointer compares one optional field, whose nil is what "the user did
+// not say" is expressed with.
+func assertPointer[T comparable](t *testing.T, name string, got, want *T) {
+	t.Helper()
+
+	switch {
+	case got == nil && want == nil:
+	case got == nil:
+		t.Errorf("%s = nil, want %v", name, *want)
+	case want == nil:
+		t.Errorf("%s = %v, want nil", name, *got)
+	case *got != *want:
+		t.Errorf("%s = %v, want %v", name, *got, *want)
+	}
+}

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
 )
 
 // FileName is the name of the recording file inside this package's directory.
@@ -31,6 +32,17 @@ func (r Rect) String() string {
 	return fmt.Sprintf("%g,%g %gx%g", r.X, r.Y, r.W, r.H)
 }
 
+// Geometry returns the rectangle as the geometry module's, which holds the
+// same four fields.
+//
+// The recording keeps a type of its own so that the names the frames are
+// stored under stay a property of this file format rather than of the pure
+// module, and so that re-recording is never needed to change one. This is the
+// single place the two are converted.
+func (r Rect) Geometry() geometry.Rect {
+	return geometry.Rect(r)
+}
+
 // Display is everything the action layer had to ask macOS about the screen when
 // the recording was made. A recording is only replayable against a display that
 // reports the same values, which is why the whole set is stored.
@@ -44,6 +56,17 @@ type Display struct {
 	MarginsEnabled bool `json:"marginsEnabled"`
 	// MarginSize is the system tiled-window margin, in points.
 	MarginSize float64 `json:"marginSize"`
+}
+
+// Screen returns the display as the geometry module's screen — the same set of
+// values, which is what the recording stores it for.
+func (d Display) Screen() geometry.Screen {
+	return geometry.Screen{
+		Visible:        d.Visible.Geometry(),
+		PrimaryHeight:  d.PrimaryHeight,
+		MarginsEnabled: d.MarginsEnabled,
+		MarginSize:     d.MarginSize,
+	}
 }
 
 // ResizeCase is one recorded resize_window invocation: the flags, the frame the

--- a/internal/baseline/geometry_baseline_test.go
+++ b/internal/baseline/geometry_baseline_test.go
@@ -1,11 +1,70 @@
 package baseline_test
 
 import (
+	"math"
 	"testing"
 
+	"github.com/y3owk1n/mimi/internal/action"
 	"github.com/y3owk1n/mimi/internal/baseline"
 	"github.com/y3owk1n/mimi/internal/geometry"
 )
+
+// quantum is how far a computed frame may sit from the recorded one.
+//
+// macOS stores window frames in whole points: every frame in the recording was
+// read back after the Accessibility API had truncated the one it was handed.
+// Forty-seven of the forty-nine recorded cases are whole points already and
+// match exactly; the two percentage ones are fractional, and the truncation
+// moves them by less than a point. Nothing the geometry itself could get wrong
+// is that small — the margin rules move an edge by four points, the anchors
+// and dimensions by hundreds.
+const quantum = 1.0
+
+// TestResize_ReproducesTheRecordedFrames replays every recorded resize_window
+// invocation through the argument parsing and the pure geometry, and checks it
+// arrives at the frame macOS actually produced. This is the equivalence oracle
+// for the extraction: it lives here, next to the recording, so that
+// internal/geometry stays free of every import outside the standard library.
+func TestResize_ReproducesTheRecordedFrames(t *testing.T) {
+	recording, err := baseline.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(recording.Resize) == 0 {
+		t.Fatal("the recording holds no resize cases")
+	}
+
+	screen := recording.Display.Screen()
+
+	for _, resize := range recording.Resize {
+		t.Run(resize.Name, func(t *testing.T) {
+			req, err := action.ParseResizeRequest(resize.Args)
+			if err != nil {
+				t.Fatalf("ParseResizeRequest(%v) error = %v", resize.Args, err)
+			}
+
+			got := baseline.Rect(geometry.Resize(resize.Start.Geometry(), screen, req))
+			if !within(got, resize.Want) {
+				t.Errorf(
+					"resize_window %v computed %s, macOS produced %s",
+					resize.Args,
+					got,
+					resize.Want,
+				)
+			}
+		})
+	}
+}
+
+// within reports whether two frames agree to within the point macOS quantizes
+// a frame to.
+func within(got, want baseline.Rect) bool {
+	return math.Abs(got.X-want.X) < quantum &&
+		math.Abs(got.Y-want.Y) < quantum &&
+		math.Abs(got.W-want.W) < quantum &&
+		math.Abs(got.H-want.H) < quantum
+}
 
 // TestNearest_ReproducesTheRecordedFocusTargets replays every recorded
 // focus_window arrangement through the pure geometry and checks it picks the
@@ -32,7 +91,8 @@ func TestNearest_ReproducesTheRecordedFocusTargets(t *testing.T) {
 			frames := make([]*geometry.Rect, 0, len(focus.Arrangement))
 
 			for _, rect := range focus.Arrangement {
-				frames = append(frames, &geometry.Rect{X: rect.X, Y: rect.Y, W: rect.W, H: rect.H})
+				frame := rect.Geometry()
+				frames = append(frames, &frame)
 			}
 
 			got, found := geometry.Nearest(frames, focus.Current, dir)

--- a/internal/geometry/resize.go
+++ b/internal/geometry/resize.go
@@ -1,0 +1,351 @@
+package geometry
+
+// percentageWhole is the denominator a percentage dimension is taken over.
+const percentageWhole = 100.0
+
+// bothSides splits a length between the two sides that share it: the leftover
+// space either side of a centered window, and the margin between two tiled
+// windows.
+const bothSides = 2.0
+
+// Screen is everything the geometry has to know about the display a window is
+// being placed on — the set the action layer reads from macOS before it can
+// compute anything.
+type Screen struct {
+	// Visible is the screen's visible frame — the full frame less the menu bar
+	// and the Dock — in NSScreen coordinates: y-up, with the origin at the
+	// primary display's bottom-left, exactly as macOS reports it.
+	Visible Rect
+	// PrimaryHeight is the primary display's height. It is the constant that
+	// relates the y-up screen coordinates to the y-down window ones, and Resize
+	// applies the conversion itself so that no caller can forget to.
+	PrimaryHeight float64
+	// MarginsEnabled is the system tiled-window-margins setting, used when the
+	// request expresses no preference of its own.
+	MarginsEnabled bool
+	// MarginSize is the system tiled-window margin, in points.
+	MarginSize float64
+}
+
+// Request is what the user asked for. Every field is optional; the zero
+// Request keeps the window's current size and centers it.
+type Request struct {
+	// Preset is a named tiling shortcut, or "" for none. An unknown name is
+	// ignored — IsPreset is what turns one into an error, at parse time.
+	Preset string
+	// Width and Height are the size asked for: a length in points, a share of
+	// the visible frame, or the window's current size.
+	Width  Dimension
+	Height Dimension
+	// X and Y place the window's origin explicitly, in window coordinates
+	// (y-down). A nil coordinate is derived from the anchor instead.
+	X *float64
+	Y *float64
+	// Anchor is where inside the visible frame the window is placed. A nil
+	// anchor centers the window, unless a preset supplies one.
+	Anchor *Anchor
+	// UseMargins overrides the system tiled-window-margins setting. A nil
+	// preference follows the system.
+	UseMargins *bool
+}
+
+// dimensionKind is how a requested dimension is expressed.
+type dimensionKind uint8
+
+const (
+	// keepKind holds the window's current size, and is the zero dimension.
+	keepKind dimensionKind = iota
+	// absoluteKind is a length in points.
+	absoluteKind
+	// percentKind is a share of the screen's visible frame.
+	percentKind
+)
+
+// Dimension is one requested window dimension: a length in points, a share of
+// the visible frame, or the current size kept as it is. The zero Dimension
+// keeps the current size.
+//
+// The three are ordered rather than combined: a dimension is exactly one of
+// them, so nothing has to fall through from one to the next at placement time.
+type Dimension struct {
+	kind  dimensionKind
+	value float64
+}
+
+// Keep leaves the window's current size along this axis untouched.
+//
+// The CLI maps a zero --width or --width-percent onto it, which is how a zero
+// stays inert rather than collapsing the window.
+func Keep() Dimension {
+	return Dimension{}
+}
+
+// Absolute is a size in points.
+func Absolute(points float64) Dimension {
+	return Dimension{kind: absoluteKind, value: points}
+}
+
+// Percent is a size given as a share of the screen's visible frame, from 0
+// to 100.
+func Percent(share float64) Dimension {
+	return Dimension{kind: percentKind, value: share}
+}
+
+// resolve turns the requested dimension into a length, given the window's
+// current length along that axis and the visible frame's.
+func (d Dimension) resolve(current, available float64) float64 {
+	switch d.kind {
+	case absoluteKind:
+		return d.value
+	case percentKind:
+		return available * d.value / percentageWhole
+	case keepKind:
+		return current
+	default:
+		return current
+	}
+}
+
+// Resize returns the frame a window at cur should be moved to on scr to
+// satisfy req.
+//
+// It is total: every input produces a frame. An unknown preset name is
+// ignored, and nothing here reports an error.
+//
+// cur and the returned frame are in window coordinates — y-down, origin at the
+// primary display's top-left — while scr.Visible is in screen coordinates.
+// Resize converts between the two.
+func Resize(cur Rect, scr Screen, req Request) Rect {
+	req = expandPreset(req)
+
+	width := req.Width.resolve(cur.W, scr.Visible.W)
+	height := req.Height.resolve(cur.H, scr.Visible.H)
+
+	// The visible frame in window coordinates. Its top edge is the one line
+	// that converts between the two systems:
+	//
+	//	y-down top = primaryHeight - visibleFrameY - visibleFrameHeight
+	//
+	// Everything below this point is in window coordinates.
+	bounds := Rect{
+		X: scr.Visible.X,
+		Y: scr.PrimaryHeight - scr.Visible.Y - scr.Visible.H,
+		W: scr.Visible.W,
+		H: scr.Visible.H,
+	}
+
+	anchor := Center
+	if req.Anchor != nil {
+		anchor = *req.Anchor
+	}
+
+	posX := anchor.originX(bounds, width)
+	if req.X != nil {
+		posX = *req.X
+	}
+
+	posY := anchor.originY(bounds, height)
+	if req.Y != nil {
+		posY = *req.Y
+	}
+
+	frame := Rect{X: posX, Y: posY, W: width, H: height}
+
+	useMargins := scr.MarginsEnabled
+	if req.UseMargins != nil {
+		useMargins = *req.UseMargins
+	}
+
+	if useMargins {
+		frame = inset(frame, bounds, scr.MarginSize)
+	}
+
+	return frame
+}
+
+// inset applies the tiled-window margin to a frame: a full margin on each edge
+// that abuts the visible frame's boundary, half a margin on each internal one,
+// so that the gap between two tiled windows is one margin rather than two.
+//
+// Two known defects live here, both preserved from the code this replaced. An
+// edge abuts only on exact float equality, so a window a fraction of a point
+// off the boundary is treated as internal (issue #66); and nothing stops the
+// margins from driving a width or height to zero or below (issue #65).
+func inset(frame, bounds Rect, size float64) Rect {
+	left := marginOn(frame.X == bounds.X, size)
+	right := marginOn(frame.Right() == bounds.Right(), size)
+	top := marginOn(frame.Y == bounds.Y, size)
+	bottom := marginOn(frame.Bottom() == bounds.Bottom(), size)
+
+	frame.X += left
+	frame.W -= left + right
+	frame.Y += top
+	frame.H -= top + bottom
+
+	return frame
+}
+
+// marginOn returns the margin one edge takes: the whole of it when the edge
+// abuts the visible frame's boundary, half of it when the edge is internal and
+// the gap is shared with whatever is tiled alongside.
+func marginOn(abuts bool, size float64) float64 {
+	if abuts {
+		return size
+	}
+
+	return size / bothSides
+}
+
+// expandPreset fills in what the request's named preset asks for: its
+// percentages wherever the request keeps the current size, and its anchor. An
+// unknown name — including the empty one — leaves the request untouched.
+//
+// The preset's anchor is applied unconditionally, so a preset silently
+// overrides an anchor the user gave explicitly. That is what the CLI does
+// today; see issue #64.
+func expandPreset(req Request) Request {
+	named, ok := presets[req.Preset]
+	if !ok {
+		return req
+	}
+
+	anchor := named.anchor
+	req.Anchor = &anchor
+
+	if req.Width.kind == keepKind {
+		req.Width = Percent(named.widthPercent)
+	}
+
+	if req.Height.kind == keepKind {
+		req.Height = Percent(named.heightPercent)
+	}
+
+	return req
+}
+
+// Anchor is one of the nine positions a window can be placed at inside the
+// screen's visible frame.
+type Anchor uint8
+
+// The nine anchors, named vertical-first to match the two-letter form the CLI
+// takes ("tl", "cc", "br").
+const (
+	TopLeft Anchor = iota
+	TopCenter
+	TopRight
+	CenterLeft
+	Center
+	CenterRight
+	BottomLeft
+	BottomCenter
+	BottomRight
+)
+
+// anchorNames maps each anchor onto the two-letter name the CLI uses.
+var anchorNames = map[Anchor]string{
+	TopLeft:      "tl",
+	TopCenter:    "tc",
+	TopRight:     "tr",
+	CenterLeft:   "cl",
+	Center:       "cc",
+	CenterRight:  "cr",
+	BottomLeft:   "bl",
+	BottomCenter: "bc",
+	BottomRight:  "br",
+}
+
+// String returns the two-letter name of the anchor.
+func (a Anchor) String() string {
+	name, ok := anchorNames[a]
+	if !ok {
+		return "unknown"
+	}
+
+	return name
+}
+
+// ParseAnchor maps a two-letter anchor name onto its anchor, and reports
+// whether the name is one of the nine.
+//
+// An unknown name reports false alongside the zero anchor, which is itself a
+// valid one — following Nearest, callers have to read the boolean.
+func ParseAnchor(name string) (Anchor, bool) {
+	for anchor, known := range anchorNames {
+		if known == name {
+			return anchor, true
+		}
+	}
+
+	return 0, false
+}
+
+// originX returns the x the anchor places a window of the given width at
+// inside bounds, the visible frame in window coordinates.
+func (a Anchor) originX(bounds Rect, width float64) float64 {
+	switch a {
+	case TopLeft, CenterLeft, BottomLeft:
+		return bounds.X
+	case TopCenter, Center, BottomCenter:
+		return bounds.X + (bounds.W-width)/bothSides
+	case TopRight, CenterRight, BottomRight:
+		return bounds.X + bounds.W - width
+	default:
+		return bounds.X
+	}
+}
+
+// originY returns the y the anchor places a window of the given height at
+// inside bounds, the visible frame in window coordinates — so bounds.Y is its
+// upper edge.
+func (a Anchor) originY(bounds Rect, height float64) float64 {
+	switch a {
+	case TopLeft, TopCenter, TopRight:
+		return bounds.Y
+	case CenterLeft, Center, CenterRight:
+		return bounds.Y + (bounds.H-height)/bothSides
+	case BottomLeft, BottomCenter, BottomRight:
+		return bounds.Y + bounds.H - height
+	default:
+		return bounds.Y
+	}
+}
+
+// preset is the size and placement a named preset asks for.
+type preset struct {
+	widthPercent  float64
+	heightPercent float64
+	anchor        Anchor
+}
+
+// The shares of the visible frame the presets are defined in.
+const (
+	wholeScreen  = percentageWhole
+	halfScreen   = 50.0
+	centerWidth  = 60.0
+	centerHeight = 80.0
+)
+
+// presets are the named tiling shortcuts resize_window accepts as its
+// positional argument.
+var presets = map[string]preset{
+	"left-half":    {widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopLeft},
+	"right-half":   {widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopRight},
+	"top-half":     {widthPercent: wholeScreen, heightPercent: halfScreen, anchor: TopLeft},
+	"bottom-half":  {widthPercent: wholeScreen, heightPercent: halfScreen, anchor: BottomLeft},
+	"top-left":     {widthPercent: halfScreen, heightPercent: halfScreen, anchor: TopLeft},
+	"top-right":    {widthPercent: halfScreen, heightPercent: halfScreen, anchor: TopRight},
+	"bottom-left":  {widthPercent: halfScreen, heightPercent: halfScreen, anchor: BottomLeft},
+	"bottom-right": {widthPercent: halfScreen, heightPercent: halfScreen, anchor: BottomRight},
+	"center":       {widthPercent: centerWidth, heightPercent: centerHeight, anchor: Center},
+	"fill":         {widthPercent: wholeScreen, heightPercent: wholeScreen, anchor: TopLeft},
+}
+
+// IsPreset reports whether name is one of the named resize presets.
+//
+// Resize ignores a name it does not know, so callers that want an unknown
+// preset to be an error — the CLI does — check it with this first.
+func IsPreset(name string) bool {
+	_, ok := presets[name]
+
+	return ok
+}

--- a/internal/geometry/resize_test.go
+++ b/internal/geometry/resize_test.go
@@ -1,0 +1,600 @@
+package geometry_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// The display the window baseline was recorded on: one 1920x1080 screen whose
+// visible frame is inset by the 30pt menu bar. Wherever a case below matches a
+// recorded one, its expected frame is the frame macOS actually produced;
+// internal/baseline replays the whole recording against this same geometry.
+var singleDisplay = geometry.Screen{
+	Visible:        geometry.Rect{X: 0, Y: 0, W: 1920, H: 1050},
+	PrimaryHeight:  1080,
+	MarginsEnabled: false,
+	MarginSize:     8,
+}
+
+// The preset names the tests below reach for by name.
+const (
+	presetLeftHalf    = "left-half"
+	presetRightHalf   = "right-half"
+	presetTopHalf     = "top-half"
+	presetBottomHalf  = "bottom-half"
+	presetTopLeft     = "top-left"
+	presetTopRight    = "top-right"
+	presetBottomLeft  = "bottom-left"
+	presetBottomRight = "bottom-right"
+	presetCenter      = "center"
+	presetFill        = "fill"
+)
+
+// The frame every recorded resize case started from.
+var startFrame = geometry.Rect{X: 300, Y: 180, W: 700, H: 500}
+
+func TestResize_AnchorsAnAbsolutelySizedWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		anchor geometry.Anchor
+		want   geometry.Rect
+	}{
+		{anchor: geometry.TopLeft, want: geometry.Rect{X: 0, Y: 30, W: 800, H: 600}},
+		{anchor: geometry.TopCenter, want: geometry.Rect{X: 560, Y: 30, W: 800, H: 600}},
+		{anchor: geometry.TopRight, want: geometry.Rect{X: 1120, Y: 30, W: 800, H: 600}},
+		{anchor: geometry.CenterLeft, want: geometry.Rect{X: 0, Y: 255, W: 800, H: 600}},
+		{anchor: geometry.Center, want: geometry.Rect{X: 560, Y: 255, W: 800, H: 600}},
+		{anchor: geometry.CenterRight, want: geometry.Rect{X: 1120, Y: 255, W: 800, H: 600}},
+		{anchor: geometry.BottomLeft, want: geometry.Rect{X: 0, Y: 480, W: 800, H: 600}},
+		{anchor: geometry.BottomCenter, want: geometry.Rect{X: 560, Y: 480, W: 800, H: 600}},
+		{anchor: geometry.BottomRight, want: geometry.Rect{X: 1120, Y: 480, W: 800, H: 600}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.anchor.String(), func(t *testing.T) {
+			t.Parallel()
+
+			anchor := testCase.anchor
+			got := geometry.Resize(startFrame, singleDisplay, geometry.Request{
+				Width:  geometry.Absolute(800),
+				Height: geometry.Absolute(600),
+				Anchor: &anchor,
+			})
+
+			if got != testCase.want {
+				t.Errorf("Resize(anchor %s) = %v, want %v", testCase.anchor, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestResize_ResolvesEachKindOfDimension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		req  geometry.Request
+		want geometry.Rect
+	}{
+		{
+			name: "an empty request keeps both dimensions and centers the window",
+			req:  geometry.Request{},
+			want: geometry.Rect{X: 610, Y: 305, W: 700, H: 500},
+		},
+		{
+			name: "an absolute width keeps the current height",
+			req:  geometry.Request{Width: geometry.Absolute(800)},
+			want: geometry.Rect{X: 560, Y: 305, W: 800, H: 500},
+		},
+		{
+			name: "an absolute height keeps the current width",
+			req:  geometry.Request{Height: geometry.Absolute(600)},
+			want: geometry.Rect{X: 610, Y: 255, W: 700, H: 600},
+		},
+		{
+			name: "a kept dimension is the zero dimension",
+			req:  geometry.Request{Width: geometry.Keep(), Height: geometry.Keep()},
+			want: geometry.Rect{X: 610, Y: 305, W: 700, H: 500},
+		},
+		{
+			// 45% of 1920 and 55% of 1050. macOS quantizes the frame it is
+			// handed, so the recording holds the whole-point form of this.
+			name: "percentages are taken over the visible frame",
+			req: geometry.Request{
+				Width:  geometry.Percent(45),
+				Height: geometry.Percent(55),
+			},
+			want: geometry.Rect{X: 528, Y: 266.25, W: 864, H: 577.5},
+		},
+		{
+			name: "a full-height percentage fills the visible frame",
+			req: geometry.Request{
+				Width:  geometry.Percent(50),
+				Height: geometry.Percent(100),
+			},
+			want: geometry.Rect{X: 480, Y: 30, W: 960, H: 1050},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.Resize(startFrame, singleDisplay, testCase.req)
+			if got != testCase.want {
+				t.Errorf("Resize() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestResize_PlacesAnExplicitOriginVerbatim(t *testing.T) {
+	t.Parallel()
+
+	posX, posY := 100.0, 230.0
+
+	tests := []struct {
+		name string
+		req  geometry.Request
+		want geometry.Rect
+	}{
+		{
+			name: "an explicit origin keeps the current size",
+			req:  geometry.Request{X: &posX, Y: &posY},
+			want: geometry.Rect{X: 100, Y: 230, W: 700, H: 500},
+		},
+		{
+			name: "an explicit origin overrides the anchor on both axes",
+			req: geometry.Request{
+				X:      &posX,
+				Y:      &posY,
+				Width:  geometry.Absolute(800),
+				Height: geometry.Absolute(600),
+			},
+			want: geometry.Rect{X: 100, Y: 230, W: 800, H: 600},
+		},
+		{
+			name: "an explicit x leaves y to the anchor",
+			req:  geometry.Request{X: &posX, Height: geometry.Absolute(600)},
+			want: geometry.Rect{X: 100, Y: 255, W: 700, H: 600},
+		},
+		{
+			name: "an explicit y leaves x to the anchor",
+			req:  geometry.Request{Y: &posY, Width: geometry.Absolute(800)},
+			want: geometry.Rect{X: 560, Y: 230, W: 800, H: 500},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.Resize(startFrame, singleDisplay, testCase.req)
+			if got != testCase.want {
+				t.Errorf("Resize() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestResize_ExpandsEveryPreset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		preset string
+		want   geometry.Rect
+	}{
+		{preset: presetLeftHalf, want: geometry.Rect{X: 0, Y: 30, W: 960, H: 1050}},
+		{preset: presetRightHalf, want: geometry.Rect{X: 960, Y: 30, W: 960, H: 1050}},
+		{preset: presetTopHalf, want: geometry.Rect{X: 0, Y: 30, W: 1920, H: 525}},
+		{preset: presetBottomHalf, want: geometry.Rect{X: 0, Y: 555, W: 1920, H: 525}},
+		{preset: presetTopLeft, want: geometry.Rect{X: 0, Y: 30, W: 960, H: 525}},
+		{preset: presetTopRight, want: geometry.Rect{X: 960, Y: 30, W: 960, H: 525}},
+		{preset: presetBottomLeft, want: geometry.Rect{X: 0, Y: 555, W: 960, H: 525}},
+		{preset: presetBottomRight, want: geometry.Rect{X: 960, Y: 555, W: 960, H: 525}},
+		{preset: presetCenter, want: geometry.Rect{X: 384, Y: 135, W: 1152, H: 840}},
+		{preset: presetFill, want: geometry.Rect{X: 0, Y: 30, W: 1920, H: 1050}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.preset, func(t *testing.T) {
+			t.Parallel()
+
+			req := geometry.Request{Preset: testCase.preset}
+
+			got := geometry.Resize(startFrame, singleDisplay, req)
+			if got != testCase.want {
+				t.Errorf("Resize(preset %s) = %v, want %v", testCase.preset, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestResize_PresetSizesAreDefaults(t *testing.T) {
+	t.Parallel()
+
+	// left-half is 50% x 100%; an explicit width replaces its width and leaves
+	// its height and anchor in place.
+	got := geometry.Resize(startFrame, singleDisplay, geometry.Request{
+		Preset: presetLeftHalf,
+		Width:  geometry.Absolute(800),
+	})
+
+	want := geometry.Rect{X: 0, Y: 30, W: 800, H: 1050}
+	if got != want {
+		t.Errorf("Resize(left-half --width 800) = %v, want %v", got, want)
+	}
+}
+
+func TestResize_IgnoresAnUnknownPreset(t *testing.T) {
+	t.Parallel()
+
+	// Resize is total, so an unknown name cannot be an error here; the CLI
+	// rejects one at parse time with IsPreset.
+	got := geometry.Resize(startFrame, singleDisplay, geometry.Request{Preset: "left-third"})
+
+	want := geometry.Resize(startFrame, singleDisplay, geometry.Request{})
+	if got != want {
+		t.Errorf("Resize(preset left-third) = %v, want the presetless %v", got, want)
+	}
+}
+
+func TestResize_AppliesMargins(t *testing.T) {
+	t.Parallel()
+
+	// The same display with the system tiled-window margins switched on.
+	withMargins := singleDisplay
+	withMargins.MarginsEnabled = true
+
+	posX, posY := 100.0, 230.0
+	topCenter := geometry.TopCenter
+
+	tests := []struct {
+		name string
+		req  geometry.Request
+		want geometry.Rect
+	}{
+		{
+			// Left, top and bottom abut the visible frame and take a full 8pt
+			// margin; the right edge is internal and takes half of one.
+			name: "a half-screen preset takes a full margin on the edges it abuts",
+			req:  geometry.Request{Preset: presetLeftHalf},
+			want: geometry.Rect{X: 8, Y: 38, W: 948, H: 1034},
+		},
+		{
+			name: "a filling preset takes a full margin on all four edges",
+			req:  geometry.Request{Preset: presetFill},
+			want: geometry.Rect{X: 8, Y: 38, W: 1904, H: 1034},
+		},
+		{
+			name: "a preset that abuts nothing takes half a margin on all four edges",
+			req:  geometry.Request{Preset: presetCenter},
+			want: geometry.Rect{X: 388, Y: 139, W: 1144, H: 832},
+		},
+		{
+			name: "an anchored window takes a full margin only where it abuts",
+			req: geometry.Request{
+				Width:  geometry.Absolute(800),
+				Height: geometry.Absolute(600),
+				Anchor: &topCenter,
+			},
+			want: geometry.Rect{X: 564, Y: 38, W: 792, H: 588},
+		},
+		{
+			name: "an explicitly placed window is inset too",
+			req: geometry.Request{
+				X:      &posX,
+				Y:      &posY,
+				Width:  geometry.Absolute(800),
+				Height: geometry.Absolute(600),
+			},
+			want: geometry.Rect{X: 104, Y: 234, W: 792, H: 592},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.Resize(startFrame, withMargins, testCase.req)
+			if got != testCase.want {
+				t.Errorf("Resize() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestResize_MarginPreferenceOverridesTheSystemSetting(t *testing.T) {
+	t.Parallel()
+
+	withMargins := singleDisplay
+	withMargins.MarginsEnabled = true
+
+	enabled, disabled := true, false
+	inset := geometry.Rect{X: 8, Y: 38, W: 948, H: 1034}
+	full := geometry.Rect{X: 0, Y: 30, W: 960, H: 1050}
+
+	tests := []struct {
+		name string
+		scr  geometry.Screen
+		req  geometry.Request
+		want geometry.Rect
+	}{
+		{
+			name: "no preference follows a system setting that is on",
+			scr:  withMargins,
+			req:  geometry.Request{Preset: presetLeftHalf},
+			want: inset,
+		},
+		{
+			name: "no preference follows a system setting that is off",
+			scr:  singleDisplay,
+			req:  geometry.Request{Preset: presetLeftHalf},
+			want: full,
+		},
+		{
+			name: "margins off overrides a system setting that is on",
+			scr:  withMargins,
+			req:  geometry.Request{Preset: presetLeftHalf, UseMargins: &disabled},
+			want: full,
+		},
+		{
+			name: "margins on overrides a system setting that is off",
+			scr:  singleDisplay,
+			req:  geometry.Request{Preset: presetLeftHalf, UseMargins: &enabled},
+			want: inset,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.Resize(startFrame, testCase.scr, testCase.req)
+			if got != testCase.want {
+				t.Errorf("Resize() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestResize_PlacesWindowsOnSecondaryDisplays(t *testing.T) {
+	t.Parallel()
+
+	// A second 1920x1080 display to the left of the primary. macOS gives it a
+	// negative x in both coordinate systems; its bottom edge is level with the
+	// primary's, so the flip leaves its top at 0.
+	toTheLeft := geometry.Screen{
+		Visible:       geometry.Rect{X: -1920, Y: 0, W: 1920, H: 1080},
+		PrimaryHeight: 1080,
+		MarginSize:    8,
+	}
+
+	// A second 1920x1080 display above the primary. In screen coordinates it
+	// sits a whole primary height up; in window coordinates that is a whole
+	// primary height *down* from the origin, so every y on it is negative.
+	above := geometry.Screen{
+		Visible:       geometry.Rect{X: 0, Y: 1080, W: 1920, H: 1080},
+		PrimaryHeight: 1080,
+		MarginSize:    8,
+	}
+
+	tests := []struct {
+		name string
+		scr  geometry.Screen
+		req  geometry.Request
+		want geometry.Rect
+	}{
+		{
+			name: "filling the display to the left",
+			scr:  toTheLeft,
+			req:  geometry.Request{Preset: presetFill},
+			want: geometry.Rect{X: -1920, Y: 0, W: 1920, H: 1080},
+		},
+		{
+			name: "the right half of the display to the left",
+			scr:  toTheLeft,
+			req:  geometry.Request{Preset: presetRightHalf},
+			want: geometry.Rect{X: -960, Y: 0, W: 960, H: 1080},
+		},
+		{
+			name: "margins on the display to the left",
+			scr:  toTheLeft,
+			req:  geometry.Request{Preset: presetFill, UseMargins: new(true)},
+			want: geometry.Rect{X: -1912, Y: 8, W: 1904, H: 1064},
+		},
+		{
+			name: "filling the display above sits a whole primary height up",
+			scr:  above,
+			req:  geometry.Request{Preset: presetFill},
+			want: geometry.Rect{X: 0, Y: -1080, W: 1920, H: 1080},
+		},
+		{
+			name: "the bottom half of the display above still ends at the primary's top",
+			scr:  above,
+			req:  geometry.Request{Preset: presetBottomHalf},
+			want: geometry.Rect{X: 0, Y: -540, W: 1920, H: 540},
+		},
+		{
+			name: "an anchor on the display above is relative to its own frame",
+			scr:  above,
+			req: geometry.Request{
+				Width:  geometry.Absolute(800),
+				Height: geometry.Absolute(600),
+				Anchor: new(geometry.BottomRight),
+			},
+			want: geometry.Rect{X: 1120, Y: -600, W: 800, H: 600},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.Resize(startFrame, testCase.scr, testCase.req)
+			if got != testCase.want {
+				t.Errorf("Resize() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestResize_PresetOverridesExplicitAnchor_KnownBug pins issue #64: a preset
+// supplies its width and height only where the request left them unset, but
+// takes the anchor unconditionally, so an explicit --anchor is silently
+// dropped. The expected frame here is the one macOS produced for
+// `resize_window left-half --anchor br --no-margin` in the recorded baseline.
+//
+// #64 inverts this test.
+func TestResize_PresetOverridesExplicitAnchor_KnownBug(t *testing.T) {
+	t.Parallel()
+
+	got := geometry.Resize(startFrame, singleDisplay, geometry.Request{
+		Preset: presetLeftHalf,
+		Anchor: new(geometry.BottomRight),
+	})
+
+	// left-half's own top-left anchor, not the bottom-right that was asked for.
+	want := geometry.Rect{X: 0, Y: 30, W: 960, H: 1050}
+	if got != want {
+		t.Errorf("Resize(left-half --anchor br) = %v, want %v", got, want)
+	}
+}
+
+// TestResize_MarginsCanDriveADimensionNonPositive_KnownBug pins issue #65:
+// margins are subtracted with no lower bound, so a window narrower than the
+// margins it takes ends up with a zero or negative size, which is then handed
+// to the Accessibility API as-is.
+//
+// #65 skips margins entirely in this case, and inverts this test.
+func TestResize_MarginsCanDriveADimensionNonPositive_KnownBug(t *testing.T) {
+	t.Parallel()
+
+	// A large configured margin: 16pt on each internal edge.
+	wide := singleDisplay
+	wide.MarginsEnabled = true
+	wide.MarginSize = 32
+
+	got := geometry.Resize(startFrame, wide, geometry.Request{
+		Width:  geometry.Absolute(20),
+		Height: geometry.Absolute(20),
+	})
+
+	// 20 points of window less 32 points of margin, on both axes.
+	want := geometry.Rect{X: 966, Y: 561, W: -12, H: -12}
+	if got != want {
+		t.Errorf("Resize(--width 20 --height 20 --margin) = %v, want %v", got, want)
+	}
+}
+
+// TestResize_EdgeDetectionUsesExactFloatEquality_KnownBug pins issue #66:
+// whether an edge takes a full margin or half of one is decided by comparing
+// computed floats for exact equality, so an edge that is flush by construction
+// can still be read as internal.
+//
+// The display here is a 1512x982 primary with a second display directly above
+// it, which is what makes the arithmetic inexact: the flip puts the upper
+// display's top at -1080, and 10% of 982 is 98.2, so the bottom edge computed
+// as y+h misses the visible frame's lower boundary by a few ulps.
+//
+// That scenario is deliberate. #66's own repro — `fill` against a centered
+// 100%x100% request — does not actually diverge on a display whose metrics are
+// whole points: a 100% dimension comes back exactly, and centering a window as
+// wide as the frame lands exactly on its edge. Only a fractional dimension
+// separates the two rules, which is why this test reaches for one.
+//
+// #66 derives the edge flags from the anchor instead, and inverts this test.
+func TestResize_EdgeDetectionUsesExactFloatEquality_KnownBug(t *testing.T) {
+	t.Parallel()
+
+	above := geometry.Screen{
+		Visible:        geometry.Rect{X: 0, Y: 1080, W: 1512, H: 982},
+		PrimaryHeight:  982,
+		MarginsEnabled: true,
+		MarginSize:     8,
+	}
+
+	// Both windows are one tenth of the visible frame tall and flush against
+	// one of its horizontal boundaries, so both should take a full 8pt margin
+	// there and half of one on the opposite, internal edge.
+	const requested = 98.2
+
+	tests := []struct {
+		name   string
+		anchor geometry.Anchor
+		want   float64
+	}{
+		{
+			// The top edge is assigned from the visible frame, so it compares
+			// equal and takes its full margin.
+			name:   "an edge assigned from the visible frame is recognized",
+			anchor: geometry.TopLeft,
+			want:   8 + 4,
+		},
+		{
+			// The bottom edge is computed, so it does not.
+			name:   "an edge arrived at by arithmetic is not",
+			anchor: geometry.BottomLeft,
+			want:   4 + 4,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.Resize(startFrame, above, geometry.Request{
+				Height: geometry.Percent(10),
+				Anchor: &testCase.anchor,
+			})
+
+			if taken := requested - got.H; math.Abs(taken-testCase.want) > tolerance {
+				t.Errorf(
+					"Resize(--height-percent 10 --anchor %s --margin) gave up %v points of height to margins, want %v",
+					testCase.anchor,
+					taken,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+// tolerance is the slack the float comparisons in this file allow, well below
+// anything a display can show.
+const tolerance = 1e-9
+
+func TestIsPreset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: presetLeftHalf, want: true},
+		{name: presetRightHalf, want: true},
+		{name: presetTopHalf, want: true},
+		{name: presetBottomHalf, want: true},
+		{name: presetTopLeft, want: true},
+		{name: presetTopRight, want: true},
+		{name: presetBottomLeft, want: true},
+		{name: presetBottomRight, want: true},
+		{name: presetCenter, want: true},
+		{name: presetFill, want: true},
+		{name: "left-third", want: false},
+		{name: "", want: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := geometry.IsPreset(testCase.name); got != testCase.want {
+				t.Fatalf("IsPreset(%q) = %v, want %v", testCase.name, got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR moves the arithmetic behind `mimi action resize_window` out of the action layer and into the pure geometry module, with no change to what the command does. Every recorded frame macOS produces today — all ten presets in both margin states, all nine anchors in both margin states, and the explicit width, height, percentage and position combinations — is reproduced exactly by the extracted code, and that equivalence now runs as a test on every build rather than resting on a reading of the old code.

Until now the coordinate conversion between the screen and window coordinate systems, the nine-anchor placement, the preset expansion and the tiled-window margin rules were interleaved with the Accessibility calls that fetch the window and the screen, so none of them could be tested. The existing tests said as much: they only ever asserted that an invocation survived argument parsing. Resize behaviour is now covered by unit tests across three display arrangements — a single display with a menu-bar inset, a second display to the left of the primary, and a second display above it.

Three known defects live in this code and are deliberately left as they behave today, each pinned by a test that names its follow-up issue: an explicit `--anchor` is still ignored when a preset is given (#64), margins can still drive a window's width or height to zero or below (#65), and edge detection still uses exact float comparison (#66). Fixing any of them here would have hidden it inside a large refactor; they now change as visible one-line diffs.

## Related Issues

Closes #63.

Follow-ups this deliberately does not fix, and now pins with tests: #64, #65, #66.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed; the module layout already documented in `docs/ARCHITECTURE.md` and `docs/CODING_STANDARDS.md` is unchanged.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A — no user-visible output changed.

## Additional Context

**No user-facing surface changed.** Every `resize_window` flag, preset name, anchor name and error message is byte-for-byte what it was, and no config key, hook variable or exit code moved. Nothing in an existing config or script has to change.

**How the extraction was verified.** The recorded window baseline from #61 is the oracle. Its 49 resize cases are replayed through argument parsing and the pure geometry and compared against the frames macOS actually produced; 47 match exactly. The two percentage cases compute a fractional frame, which macOS stores as whole points, so the comparison allows less than one point per field — well below anything a geometry mistake could produce, since the margin rules move an edge by four points and the anchors by hundreds. The macOS-driven integration recorder itself was run six times against a real window and asserted all 49 resize frames every time.

**One note for whoever picks up #66.** Its stated reproduction — `fill` against a centred 100%×100% request — does not actually diverge on a display whose metrics are whole points: a 100% dimension comes back exactly and centring a full-width window lands exactly on the edge. Only a fractional dimension separates the two margin rules, so the test pinning #66 reaches for one, and its comment explains why.

**Two smaller judgement calls.** The recording keeps its own rectangle type with a single conversion to the geometry one, rather than embedding the geometry type, so the names the baseline file is stored under stay a property of that file and re-recording is never needed to change one. And the margin size is now read from macOS alongside the rest of the screen even when margins are switched off — one extra read of a system default on the `--no-margin` path, which is the shape the geometry module's screen input was specified in.
