### PR TITLE
refactor(native): derive the enumerated applications from the window list

### DIFF
--- a/docs/testing/TESTING_PATTERNS.md
+++ b/docs/testing/TESTING_PATTERNS.md
@@ -103,11 +103,13 @@ Two properties matter when changing it:
   permission (CI), a locked screen, or a display other than the one the
   recording was captured on.
 
-The recorder must launch its helper application before the first window
-enumeration. `NSWorkspace` refreshes its running-application list from the run
-loop, which a test binary never spins, so an application launched after that
-list is first read stays invisible to the action layer for the rest of the
-process.
+The recorder used to have to launch its helper application before the first
+window enumeration, because the enumeration read its application list from
+`NSWorkspace`, which only refreshes from the run loop a test binary never
+spins. That constraint is gone — the enumeration derives its applications from
+the window list instead — and
+`TestEnumeration_SeesAnApplicationLaunchedAfterTheFirstEnumeration` is what
+keeps it gone.
 
 Re-record after changing a case, or to capture the baseline on your own display:
 

--- a/internal/baseline/enumeration_integration_test.go
+++ b/internal/baseline/enumeration_integration_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+// Regression test for the enumeration staleness in #69.
+//
+// The applications the active-space enumeration walks used to come from
+// -[NSWorkspace runningApplications], which only refreshes while the main
+// thread's run loop runs. A test binary never pumps it, so the list froze at
+// the first enumeration and nothing launched afterwards was ever seen again.
+// The enumeration now derives its applications from the window list instead,
+// which has no such dependency.
+//
+// The test opens one throwaway TextEdit document, never touches a window it did
+// not open, and skips rather than fails whenever the machine cannot support it.
+
+package baseline_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/permissions"
+	"github.com/y3owk1n/mimi/internal/window"
+)
+
+func TestEnumeration_SeesAnApplicationLaunchedAfterTheFirstEnumeration(t *testing.T) {
+	if !permissions.Check().Accessibility {
+		t.Skip("Accessibility permission is not granted; windows cannot be enumerated")
+	}
+
+	// Read the window list once, so that anything cached behind it is cached
+	// before the helper exists. Without this the test would only be meaningful
+	// when it happens to run first in the binary.
+	windows, err := window.AllFocusableOnActiveSpace()
+	if err != nil {
+		t.Fatalf("could not enumerate the windows on the active space: %v", err)
+	}
+
+	window.ReleaseAll(windows)
+
+	pids := launchHelper(t, 1)
+
+	// Whether the helper really has a usable window is established through the
+	// focused-application path, which reads Accessibility directly and so
+	// cannot be answered out of the same cache the enumeration used to depend
+	// on. If that never agrees, this machine is not in a state the test can
+	// judge — somebody took focus back, or the document did not open.
+	if !waitForHelperToBeFrontmost(t, pids) {
+		t.Skipf("the helper never came to the front within %s", focusTimeout)
+	}
+
+	// The helper owns a real, focused window that the enumeration did not know
+	// about when it last ran. Anything short of finding it is the defect.
+	if !waitForHelperInEnumeration(t, pids) {
+		t.Fatalf(
+			"the helper is frontmost but is still missing from the enumeration after %s; "+
+				"the application list is stale (see #69)",
+			settleTimeout,
+		)
+	}
+}
+
+// waitForHelperToBeFrontmost reports whether the frontmost window belongs to one
+// of the given helper processes before focusTimeout.
+func waitForHelperToBeFrontmost(t *testing.T, pids map[int]bool) bool {
+	t.Helper()
+
+	return waitFor(focusTimeout, func() bool {
+		front := window.Frontmost()
+		if front == nil {
+			return false
+		}
+		defer front.Release()
+
+		pid, err := front.PID()
+
+		return err == nil && pids[pid]
+	})
+}
+
+// waitForHelperInEnumeration reports whether the active space's enumeration
+// includes a window owned by one of the given helper processes before
+// settleTimeout.
+func waitForHelperInEnumeration(t *testing.T, pids map[int]bool) bool {
+	t.Helper()
+
+	return waitFor(settleTimeout, func() bool {
+		windows, err := window.AllFocusableOnActiveSpace()
+		if err != nil {
+			t.Fatalf("could not enumerate the windows on the active space: %v", err)
+		}
+		defer window.ReleaseAll(windows)
+
+		for _, element := range windows {
+			pid, pidErr := element.PID()
+			if pidErr == nil && pids[pid] {
+				return true
+			}
+		}
+
+		return false
+	})
+}
+
+// waitFor polls condition until it holds or the timeout expires.
+func waitFor(timeout time.Duration, condition func() bool) bool {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		if condition() {
+			return true
+		}
+
+		if time.Now().After(deadline) {
+			return false
+		}
+
+		time.Sleep(pollInterval)
+	}
+}

--- a/internal/baseline/helper_integration_test.go
+++ b/internal/baseline/helper_integration_test.go
@@ -32,25 +32,20 @@ const (
 	quitTimeout   = 10 * time.Second
 )
 
-// launchHelper starts a fresh helper instance holding windowCount documents,
-// registers a cleanup that terminates exactly the processes it started, and
-// returns their process IDs.
-//
-// It has to run before the first window enumeration. NSWorkspace only refreshes
-// its running-application list from the run loop, which a test binary never
-// spins, so an application launched after that list is first read stays
-// invisible to the action layer for the rest of the process.
-func launchHelper(t *testing.T) map[int]bool {
+// launchHelper starts a fresh helper instance holding the given number of
+// documents — one per window the caller needs — registers a cleanup that
+// terminates exactly the processes it started, and returns their process IDs.
+func launchHelper(t *testing.T, documents int) map[int]bool {
 	t.Helper()
 
 	dir := t.TempDir()
 
 	const openFlags = 3
 
-	args := make([]string, 0, openFlags+windowCount)
+	args := make([]string, 0, openFlags+documents)
 	args = append(args, "-n", "-a", helperApp)
 
-	for index := range windowCount {
+	for index := range documents {
 		path := filepath.Join(dir, fmt.Sprintf("mimi-baseline-%d.txt", index))
 
 		err := os.WriteFile(path, []byte("mimi window baseline\n"), 0o600)

--- a/internal/baseline/window_integration_test.go
+++ b/internal/baseline/window_integration_test.go
@@ -145,9 +145,7 @@ func TestWindowBaseline_ResizeAndFocus(t *testing.T) {
 		)
 	}
 
-	// The helper has to start before the first window enumeration; see
-	// launchHelper. Everything above this line only reads screens and files.
-	fixture := newHarness(t, live, launchHelper(t))
+	fixture := newHarness(t, live, launchHelper(t, windowCount))
 
 	var resizeCount, focusCount int
 

--- a/internal/native/element.m
+++ b/internal/native/element.m
@@ -22,6 +22,11 @@ void *MimiGetFocusedApplication(void) {
 			}
 		}
 
+		// Last resort only. NSWorkspace answers this out of state it refreshes
+		// from the main thread's run loop, which neither the CLI nor an
+		// action-serving daemon thread pumps, so it can name an application
+		// that is no longer frontmost. The system-wide Accessibility query
+		// above is the one that is always current.
 		NSRunningApplication *front = [NSWorkspace sharedWorkspace].frontmostApplication;
 		if (!front)
 			return NULL;

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -9,11 +9,14 @@
 #import <Cocoa/Cocoa.h>
 #import <CoreGraphics/CoreGraphics.h>
 
-static NSSet<NSNumber *> *mimiVisibleRegularAppPIDs(void) {
+/// Process identifiers of every process owning an on-screen, layer-0 window,
+/// in ascending order. This is the source of the applications to enumerate, so
+/// it is deliberately fetched fresh on every call.
+static NSArray<NSNumber *> *mimiOnScreenWindowOwnerPIDs(void) {
 	CFArrayRef windowList = CGWindowListCopyWindowInfo(
 	    kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
 	if (!windowList)
-		return [NSSet set];
+		return @[];
 
 	NSMutableSet<NSNumber *> *pids = [NSMutableSet set];
 	CFIndex count = CFArrayGetCount(windowList);
@@ -42,7 +45,7 @@ static NSSet<NSNumber *> *mimiVisibleRegularAppPIDs(void) {
 	}
 
 	CFRelease(windowList);
-	return [pids copy];
+	return [pids.allObjects sortedArrayUsingSelector:@selector(compare:)];
 }
 
 void *MimiGetFrontmostWindow(void) {
@@ -52,6 +55,11 @@ void *MimiGetFrontmostWindow(void) {
 		bool shouldReleaseAppRef = false;
 
 		if (!appRef) {
+			// Last resort only. NSWorkspace answers this out of state it
+			// refreshes from the main thread's run loop, which neither the CLI
+			// nor an action-serving daemon thread pumps, so it can name an
+			// application that is no longer frontmost. The Accessibility path
+			// above is the one that is always current.
 			NSRunningApplication *front = [NSWorkspace sharedWorkspace].frontmostApplication;
 			if (!front)
 				return NULL;
@@ -161,16 +169,23 @@ static CFArrayRef mimiCollectFocusableWindowsOnActiveSpace(int *outCount, int *o
 		if (outFocusedIndex)
 			*outFocusedIndex = -1;
 
-		NSSet<NSNumber *> *visiblePIDs = mimiVisibleRegularAppPIDs();
-		NSArray *runningApps = [[NSWorkspace sharedWorkspace].runningApplications
-		    sortedArrayUsingComparator:^NSComparisonResult(NSRunningApplication *obj1, NSRunningApplication *obj2) {
-			    if (obj1.processIdentifier < obj2.processIdentifier) {
-				    return NSOrderedAscending;
-			    } else if (obj1.processIdentifier > obj2.processIdentifier) {
-				    return NSOrderedDescending;
-			    }
-			    return NSOrderedSame;
-		    }];
+		// The applications to walk are derived from the window list, not from
+		// -[NSWorkspace runningApplications]. That array is only refreshed
+		// while the *main* thread's run loop runs, and nothing here can
+		// guarantee that: the CLI never pumps it, and the daemon pumps it on
+		// its own observer thread while actions are served from another. In a
+		// process that does not pump it, the array stays frozen at its first
+		// read and every application launched afterwards is invisible for the
+		// life of the process. CGWindowListCopyWindowInfo carries no such
+		// dependency and was already being fetched here anyway.
+		//
+		// The per-pid NSRunningApplication lookup below is answered live
+		// rather than from that array, which is what lets the activation
+		// policy and hidden filters stay exactly as they were. Dropping them
+		// and taking the window list alone would widen enumeration to
+		// processes that own a layer-0 window without being applications —
+		// border drawers and overlays, which have no AX window list to walk.
+		NSArray<NSNumber *> *ownerPIDs = mimiOnScreenWindowOwnerPIDs();
 		CFMutableArrayRef windowsCollector = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
 		if (!windowsCollector)
 			return NULL;
@@ -194,14 +209,15 @@ static CFArrayRef mimiCollectFocusableWindowsOnActiveSpace(int *outCount, int *o
 			CFRelease(focusedApp);
 		}
 
-		for (NSRunningApplication *app in runningApps) {
+		for (NSNumber *ownerPID in ownerPIDs) {
+			pid_t pid = (pid_t)ownerPID.intValue;
+
+			NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+			if (!app)
+				continue;
 			if (app.activationPolicy != NSApplicationActivationPolicyRegular)
 				continue;
 			if (app.hidden)
-				continue;
-
-			pid_t pid = app.processIdentifier;
-			if (![visiblePIDs containsObject:@(pid)])
 				continue;
 
 			AXUIElementRef appElement = AXUIElementCreateApplication(pid);


### PR DESCRIPTION
## Description

This PR reworks how mimi decides which applications to look inside when it lists the windows on the active space. It used to ask the system for a list of running applications and cross it with a live window list. The window half was current; the application half was not — that list is only refreshed while a run loop is running on the main thread, and nothing at the call site can promise one is. In a process that never pumps one, the list freezes the first time it is read and anything launched afterwards stays invisible for the rest of that process's life.

The applications are now taken from the window list itself, which was already being fetched in the same place and has no such dependency. The same two filters as before — regular applications only, nothing hidden — still apply, by looking each window's owner up individually rather than out of the frozen list, so the windows that come back, the order they come back in, and which one is reported as focused are all unchanged.

Nothing a user does today is affected: the CLI is short-lived and the daemon runs a run loop, so both paths were already safe. What changes is that they no longer have to be — the constraint is gone rather than accidentally satisfied.

## Related Issues

Closes #69

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

`refactor` rather than `fix` on purpose: the defect has no user-visible symptom on either shipped path, so it would read strangely in the changelog. Happy to change it if you would rather it shipped as a `fix`.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

`just fmt-check` and `just vet` also pass.

## Additional Context

**Why this option and not the other one.** The issue offered two: pump the run loop briefly inside the enumeration, or derive the applications from the window list. A standalone probe settled it — pumping a *secondary* thread's run loop does not refresh the application list at all; only the main thread's does. The enumeration runs on whichever OS thread the goroutine lands on, and the daemon pumps its run loop on the observer thread while actions are served from another, so the pump would have had to be dispatched to the main thread and waited on. That is a blocking hop and a run-loop re-entry on a read path, to fix something the other option removes outright.

**Why the per-process lookup stayed.** Taking the window list alone would have changed which applications are considered. Processes that own an ordinary window without being applications — a border drawer was running here — are not resolvable that way and would have been walked for windows they cannot answer for. Looking each owner up individually keeps the old filters exactly, and the same lookup is already used elsewhere in the window and observer code.

**What was measured, before and after.**

| Probe | Before | After |
| --- | --- | --- |
| No run loop, launch an app, re-enumerate for 12s | never appears; count pinned | appears within one poll |
| Same, pumping a *secondary* thread's run loop | still never appears | n/a |
| Steady-state application set, old selection vs new | identical, same order | identical, same order |
| Per-process lookup for a just-launched process | correct policy and hidden state | same |
| Hidden state after hiding an app, no run loop | reflects the change immediately | same |

**Baselines.** No recorded case moved. `window_baseline.json` is untouched, `TestResize_ReproducesTheRecordedFrames` and `TestNearest_ReproducesTheRecordedFocusTargets` replay clean, and the live `TestWindowBaseline_ResizeAndFocus` passes all four focus recordings against real windows.

**The new test.** It enumerates once, then opens one throwaway document and requires it to show up. It confirms the document really has a focused window through Accessibility first, so a machine that cannot run it skips instead of failing. Reverting just the native change turns it red, which is what makes it a regression test rather than a description.

**Left alone.** Two fallbacks that ask the same subsystem for the frontmost application carry the same trap. Both sit behind an Accessibility path that answers first, so neither is a live bug; each now carries a note saying why it is a last resort.
