### PR TITLE
refactor(action,geometry): parse a direction name in one place

### DIFF
--- a/internal/action/perform.go
+++ b/internal/action/perform.go
@@ -37,7 +37,7 @@ func FocusWindow(backward bool, direction string) error {
 	defer window.ReleaseAll(windows)
 
 	if direction != "" {
-		dir, ok := directionFromFlag(direction)
+		dir, ok := geometry.ParseDirection(direction)
 		if !ok {
 			return derrors.Newf(
 				derrors.CodeInvalidInput,
@@ -73,23 +73,6 @@ func FocusWindow(backward bool, direction string) error {
 	}
 
 	return nil
-}
-
-// directionFromFlag maps a focus_window direction flag onto the geometry
-// direction it navigates in.
-func directionFromFlag(flag string) (geometry.Direction, bool) {
-	switch flag {
-	case "up":
-		return geometry.Up, true
-	case "down":
-		return geometry.Down, true
-	case "left":
-		return geometry.Left, true
-	case "right":
-		return geometry.Right, true
-	default:
-		return 0, false
-	}
 }
 
 // focusDirectional moves focus to the window nearest windows[currentIndex] in

--- a/internal/baseline/geometry_baseline_test.go
+++ b/internal/baseline/geometry_baseline_test.go
@@ -83,7 +83,7 @@ func TestNearest_ReproducesTheRecordedFocusTargets(t *testing.T) {
 
 	for _, focus := range recording.Focus {
 		t.Run(focus.Direction, func(t *testing.T) {
-			dir, ok := directionOf(focus.Direction)
+			dir, ok := geometry.ParseDirection(focus.Direction)
 			if !ok {
 				t.Fatalf("the recording holds an unknown direction %q", focus.Direction)
 			}
@@ -116,21 +116,5 @@ func TestNearest_ReproducesTheRecordedFocusTargets(t *testing.T) {
 				)
 			}
 		})
-	}
-}
-
-// directionOf maps a recorded direction name onto the geometry direction.
-func directionOf(name string) (geometry.Direction, bool) {
-	switch name {
-	case "up":
-		return geometry.Up, true
-	case "down":
-		return geometry.Down, true
-	case "left":
-		return geometry.Left, true
-	case "right":
-		return geometry.Right, true
-	default:
-		return 0, false
 	}
 }

--- a/internal/geometry/nearest.go
+++ b/internal/geometry/nearest.go
@@ -14,6 +14,27 @@ const (
 	Right
 )
 
+// directionsByName maps each direction name onto its direction. It is keyed by
+// name rather than by direction — unlike anchorNames, which a String method
+// also reads the other way round.
+var directionsByName = map[string]Direction{
+	"up":    Up,
+	"down":  Down,
+	"left":  Left,
+	"right": Right,
+}
+
+// ParseDirection maps a direction name onto its direction, and reports whether
+// the name is one of the four.
+//
+// An unknown name reports false alongside the zero direction, which is itself
+// a valid one — following Nearest, callers have to read the boolean.
+func ParseDirection(name string) (Direction, bool) {
+	dir, ok := directionsByName[name]
+
+	return dir, ok
+}
+
 // Nearest returns the index of the window nearest to frames[current] in the
 // given direction, and whether one was found.
 //

--- a/internal/geometry/nearest_test.go
+++ b/internal/geometry/nearest_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/y3owk1n/mimi/internal/geometry"
 )
 
+// The four direction names ParseDirection accepts.
+const (
+	directionUp    = "up"
+	directionDown  = "down"
+	directionLeft  = "left"
+	directionRight = "right"
+)
+
 func TestNearest_BreaksTiesOnTopThenLeftThenIndex(t *testing.T) {
 	current := &geometry.Rect{X: 0, Y: 0, W: 100, H: 100}
 
@@ -72,25 +80,25 @@ func TestNearest_PrefersAnOverlappingWindowOverACloserOffsetOne(t *testing.T) {
 		aligned *geometry.Rect
 	}{
 		{
-			name:    "up",
+			name:    directionUp,
 			dir:     geometry.Up,
 			offset:  &geometry.Rect{X: 300, Y: -10, W: 100, H: 100},
 			aligned: &geometry.Rect{X: 0, Y: -200, W: 100, H: 100},
 		},
 		{
-			name:    "down",
+			name:    directionDown,
 			dir:     geometry.Down,
 			offset:  &geometry.Rect{X: 300, Y: 110, W: 100, H: 100},
 			aligned: &geometry.Rect{X: 0, Y: 200, W: 100, H: 100},
 		},
 		{
-			name:    "left",
+			name:    directionLeft,
 			dir:     geometry.Left,
 			offset:  &geometry.Rect{X: -10, Y: 300, W: 100, H: 100},
 			aligned: &geometry.Rect{X: -200, Y: 0, W: 100, H: 100},
 		},
 		{
-			name:    "right",
+			name:    directionRight,
 			dir:     geometry.Right,
 			offset:  &geometry.Rect{X: 110, Y: 300, W: 100, H: 100},
 			aligned: &geometry.Rect{X: 200, Y: 0, W: 100, H: 100},
@@ -135,10 +143,10 @@ func TestNearest_PicksTheNeighborInTheRequestedDirection(t *testing.T) {
 		dir  geometry.Direction
 		want int
 	}{
-		{"up", geometry.Up, 1},
-		{"down", geometry.Down, 7},
-		{"left", geometry.Left, 3},
-		{"right", geometry.Right, 5},
+		{directionUp, geometry.Up, 1},
+		{directionDown, geometry.Down, 7},
+		{directionLeft, geometry.Left, 3},
+		{directionRight, geometry.Right, 5},
 	}
 
 	for _, tt := range tests {
@@ -206,6 +214,51 @@ func TestNearest_ReportsNotFoundWhenTheCurrentFrameIsUnusable(t *testing.T) {
 			got, ok := geometry.Nearest(tt.frames, tt.current, geometry.Right)
 			if ok {
 				t.Errorf("Nearest() = %d, true; want not found", got)
+			}
+		})
+	}
+}
+
+func TestParseDirection_MapsEveryName(t *testing.T) {
+	tests := []struct {
+		name string
+		want geometry.Direction
+	}{
+		{directionUp, geometry.Up},
+		{directionDown, geometry.Down},
+		{directionLeft, geometry.Left},
+		{directionRight, geometry.Right},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := geometry.ParseDirection(tt.name)
+			if !ok || got != tt.want {
+				t.Errorf("ParseDirection(%q) = %d, %v; want %d, true", tt.name, got, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDirection_ReportsUnknownNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"no direction at all", ""},
+		{"upper case", "UP"},
+		{"title case", "Up"},
+		{"trailing space", "up "},
+		{"a direction that does not exist", "north"},
+		{"an abbreviation", "u"},
+		{"two names run together", "updown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := geometry.ParseDirection(tt.input)
+			if ok {
+				t.Errorf("ParseDirection(%q) = %d, true; want not recognized", tt.input, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

This PR removes a duplicated piece of logic: the mapping from a direction name
("up", "down", "left", "right") onto the internal direction used by directional
window focus was written out twice — once where the focus command's direction
flag is handled, and once in the baseline oracle test. Both copies now call a
single parse helper that lives next to the direction type itself.

Nothing changes for users. The same four names are accepted, the same error
text comes back for anything else, and the pure geometry module still depends
on the standard library alone.

## Related Issues

Closes #71

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The new parse helper deliberately matches the convention the anchor parser set
in the same module: same return shape, an unrecognised name reported through
the boolean rather than a sentinel value, and the name table kept as a
package-level var beside its type. The one difference is which way the table is
keyed — the anchor table is keyed by anchor because it also backs that type's
string form, and the direction type has no string form to back, so its table is
keyed by name and says so in its comment. The anchor parser is untouched.

The direction flag names the focus command accepts are still spelled out
separately where those flags are parsed; folding that list into the same table
would change what the command rejects and how, so it was left for its own
change.

The failure branch on the focus path stays exactly as it was, including its
error code and message. It remains unreachable in practice, because the flag
parser only ever hands down one of the four names or the empty string; that was
true before this change and is still true after it.
