### PR TITLE
fix(geometry): give every flush window edge its full tiled margin

### DIFF
--- a/internal/geometry/resize.go
+++ b/internal/geometry/resize.go
@@ -1,5 +1,7 @@
 package geometry
 
+import "math"
+
 // percentageWhole is the denominator a percentage dimension is taken over.
 const percentageWhole = 100.0
 
@@ -157,15 +159,87 @@ func Resize(cur Rect, scr Screen, req Request) Rect {
 	}
 
 	if useMargins {
-		frame = inset(frame, bounds, scr.MarginSize)
+		frame = inset(frame, scr.MarginSize, flushEdges(req, anchor, frame, bounds))
 	}
 
 	return frame
 }
 
+// adjacency is how far apart two points may lie and still count as the same
+// one: the slack an explicitly positioned edge is measured against the visible
+// frame's boundary with, and a requested length against the frame's own. macOS
+// stores window frames in whole points, so half of one is below anything a
+// display can show.
+const adjacency = 0.5
+
+// ends records, for one axis, whether each end of a frame lies against the
+// visible frame's boundary rather than against whatever is tiled alongside it.
+// Low is the end at the smaller coordinate — left or top — and high the other.
+type ends struct {
+	low  bool
+	high bool
+}
+
+// edges records the same for both axes of a frame.
+type edges struct {
+	horizontal ends
+	vertical   ends
+}
+
+// flushEdges reports which of the placed frame's edges lie against the visible
+// frame's boundary.
+//
+// An anchored window's edges follow from the anchor and the size that was
+// asked for: the side the anchor pins is flush by construction, and the
+// opposite side only once the window is as long as the frame. Deriving them
+// keeps the answer out of reach of the rounding that computing an edge as
+// origin + size or through a division introduces — a bottom-anchored window is
+// flush at the bottom whether or not y+h lands exactly on the boundary
+// (issue #66).
+//
+// An explicit --x or --y is the one placement that has to be measured, because
+// the coordinate is the user's own and follows from nothing. Each axis is
+// decided on its own, so an explicit --x still leaves the vertical edges to the
+// anchor.
+func flushEdges(req Request, anchor Anchor, frame, bounds Rect) edges {
+	found := edges{}
+
+	if req.X != nil {
+		found.horizontal = ends{
+			low:  adjacent(frame.X, bounds.X),
+			high: adjacent(frame.Right(), bounds.Right()),
+		}
+	} else {
+		// A window as long as the visible frame lies against the boundary at
+		// both ends of the axis rather than at only the one its anchor pins. A
+		// window longer than the frame does not: its far edge is off screen,
+		// and takes the same margin there as it always has.
+		found.horizontal = anchor.flushX(adjacent(frame.W, bounds.W))
+	}
+
+	if req.Y != nil {
+		found.vertical = ends{
+			low:  adjacent(frame.Y, bounds.Y),
+			high: adjacent(frame.Bottom(), bounds.Bottom()),
+		}
+	} else {
+		found.vertical = anchor.flushY(adjacent(frame.H, bounds.H))
+	}
+
+	return found
+}
+
+// adjacent reports whether two coordinates name the same point, or two lengths
+// the same length, to within the half point below which nothing is observable.
+func adjacent(first, second float64) bool {
+	return math.Abs(first-second) <= adjacency
+}
+
 // inset applies the tiled-window margin to a frame: a full margin on each edge
-// that abuts the visible frame's boundary, half a margin on each internal one,
-// so that the gap between two tiled windows is one margin rather than two.
+// that lies against the visible frame's boundary, half a margin on each
+// internal one, so that the gap between two tiled windows is one margin rather
+// than two. Which edges those are is flushEdges' answer, not a measurement of
+// the frame.
 //
 // Margins are a refinement rather than part of what was asked for, so they are
 // all or nothing: a frame too small to give up what its edges want keeps the
@@ -174,15 +248,11 @@ func Resize(cur Rect, scr Screen, req Request) Rect {
 // axis falling short drops the margins on both — a dimension takes its margins
 // only while what is left of it stays above zero, so a width exactly equal to
 // the margins it would give up keeps all of it.
-//
-// One known defect lives here, preserved from the code this replaced: an edge
-// abuts only on exact float equality, so a window a fraction of a point off
-// the boundary is treated as internal (issue #66).
-func inset(frame, bounds Rect, size float64) Rect {
-	left := marginOn(frame.X == bounds.X, size)
-	right := marginOn(frame.Right() == bounds.Right(), size)
-	top := marginOn(frame.Y == bounds.Y, size)
-	bottom := marginOn(frame.Bottom() == bounds.Bottom(), size)
+func inset(frame Rect, size float64, flush edges) Rect {
+	left := marginOn(flush.horizontal.low, size)
+	right := marginOn(flush.horizontal.high, size)
+	top := marginOn(flush.vertical.low, size)
+	bottom := marginOn(flush.vertical.high, size)
 
 	horizontal := left + right
 	vertical := top + bottom
@@ -200,10 +270,10 @@ func inset(frame, bounds Rect, size float64) Rect {
 }
 
 // marginOn returns the margin one edge takes: the whole of it when the edge
-// abuts the visible frame's boundary, half of it when the edge is internal and
-// the gap is shared with whatever is tiled alongside.
-func marginOn(abuts bool, size float64) float64 {
-	if abuts {
+// lies against the visible frame's boundary, half of it when the edge is
+// internal and the gap is shared with whatever is tiled alongside.
+func marginOn(flush bool, size float64) float64 {
+	if flush {
 		return size
 	}
 
@@ -324,6 +394,39 @@ func (a Anchor) originY(bounds Rect, height float64) float64 {
 		return bounds.Y + bounds.H - height
 	default:
 		return bounds.Y
+	}
+}
+
+// flushX reports which of a window's left and right edges lie against the
+// visible frame's boundary once this anchor has placed it. The side the anchor
+// pins is flush by construction; the opposite one is flush only once the window
+// is as wide as the frame, and a centered window is flush on both edges or on
+// neither.
+func (a Anchor) flushX(spansWidth bool) ends {
+	switch a {
+	case TopRight, CenterRight, BottomRight:
+		return ends{low: spansWidth, high: true}
+	case TopCenter, Center, BottomCenter:
+		return ends{low: spansWidth, high: spansWidth}
+	case TopLeft, CenterLeft, BottomLeft:
+		return ends{low: true, high: spansWidth}
+	default:
+		return ends{low: true, high: spansWidth}
+	}
+}
+
+// flushY reports the same for a window's top and bottom edges, on the terms
+// flushX describes.
+func (a Anchor) flushY(spansHeight bool) ends {
+	switch a {
+	case BottomLeft, BottomCenter, BottomRight:
+		return ends{low: spansHeight, high: true}
+	case CenterLeft, Center, CenterRight:
+		return ends{low: spansHeight, high: spansHeight}
+	case TopLeft, TopCenter, TopRight:
+		return ends{low: true, high: spansHeight}
+	default:
+		return ends{low: true, high: spansHeight}
 	}
 }
 

--- a/internal/geometry/resize_test.go
+++ b/internal/geometry/resize_test.go
@@ -1,6 +1,7 @@
 package geometry_test
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -545,55 +546,42 @@ func TestResize_SkipsMarginsThatWouldLeaveNoWindow(t *testing.T) {
 	}
 }
 
-// TestResize_EdgeDetectionUsesExactFloatEquality_KnownBug pins issue #66:
-// whether an edge takes a full margin or half of one is decided by comparing
-// computed floats for exact equality, so an edge that is flush by construction
-// can still be read as internal.
+// TestResize_EdgeAdjacencyFollowsTheAnchorNotTheArithmetic covers issue #66: an
+// edge that is flush against the visible frame by construction takes a full
+// margin whichever anchor put it there, rather than only when the arithmetic
+// happens to land on the boundary exactly.
 //
 // The display here is a 1512x982 primary with a second display directly above
 // it, which is what makes the arithmetic inexact: the flip puts the upper
-// display's top at -1080, and 10% of 982 is 98.2, so the bottom edge computed
-// as y+h misses the visible frame's lower boundary by a few ulps.
+// display's top at -1080, and 10% of 982 is 98.2, so a bottom edge computed as
+// y+h misses the visible frame's lower boundary by a few ulps. Under the old
+// rule the top-anchored window took its full 8pt margin and the bottom-anchored
+// one, flush against the same kind of boundary, took half of one.
 //
-// That scenario is deliberate. #66's own repro — `fill` against a centered
-// 100%x100% request — does not actually diverge on a display whose metrics are
-// whole points: a 100% dimension comes back exactly, and centering a window as
-// wide as the frame lands exactly on its edge. Only a fractional dimension
-// separates the two rules, which is why this test reaches for one.
-//
-// #66 derives the edge flags from the anchor instead, and inverts this test.
-func TestResize_EdgeDetectionUsesExactFloatEquality_KnownBug(t *testing.T) {
+// That scenario is deliberate. #66's own first repro — `fill` against a
+// centered 100%x100% request — does not actually diverge on a display whose
+// metrics are whole points: a 100% dimension comes back exactly, and centering
+// a window as wide as the frame lands exactly on its edge. Only a fractional
+// dimension separates the two rules, which is why this test reaches for one.
+func TestResize_EdgeAdjacencyFollowsTheAnchorNotTheArithmetic(t *testing.T) {
 	t.Parallel()
 
-	above := geometry.Screen{
-		Visible:        geometry.Rect{X: 0, Y: 1080, W: 1512, H: 982},
-		PrimaryHeight:  982,
-		MarginsEnabled: true,
-		MarginSize:     8,
-	}
-
 	// Both windows are one tenth of the visible frame tall and flush against
-	// one of its horizontal boundaries, so both should take a full 8pt margin
-	// there and half of one on the opposite, internal edge.
+	// one of its horizontal boundaries, so both take a full 8pt margin there
+	// and half of one on the opposite, internal edge.
 	const requested = 98.2
 
 	tests := []struct {
 		name   string
 		anchor geometry.Anchor
-		want   float64
 	}{
 		{
-			// The top edge is assigned from the visible frame, so it compares
-			// equal and takes its full margin.
-			name:   "an edge assigned from the visible frame is recognized",
+			name:   "an edge assigned from the visible frame is flush",
 			anchor: geometry.TopLeft,
-			want:   8 + 4,
 		},
 		{
-			// The bottom edge is computed, so it does not.
-			name:   "an edge arrived at by arithmetic is not",
+			name:   "an edge arrived at by arithmetic is flush too",
 			anchor: geometry.BottomLeft,
-			want:   4 + 4,
 		},
 	}
 
@@ -601,19 +589,273 @@ func TestResize_EdgeDetectionUsesExactFloatEquality_KnownBug(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := geometry.Resize(startFrame, above, geometry.Request{
+			got := geometry.Resize(startFrame, displayAbove, geometry.Request{
 				Height: geometry.Percent(10),
 				Anchor: &testCase.anchor,
 			})
 
-			if taken := requested - got.H; math.Abs(taken-testCase.want) > tolerance {
-				t.Errorf(
-					"Resize(--height-percent 10 --anchor %s --margin) gave up %v points of height to margins, want %v",
-					testCase.anchor,
-					taken,
-					testCase.want,
-				)
-			}
+			assertMargin(
+				t,
+				fmt.Sprintf("--height-percent 10 --anchor %s --margin", testCase.anchor),
+				"height",
+				requested-got.H,
+				pinnedMargin,
+			)
+		})
+	}
+}
+
+// displayAbove is a 1512x982 primary with a second display directly above it,
+// with the system tiled-window margins on. Every dimension a percentage takes
+// of its visible frame is fractional, and the flip puts the frame's top at a
+// whole -1080, so the positions the anchors compute are inexact.
+var displayAbove = geometry.Screen{
+	Visible:        geometry.Rect{X: 0, Y: 1080, W: 1512, H: 982},
+	PrimaryHeight:  982,
+	MarginsEnabled: true,
+	MarginSize:     8,
+}
+
+// What an 8pt margin takes across one axis of a window: a full margin on the
+// end that lies against the visible frame's boundary plus half of one on the
+// internal end, half of one on each of two internal ends, or a full margin on
+// each end of a window that reaches the boundary on both.
+const (
+	pinnedMargin   = 8 + 4
+	internalMargin = 4 + 4
+	spanningMargin = 8 + 8
+)
+
+// assertMargin fails when a window gave up something other than want points of
+// one dimension to its margins.
+func assertMargin(t *testing.T, request, axis string, taken, want float64) {
+	t.Helper()
+
+	if math.Abs(taken-want) > tolerance {
+		t.Errorf(
+			"Resize(%s) gave up %v points of %s to margins, want %v",
+			request,
+			taken,
+			axis,
+			want,
+		)
+	}
+}
+
+// TestResize_MarginsAreTheSameAtWholeAndFractionalSizes covers issue #66 across
+// all nine anchors: which edges take a full margin follows from the anchor
+// alone, so the same anchor gives up the same margin whether the size it was
+// asked for lands on whole points or not.
+//
+// None of these windows spans either axis, so each anchor takes a full 8pt
+// margin on the two boundaries it pins itself against and half of one on the
+// two internal edges — 12 points across an axis it pins, 8 across one it
+// centers on.
+func TestResize_MarginsAreTheSameAtWholeAndFractionalSizes(t *testing.T) {
+	t.Parallel()
+
+	// The recorded display with the system margins switched on. 45% of 1920 and
+	// 20% of 1050 are whole points; the same shares of displayAbove's 1512x982
+	// frame are not, and neither is any position an anchor computes from them.
+	whole := singleDisplay
+	whole.MarginsEnabled = true
+
+	const (
+		widthShare  = 45.0
+		heightShare = 20.0
+	)
+
+	anchors := []struct {
+		anchor     geometry.Anchor
+		horizontal float64
+		vertical   float64
+	}{
+		{anchor: geometry.TopLeft, horizontal: pinnedMargin, vertical: pinnedMargin},
+		{anchor: geometry.TopCenter, horizontal: internalMargin, vertical: pinnedMargin},
+		{anchor: geometry.TopRight, horizontal: pinnedMargin, vertical: pinnedMargin},
+		{anchor: geometry.CenterLeft, horizontal: pinnedMargin, vertical: internalMargin},
+		{anchor: geometry.Center, horizontal: internalMargin, vertical: internalMargin},
+		{anchor: geometry.CenterRight, horizontal: pinnedMargin, vertical: internalMargin},
+		{anchor: geometry.BottomLeft, horizontal: pinnedMargin, vertical: pinnedMargin},
+		{anchor: geometry.BottomCenter, horizontal: internalMargin, vertical: pinnedMargin},
+		{anchor: geometry.BottomRight, horizontal: pinnedMargin, vertical: pinnedMargin},
+	}
+
+	displays := []struct {
+		name string
+		scr  geometry.Screen
+	}{
+		{name: "whole", scr: whole},
+		{name: "fractional", scr: displayAbove},
+	}
+
+	for _, display := range displays {
+		for _, testCase := range anchors {
+			t.Run(display.name+"/"+testCase.anchor.String(), func(t *testing.T) {
+				t.Parallel()
+
+				anchor := testCase.anchor
+				req := geometry.Request{
+					Width:  geometry.Percent(widthShare),
+					Height: geometry.Percent(heightShare),
+					Anchor: &anchor,
+				}
+
+				requestedW := display.scr.Visible.W * widthShare / 100
+				requestedH := display.scr.Visible.H * heightShare / 100
+
+				got := geometry.Resize(startFrame, display.scr, req)
+				request := fmt.Sprintf("--anchor %s --margin", testCase.anchor)
+
+				assertMargin(t, request, "width", requestedW-got.W, testCase.horizontal)
+				assertMargin(t, request, "height", requestedH-got.H, testCase.vertical)
+			})
+		}
+	}
+}
+
+// TestResize_AWindowAsLargeAsTheFrameIsFlushOnBothEdges covers the other half
+// of the anchored rule from issue #66: the edge an anchor does not pin is flush
+// too once the window is as long as the visible frame, so a window filling the
+// frame takes a full margin on all four edges rather than only on the two its
+// anchor pins.
+//
+// The length is compared to the frame's within the same half point an explicit
+// position is, so a window a fraction short of the frame — which the arithmetic
+// can leave one — still counts as filling it, and a window a whole point short
+// does not.
+func TestResize_AWindowAsLargeAsTheFrameIsFlushOnBothEdges(t *testing.T) {
+	t.Parallel()
+
+	// 1512 wide, on a display whose window-coordinate origin the flip puts at a
+	// negative y. Every case fills the frame's height, and varies its width.
+	frame := displayAbove.Visible
+
+	tests := []struct {
+		name       string
+		width      geometry.Dimension
+		requested  float64
+		horizontal float64
+	}{
+		{
+			name:       "a window filling the frame",
+			width:      geometry.Percent(100),
+			requested:  frame.W,
+			horizontal: spanningMargin,
+		},
+		{
+			name:       "a window a quarter point short of it",
+			width:      geometry.Absolute(frame.W - 0.25),
+			requested:  frame.W - 0.25,
+			horizontal: spanningMargin,
+		},
+		{
+			name:       "a window a whole point short of it",
+			width:      geometry.Absolute(frame.W - 1),
+			requested:  frame.W - 1,
+			horizontal: pinnedMargin,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			anchor := geometry.TopLeft
+			got := geometry.Resize(startFrame, displayAbove, geometry.Request{
+				Width:  testCase.width,
+				Height: geometry.Percent(100),
+				Anchor: &anchor,
+			})
+
+			const request = "--height-percent 100 --anchor tl --margin"
+
+			assertMargin(t, request, "width", testCase.requested-got.W, testCase.horizontal)
+			assertMargin(t, request, "height", frame.H-got.H, spanningMargin)
+		})
+	}
+}
+
+// TestResize_ExplicitPositionMeasuresItsEdges covers the other half of issue
+// #66: an explicit --x or --y is the one placement whose edges have to be
+// measured, because the coordinate is the user's own and follows from no
+// anchor. The comparison allows half a point, which is below what macOS can
+// store a frame at, and nothing beyond it.
+func TestResize_ExplicitPositionMeasuresItsEdges(t *testing.T) {
+	t.Parallel()
+
+	withMargins := singleDisplay
+	withMargins.MarginsEnabled = true
+
+	// The visible frame in window coordinates: 1080 - 0 - 1050 puts its top at
+	// y = 30, and its left edge at x = 0.
+	const (
+		boundsX = 0.0
+		boundsY = 30.0
+	)
+
+	// A bottom anchor, for the axes no explicit coordinate is given for: its
+	// window is flush at the bottom and internal at the top, either way round.
+	bottomLeft := geometry.BottomLeft
+
+	tests := []struct {
+		name       string
+		posX       *float64
+		posY       *float64
+		horizontal float64
+		vertical   float64
+	}{
+		{
+			name:       "an origin on the boundary is flush",
+			posX:       new(boundsX),
+			posY:       new(boundsY),
+			horizontal: pinnedMargin,
+			vertical:   pinnedMargin,
+		},
+		{
+			name:       "an origin within half a point of it still is",
+			posX:       new(boundsX + 0.25),
+			posY:       new(boundsY - 0.25),
+			horizontal: pinnedMargin,
+			vertical:   pinnedMargin,
+		},
+		{
+			name:       "a whole point off the boundary is internal",
+			posX:       new(boundsX + 1),
+			posY:       new(boundsY + 1),
+			horizontal: internalMargin,
+			vertical:   internalMargin,
+		},
+		{
+			name:       "an explicit x leaves the vertical edges to the anchor",
+			posX:       new(boundsX + 1),
+			horizontal: internalMargin,
+			vertical:   pinnedMargin,
+		},
+		{
+			name:       "an explicit y leaves the horizontal edges to the anchor",
+			posY:       new(boundsY + 1),
+			horizontal: pinnedMargin,
+			vertical:   internalMargin,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.Resize(startFrame, withMargins, geometry.Request{
+				X:      testCase.posX,
+				Y:      testCase.posY,
+				Width:  geometry.Absolute(800),
+				Height: geometry.Absolute(600),
+				Anchor: &bottomLeft,
+			})
+
+			const request = "--x/--y --anchor bl --margin"
+
+			assertMargin(t, request, "width", 800-got.W, testCase.horizontal)
+			assertMargin(t, request, "height", 600-got.H, testCase.vertical)
 		})
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes windows flush against the same screen edge being given different
margins depending on which anchor put them there. With tiled window margins on,
an edge touching the screen boundary should take a full margin and an internal
edge half of one; whether an edge counted as touching was decided by comparing
the computed position against the visible frame exactly. That held for an edge
copied straight from the frame, but not for one arrived at by arithmetic — a
bottom or right edge, or a centred position — which misses by a fraction of a
fraction of a point whenever the display's metrics are not whole points. Those
edges silently took half a margin.

Which edges are flush now follows from what was asked for: the side an anchor
pins is flush by construction, and the opposite side once the window is as
large as the screen's visible frame along that axis. So a bottom-anchored
window and a top-anchored one now give up the same margin on the boundary they
each sit against, on any display. An explicit `--x`/`--y` is the one placement
that still has to be measured, because the coordinate is the user's own; it now
counts an edge within half a point of the boundary as touching it, which is
below what macOS can even store a frame at.

Behaviour on whole-point displays is unchanged — that is where the old
comparison happened to be right — so most users will see nothing move. What
changes is displays whose visible frame, or a percentage taken of it, lands on
fractional points: a scaled or non-integral display, or any percentage-sized
window on one. A window asked to be larger than the screen keeps the margins it
has always been given.

## Related Issues

Closes #66

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, `docs/CLI.md` already
      describes the intended rule ("full margins on screen-facing edges and
      half margins on internal edges"); this PR makes the code match it.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**The recorded baseline: no case changed, and it was re-recorded to prove it.**
`internal/baseline/window_baseline.json` holds 49 real-macOS frames replayed by
`TestResize_ReproducesTheRecordedFrames`. Every one of them was checked before
the data was touched, by replaying all 49 through the old and the new geometry
and diffing the computed frames: **zero differ**. The recording was captured on
a 1920x1050 visible frame with an 8pt margin, where every anchored position and
every percentage resolves to a whole point, so each edge that is flush by
construction also compared exactly equal under the old rule — the defect needs
fractional metrics to show at all.

That was then confirmed against macOS rather than against arithmetic: the
integration recorder was run on live macOS with the fix in place, first
asserting (all 49 resize cases matched the recording exactly, plus the four
focus cases) and then re-recording with `MIMI_RECORD_BASELINE=1`, which
produced a byte-identical file. No frame was hand-edited, no case dropped, and
the comparison tolerance in `internal/baseline/geometry_baseline_test.go` is
untouched.

One aside from re-recording, for whoever records next: a couple of the frames
whose x is zero read back from the Accessibility API as `-0` on some runs and
`0` on others — the file already holds both spellings. They compare equal, so
nothing fails, but a re-record can produce a diff that is pure sign-of-zero
noise. This branch leaves the recorded file exactly as it was.

**Tests.** The known-bug test that pinned this behaviour is inverted and
renamed: both anchors in it now agree at 12 points of margin given up. It is
joined by coverage of all nine anchors at both whole and fractional dimensions
— the margins each anchor gives up are identical across the two — a test that a
window filling the frame is flush at both ends of an axis, and a test that an
explicitly positioned edge counts as flush within half a point and not beyond
it, on each axis independently. Every one of them fails on the pre-fix
geometry, which is how they were checked to discriminate. No `_KnownBug` tests
remain in the repo.

**Trade-off.** The same half-point slack decides whether a window is as long as
the frame, so one a fraction of a point short of it still counts as filling it.
That is deliberate — below a point nothing is observable, and it is what keeps
a full-width window from losing its boundary margin to rounding. A window
*longer* than the frame is not treated as filling it: its far edge is off
screen, and it keeps the margin it has always had there.
