### PR TITLE
fix(logging): honor log_format for the console encoder

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -26,6 +26,8 @@
 # log_file = "~/.local/share/mimi/mimi.log"
 
 log_level = "info"
+# Console log format: "text" (human-readable) or "json". The log file above is
+# always JSON, whatever this is set to.
 log_format = "text"
 hook_timeout_secs = 10
 hook_shell = "/bin/sh"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,13 +17,19 @@ mimi config reload     # reload running daemon (SIGHUP)
 [settings]
 log_file = "~/.local/share/mimi/mimi.log"   # optional; omit for console-only
 log_level = "info"                           # debug | info | warn | error
-log_format = "text"                          # text | json
+log_format = "text"                          # text | json — console output only
 hook_timeout_secs = 10
 hook_shell = "/bin/sh"
 max_hook_workers = 4
 pid_file = "~/.local/share/mimi/mimi.pid"
 resize_debounce_ms = 250                     # on_window_resize debounce window
 ```
+
+`log_format` selects the **console** encoder only: `text` is the human-readable
+line (colorized when the console is a terminal), `json` is one JSON object per
+line with no color. The `log_file` log is always JSON, whatever `log_format`
+says, so anything already piping that file through `jq` keeps working. An
+unrecognized value logs a warning and falls back to `text`.
 
 ---
 

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -23,40 +23,32 @@ const (
 	logMaxAgeDays = 28
 )
 
+// Recognized values of the settings.log_format setting. It selects the console
+// encoder only; the log file is always JSON.
+const (
+	formatText = "text"
+	formatJSON = "json"
+)
+
 // New creates a zap sugared logger with console and optional file output.
 func New(cfg *config.Config) *zap.SugaredLogger {
+	consoleWriter := os.Stdout
+
+	return newLogger(cfg, zapcore.AddSync(consoleWriter), term.IsTerminal(int(consoleWriter.Fd())))
+}
+
+// newLogger builds the logger against an explicit console sink, so tests can
+// choose both the sink and whether it counts as a terminal.
+func newLogger(
+	cfg *config.Config,
+	consoleWriter zapcore.WriteSyncer,
+	isTerminal bool,
+) *zap.SugaredLogger {
 	level := parseLevel(cfg.Settings.LogLevel)
+	format, knownFormat := parseFormat(cfg.Settings.LogFormat)
 
-	consoleWriter := zapcore.WriteSyncer(os.Stdout)
-
-	isTerminal := false
-
-	if f, ok := consoleWriter.(*os.File); ok {
-		isTerminal = term.IsTerminal(int(f.Fd()))
-	}
-
-	// Configure encoder
-	consoleEncoderConfig := zap.NewDevelopmentEncoderConfig()
-
-	consoleEncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-
-	if isTerminal {
-		consoleEncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	} else {
-		consoleEncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
-	}
-
-	fileEncoderConfig := zap.NewProductionEncoderConfig()
-
-	fileEncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-	fileEncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
-
-	// Create console encoder (human-readable)
-	consoleEncoder := zapcore.NewConsoleEncoder(consoleEncoderConfig)
-
-	// Create cores slice
 	cores := []zapcore.Core{
-		zapcore.NewCore(consoleEncoder, zapcore.AddSync(consoleWriter), level),
+		zapcore.NewCore(consoleEncoder(format, isTerminal), consoleWriter, level),
 	}
 
 	if cfg.Settings.LogFile != "" {
@@ -67,16 +59,72 @@ func New(cfg *config.Config) *zap.SugaredLogger {
 			MaxAge:     logMaxAgeDays,
 		}
 
-		// Create file encoder (JSON for machine parsing)
-		fileEncoder := zapcore.NewJSONEncoder(fileEncoderConfig)
+		// The file log is JSON for machine parsing, whatever log_format says.
+		fileEncoder := zapcore.NewJSONEncoder(jsonEncoderConfig())
 
-		// Add file core
 		cores = append(cores, zapcore.NewCore(fileEncoder, zapcore.AddSync(logWriter), level))
 	}
 
 	core := zapcore.NewTee(cores...)
 
-	return zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel)).Sugar()
+	logger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel)).Sugar()
+
+	if !knownFormat {
+		// The value itself stays out of the log; it is the user's config text.
+		logger.Warnw(
+			"unrecognized settings.log_format, using text",
+			"valid",
+			formatText+"|"+formatJSON,
+		)
+	}
+
+	return logger
+}
+
+// parseFormat maps a configured log_format onto the console format it selects,
+// reporting whether the value was recognized. An empty value is the unset
+// default, and anything unrecognized falls back to text.
+func parseFormat(format string) (string, bool) {
+	switch {
+	case format == "", strings.EqualFold(format, formatText):
+		return formatText, true
+	case strings.EqualFold(format, formatJSON):
+		return formatJSON, true
+	default:
+		return formatText, false
+	}
+}
+
+// consoleEncoder builds the console encoder for a parsed log format:
+// human-readable for text, JSON for json. Only the human-readable encoder
+// colorizes its level, and only when the console is a terminal.
+func consoleEncoder(format string, isTerminal bool) zapcore.Encoder {
+	if format == formatJSON {
+		return zapcore.NewJSONEncoder(jsonEncoderConfig())
+	}
+
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+
+	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+
+	if isTerminal {
+		encoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	} else {
+		encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	}
+
+	return zapcore.NewConsoleEncoder(encoderConfig)
+}
+
+// jsonEncoderConfig is the machine-parseable encoder configuration, shared by
+// the log file and by the console when log_format is "json".
+func jsonEncoderConfig() zapcore.EncoderConfig {
+	encoderConfig := zap.NewProductionEncoderConfig()
+
+	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+
+	return encoderConfig
 }
 
 // WriteEventLog subscribes to the event bus and writes JSON events to a log file.

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,166 @@
+//nolint:testpackage
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/y3owk1n/mimi/internal/config"
+)
+
+// newTestConfig is a config with nothing set but the logging settings a test
+// cares about.
+func newTestConfig(format, logFile string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Settings.LogLevel = "info"
+	cfg.Settings.LogFormat = format
+	cfg.Settings.LogFile = logFile
+
+	return cfg
+}
+
+// newTestLogger builds a logger whose console sink is an in-memory buffer, so
+// the encoder selection can be asserted without a real terminal.
+func newTestLogger(format string, isTerminal bool) (*zap.SugaredLogger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+
+	return newLogger(newTestConfig(format, ""), zapcore.AddSync(buf), isTerminal), buf
+}
+
+func TestNewLogger_JSONFormatWritesJSONToConsole(t *testing.T) {
+	logger, buf := newTestLogger(formatJSON, false)
+
+	logger.Infow("hello", "count", 1)
+
+	var entry map[string]any
+
+	err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &entry)
+	if err != nil {
+		t.Fatalf("console output is not JSON: %v (output %q)", err, buf.String())
+	}
+
+	if entry["msg"] != "hello" {
+		t.Errorf("msg = %v, want %q", entry["msg"], "hello")
+	}
+
+	if entry["count"] != float64(1) {
+		t.Errorf("count = %v, want 1", entry["count"])
+	}
+}
+
+func TestNewLogger_TextFormatWritesTheHumanReadableConsoleLine(t *testing.T) {
+	for _, format := range []string{formatText, ""} {
+		t.Run("format "+format, func(t *testing.T) {
+			logger, buf := newTestLogger(format, false)
+
+			logger.Infow("hello", "count", 1)
+
+			out := buf.String()
+			if !strings.Contains(out, "\tINFO\t") || !strings.Contains(out, "\thello\t") {
+				t.Errorf("console output is not the human-readable line: %q", out)
+			}
+
+			if !strings.Contains(out, `{"count": 1}`) {
+				t.Errorf("console output lost its fields: %q", out)
+			}
+
+			if strings.Contains(out, "\x1b[") {
+				t.Errorf("non-terminal console output carries color escapes: %q", out)
+			}
+		})
+	}
+}
+
+func TestNewLogger_TextFormatColorsTheLevelOnATerminal(t *testing.T) {
+	logger, buf := newTestLogger(formatText, true)
+
+	logger.Info("hello")
+
+	if !strings.Contains(buf.String(), "\x1b[") {
+		t.Errorf("terminal console output lost its color escapes: %q", buf.String())
+	}
+}
+
+func TestNewLogger_JSONFormatCarriesNoColorOnATerminal(t *testing.T) {
+	logger, buf := newTestLogger(formatJSON, true)
+
+	logger.Infow("hello")
+
+	if strings.Contains(buf.String(), "\x1b[") {
+		t.Errorf("json console output carries color escapes: %q", buf.String())
+	}
+}
+
+func TestNewLogger_UnknownFormatWarnsAndFallsBackToText(t *testing.T) {
+	logger, buf := newTestLogger("yaml", false)
+
+	warning := buf.String()
+	if !strings.Contains(warning, "WARN") || !strings.Contains(warning, "settings.log_format") {
+		t.Errorf("an unknown log_format was accepted silently: %q", warning)
+	}
+
+	buf.Reset()
+	logger.Info("hello")
+
+	if !strings.Contains(buf.String(), "\thello") {
+		t.Errorf("unknown log_format did not fall back to text: %q", buf.String())
+	}
+}
+
+func TestNewLogger_KnownFormatWarnsAboutNothing(t *testing.T) {
+	for _, format := range []string{formatText, "TEXT", formatJSON, "JSON", ""} {
+		t.Run("format "+format, func(t *testing.T) {
+			_, buf := newTestLogger(format, false)
+
+			if buf.Len() != 0 {
+				t.Errorf("a known log_format warned: %q", buf.String())
+			}
+		})
+	}
+}
+
+func TestNewLogger_LogFileStaysJSONForEveryFormat(t *testing.T) {
+	for _, format := range []string{formatText, formatJSON} {
+		t.Run("format "+format, func(t *testing.T) {
+			logPath := filepath.Join(t.TempDir(), "mimi.log")
+
+			cfg := newTestConfig(format, logPath)
+
+			logger := newLogger(cfg, zapcore.AddSync(&bytes.Buffer{}), true)
+
+			logger.Infow("hello", "count", 1)
+
+			err := logger.Sync()
+			if err != nil {
+				t.Fatalf("sync: %v", err)
+			}
+
+			written, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("read log file: %v", err)
+			}
+
+			var entry map[string]any
+
+			err = json.Unmarshal(bytes.TrimSpace(written), &entry)
+			if err != nil {
+				t.Fatalf("log file is not JSON: %v (contents %q)", err, written)
+			}
+
+			if entry["msg"] != "hello" {
+				t.Errorf("msg = %v, want %q", entry["msg"], "hello")
+			}
+
+			if strings.Contains(string(written), "\x1b[") {
+				t.Errorf("log file carries color escapes: %q", written)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the `log_format` setting, which was documented and shipped in the
default config but never read: console output was always the human-readable
format no matter what the setting said. It now selects the console format, so
`json` gives one JSON object per line on stdout — useful when the daemon's
output is captured by a supervisor or shipped somewhere that parses it.

The scope is deliberately the console only. The log file stays JSON whatever
the setting says, so nobody piping that file through `jq` sees a change; since
the default is `text`, driving both sinks from the setting would have flipped
every existing log file to plain text without the user touching anything.
With `log_format = "text"` (the default) output is byte-for-byte what it was
before this change, on both sinks.

## Config, command, and hook changes

| Key | Values | Default | Effect |
| --- | --- | --- | --- |
| `settings.log_format` | `text`, `json` (case-insensitive) | `text` | Console encoder only |

```toml
[settings]
log_format = "json"   # console output becomes one JSON object per line
```

- `text` — the human-readable line, with the level colorized when stdout is a
  terminal. Unchanged from today.
- `json` — one JSON object per line, with the same field names the log file
  uses, and never colorized, terminal or not.
- The `log_file` log is always JSON, regardless of this setting.
- An unrecognized value logs a warning at startup and falls back to `text`;
  existing config files keep loading. This is the choice the issue asked to be
  named: rejecting the value at config-validation time was the alternative, but
  the setting has never done anything until now, so a config with a typo in it
  works today, and refusing to start on it would turn a cosmetic mistake into a
  daemon that will not come up. It also matches how the neighbouring
  `log_level` treats a value it does not recognize. The trade-off is that the
  warning goes through the logger it just configured, so `log_level = "error"`
  suppresses it.

## Related Issues

Closes #85

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The logger now builds its cores against an explicit console sink and an
explicit "is this a terminal" answer, so the encoder selection is tested
against an in-memory buffer and the colorized path is covered on a machine
without a terminal — the tests do not care whether the runner has one.

The text path was checked for byte equality rather than eyeballed: the old and
new encoder pipelines were run over the same entry, with and without the
terminal flag, and compared byte for byte before that scaffolding was removed.

`just vet` was also run. Nothing here touches the native bridges, and the
change has no visual surface, so no screenshots.
