### PR TITLE
fix(geometry): keep the requested window size when margins would leave nothing

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -214,7 +214,9 @@ Custom flags allow precise control using an anchor system:
   EnableTiledWindowMargins) is respected by default. Margins are
   applied intelligently: full margin on screen-facing edges, half
   margin on internal (split) edges so adjacent windows share a
-  single gap. Use --margin or --no-margin to override.
+  single gap. A window too small to give up its margins is sized
+  exactly as asked for instead, with no margins on either axis.
+  Use --margin or --no-margin to override.
 
 Examples:
   mimi action resize_window left-half

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -68,7 +68,7 @@ Move the frontmost window to a space by its 1-based index, or cycle to the next/
 
 ### `mimi action resize_window [preset] [flags]`
 
-Resize and reposition the frontmost window using presets or custom flags. Respects the macOS tiled window margins setting (`com.apple.WindowManager.EnableTiledWindowMargins`), applying full margins on screen-facing edges and half margins on internal (split) edges.
+Resize and reposition the frontmost window using presets or custom flags. Respects the macOS tiled window margins setting (`com.apple.WindowManager.EnableTiledWindowMargins`), applying full margins on screen-facing edges and half margins on internal (split) edges. Margins are skipped entirely when they would leave the window no width or height, so a window smaller than its margins is sized as you asked for it.
 
 **Presets** provide quick tiling layouts:
 

--- a/internal/geometry/resize.go
+++ b/internal/geometry/resize.go
@@ -167,20 +167,34 @@ func Resize(cur Rect, scr Screen, req Request) Rect {
 // that abuts the visible frame's boundary, half a margin on each internal one,
 // so that the gap between two tiled windows is one margin rather than two.
 //
-// Two known defects live here, both preserved from the code this replaced. An
-// edge abuts only on exact float equality, so a window a fraction of a point
-// off the boundary is treated as internal (issue #66); and nothing stops the
-// margins from driving a width or height to zero or below (issue #65).
+// Margins are a refinement rather than part of what was asked for, so they are
+// all or nothing: a frame too small to give up what its edges want keeps the
+// size it was asked for, unmargined. Clamping the dimension instead would
+// leave a window that is valid but useless. The threshold is strict and either
+// axis falling short drops the margins on both — a dimension takes its margins
+// only while what is left of it stays above zero, so a width exactly equal to
+// the margins it would give up keeps all of it.
+//
+// One known defect lives here, preserved from the code this replaced: an edge
+// abuts only on exact float equality, so a window a fraction of a point off
+// the boundary is treated as internal (issue #66).
 func inset(frame, bounds Rect, size float64) Rect {
 	left := marginOn(frame.X == bounds.X, size)
 	right := marginOn(frame.Right() == bounds.Right(), size)
 	top := marginOn(frame.Y == bounds.Y, size)
 	bottom := marginOn(frame.Bottom() == bounds.Bottom(), size)
 
+	horizontal := left + right
+	vertical := top + bottom
+
+	if frame.W-horizontal <= 0 || frame.H-vertical <= 0 {
+		return frame
+	}
+
 	frame.X += left
-	frame.W -= left + right
+	frame.W -= horizontal
 	frame.Y += top
-	frame.H -= top + bottom
+	frame.H -= vertical
 
 	return frame
 }

--- a/internal/geometry/resize_test.go
+++ b/internal/geometry/resize_test.go
@@ -463,29 +463,85 @@ func TestResize_PresetAnchorIsADefault(t *testing.T) {
 	}
 }
 
-// TestResize_MarginsCanDriveADimensionNonPositive_KnownBug pins issue #65:
-// margins are subtracted with no lower bound, so a window narrower than the
-// margins it takes ends up with a zero or negative size, which is then handed
-// to the Accessibility API as-is.
+// TestResize_SkipsMarginsThatWouldLeaveNoWindow covers issue #65: a window
+// narrower or shorter than the margins its edges take is placed unmargined,
+// at the size that was asked for, rather than being handed a zero or negative
+// dimension. Margins are cosmetic, and clamping the dimension instead would
+// leave a window that is valid but useless.
 //
-// #65 skips margins entirely in this case, and inverts this test.
-func TestResize_MarginsCanDriveADimensionNonPositive_KnownBug(t *testing.T) {
+// The threshold is the last point at which something is left: a dimension
+// takes its margins while what remains of it stays above zero, and gives them
+// all up as soon as it does not. Each axis is checked either side of that
+// line, and each drops the margins on both axes.
+func TestResize_SkipsMarginsThatWouldLeaveNoWindow(t *testing.T) {
 	t.Parallel()
 
-	// A large configured margin: 16pt on each internal edge.
+	// A large configured margin. None of these windows abuts the visible
+	// frame, so every edge takes half of it — 16 points an edge, 32 across
+	// either axis.
 	wide := singleDisplay
 	wide.MarginsEnabled = true
 	wide.MarginSize = 32
 
-	got := geometry.Resize(startFrame, wide, geometry.Request{
-		Width:  geometry.Absolute(20),
-		Height: geometry.Absolute(20),
-	})
+	tests := []struct {
+		name string
+		req  geometry.Request
+		want geometry.Rect
+	}{
+		{
+			name: "both axes too small to take their margins",
+			req: geometry.Request{
+				Width:  geometry.Absolute(20),
+				Height: geometry.Absolute(20),
+			},
+			// Centered, at the 20x20 asked for rather than at -12x-12.
+			want: geometry.Rect{X: 950, Y: 545, W: 20, H: 20},
+		},
+		{
+			name: "a width exactly equal to its margins keeps all of it",
+			req: geometry.Request{
+				Width:  geometry.Absolute(32),
+				Height: geometry.Absolute(600),
+			},
+			// Nothing would be left of the width, so the height that could
+			// have taken its own margins keeps them too.
+			want: geometry.Rect{X: 944, Y: 255, W: 32, H: 600},
+		},
+		{
+			name: "a width one point wider takes them",
+			req: geometry.Request{
+				Width:  geometry.Absolute(33),
+				Height: geometry.Absolute(600),
+			},
+			want: geometry.Rect{X: 959.5, Y: 271, W: 1, H: 568},
+		},
+		{
+			name: "a height exactly equal to its margins keeps all of it",
+			req: geometry.Request{
+				Width:  geometry.Absolute(600),
+				Height: geometry.Absolute(32),
+			},
+			want: geometry.Rect{X: 660, Y: 539, W: 600, H: 32},
+		},
+		{
+			name: "a height one point taller takes them",
+			req: geometry.Request{
+				Width:  geometry.Absolute(600),
+				Height: geometry.Absolute(33),
+			},
+			want: geometry.Rect{X: 676, Y: 554.5, W: 568, H: 1},
+		},
+	}
 
-	// 20 points of window less 32 points of margin, on both axes.
-	want := geometry.Rect{X: 966, Y: 561, W: -12, H: -12}
-	if got != want {
-		t.Errorf("Resize(--width 20 --height 20 --margin) = %v, want %v", got, want)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.Resize(startFrame, wide, testCase.req)
+			if got != testCase.want {
+				t.Errorf("Resize(%s --margin) = %v, want %v", testCase.name, got, testCase.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes resized windows coming out with a zero or negative size when tiled-window margins are larger than the window being asked for. Previously the margins were subtracted from the computed width and height with no lower bound, so `mimi action resize_window --width 20 --height 20 --margin` with a large configured margin handed a negative size straight to the Accessibility API.

Margins are now all or nothing. If applying them would leave either the width or the height at zero or below, they are skipped entirely and the window is placed at exactly the size that was asked for. Clamping the dimension to zero or to a single point was the alternative, and it produces a technically valid but useless window; the unmargined frame is what the user actually asked for. Either axis falling short drops the margins on both, so the window keeps the shape it was given.

Windows large enough to take their margins are completely unaffected — every one of the 49 recorded real-macOS frames in the resize baseline replays unchanged, so no re-recording was needed.

## Related Issues

Closes #65

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The threshold is exact and per-axis: a dimension takes its margins only while what is left of it stays above zero, so a width equal to the margins it would give up drops them. The unit test pins both sides of that line on each axis independently — a width of exactly its margins and one point wider, and likewise for the height.

No flags, config keys, or hook variables change. The `resize_window` help text and `docs/CLI.md` each gain a sentence describing the new degradation, so the man page generated from the help text stays accurate.

The `_KnownBug` test that pinned this defect is inverted and renamed in the same commit, which is where the behaviour change shows up as a diff. The sibling defect in the same margin code — edge detection comparing floats for exact equality, issue #66 — is untouched and still pinned by its own test.
