### PR TITLE
fix(cli): resolve the default config path for every command

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -10,11 +10,13 @@ import (
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
 
-// actionCmd performs immediate window and space utility actions.
-var actionCmd = &cobra.Command{
-	Use:   "action",
-	Short: "Perform window and space utility actions",
-	Long: `Perform immediate window and space utility actions.
+// newActionCmd builds the command tree that performs immediate window and
+// space utility actions.
+func newActionCmd(state *cliState) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "action",
+		Short: "Perform window and space utility actions",
+		Long: `Perform immediate window and space utility actions.
 
 Available subcommands:
   Window control:   focus_window, resize_window
@@ -32,22 +34,23 @@ Examples:
   mimi action resize_window left-half
   mimi action resize_window --width 800 --height 600 --anchor cc
   mimi action resize_window --width-percent 50 --height-percent 100 --anchor tl`,
-	RunE: func(_ *cobra.Command, _ []string) error {
-		return derrors.New(
-			derrors.CodeInvalidInput,
-			"action subcommand required (e.g., mimi action focus_window, mimi action space 1)",
-		)
-	},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return derrors.New(
+				derrors.CodeInvalidInput,
+				"action subcommand required (e.g., mimi action focus_window, mimi action space 1)",
+			)
+		},
+	}
+
+	cmd.AddCommand(buildFocusWindowCommand(state))
+	cmd.AddCommand(buildSpaceCommand(state))
+	cmd.AddCommand(buildMoveWindowToSpaceCommand(state))
+	cmd.AddCommand(buildResizeWindowCommand(state))
+
+	return cmd
 }
 
-var (
-	actionFocusWindowCmd       = buildFocusWindowCommand()
-	actionSpaceCmd             = buildSpaceCommand()
-	actionMoveWindowToSpaceCmd = buildMoveWindowToSpaceCommand()
-	actionResizeWindowCmd      = buildResizeWindowCommand()
-)
-
-func buildFocusWindowCommand() *cobra.Command {
+func buildFocusWindowCommand(state *cliState) *cobra.Command {
 	var (
 		backward   bool
 		focusUp    bool
@@ -90,7 +93,7 @@ current space are included.`,
 				args = append(args, "--right")
 			}
 
-			return runAction(string(action.NameFocusWindow), args)
+			return state.runAction(string(action.NameFocusWindow), args)
 		},
 	}
 
@@ -108,7 +111,7 @@ current space are included.`,
 	return cmd
 }
 
-func buildSpaceCommand() *cobra.Command {
+func buildSpaceCommand(state *cliState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "space <number|next|prev>",
 		Short: "Focus a Mission Control space by index or cycle next/prev",
@@ -135,12 +138,12 @@ Examples:
   mimi action space prev     Cycle to the previous space (with wrap)`,
 		Args: validateActionSpaceArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runAction(string(action.NameSpace), []string{strings.TrimSpace(args[0])})
+			return state.runAction(string(action.NameSpace), []string{strings.TrimSpace(args[0])})
 		},
 	}
 }
 
-func buildMoveWindowToSpaceCommand() *cobra.Command {
+func buildMoveWindowToSpaceCommand(state *cliState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "move_window_to_space <number|next|prev>",
 		Short: "Move current focused window to a Mission Control space by index or cycle next/prev",
@@ -163,7 +166,7 @@ Examples:
   mimi action move_window_to_space prev     Move window to previous space (with wrap)`,
 		Args: validateActionMoveWindowToSpaceArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runAction(
+			return state.runAction(
 				string(action.NameMoveWindowToSpace),
 				[]string{strings.TrimSpace(args[0])},
 			)
@@ -171,7 +174,7 @@ Examples:
 	}
 }
 
-func buildResizeWindowCommand() *cobra.Command {
+func buildResizeWindowCommand(state *cliState) *cobra.Command {
 	var (
 		width     int
 		height    int
@@ -286,7 +289,7 @@ Examples:
 				cmdArgs = append(cmdArgs, "--no-margin")
 			}
 
-			return runAction(string(action.NameResizeWindow), cmdArgs)
+			return state.runAction(string(action.NameResizeWindow), cmdArgs)
 		},
 	}
 
@@ -374,11 +377,4 @@ func validateActionIndexArgs(args []string, actionName string) error {
 	}
 
 	return nil
-}
-
-func init() {
-	actionCmd.AddCommand(actionFocusWindowCmd)
-	actionCmd.AddCommand(actionSpaceCmd)
-	actionCmd.AddCommand(actionMoveWindowToSpaceCmd)
-	actionCmd.AddCommand(actionResizeWindowCmd)
 }

--- a/cmd/mimi/cmd/action_runner.go
+++ b/cmd/mimi/cmd/action_runner.go
@@ -6,8 +6,10 @@ import (
 	"github.com/y3owk1n/mimi/internal/ipc"
 )
 
-func runAction(name string, args []string) error {
-	socketPath := ipc.ResolveSocketPath(configPath)
+// runAction sends an action to the daemon, falling back to executing it
+// directly when no daemon is listening.
+func (s *cliState) runAction(name string, args []string) error {
+	socketPath := ipc.ResolveSocketPath(s.configPath)
 
 	err := ipc.TryExecute(socketPath, name, args)
 	if err == nil {

--- a/cmd/mimi/cmd/config.go
+++ b/cmd/mimi/cmd/config.go
@@ -12,10 +12,11 @@ import (
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
 
-var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Manage Mimi configuration",
-	Long: `Commands for managing the Mimi configuration file and runtime settings.
+func newConfigCmd(state *cliState) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Mimi configuration",
+		Long: `Commands for managing the Mimi configuration file and runtime settings.
 
 Subcommands:
   dump       Print the resolved configuration as JSON
@@ -24,101 +25,109 @@ Subcommands:
   validate   Check a configuration file for errors
 
 See 'mimi config <subcommand> --help' for details on each.`,
+	}
+
+	cmd.AddCommand(newConfigDumpCmd(state))
+	cmd.AddCommand(newConfigReloadCmd(state))
+	cmd.AddCommand(newConfigInitCmd(state))
+	cmd.AddCommand(newConfigValidateCmd(state))
+
+	return cmd
 }
 
-var configDumpCmd = &cobra.Command{
-	Use:   "dump",
-	Short: "Print the resolved configuration as JSON",
-	Long:  "Print the currently resolved Mimi configuration as pretty-printed JSON. Useful for verifying that your config file is being parsed correctly.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load(configPath)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading config")
-		}
+func newConfigDumpCmd(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "dump",
+		Short: "Print the resolved configuration as JSON",
+		Long:  "Print the currently resolved Mimi configuration as pretty-printed JSON. Useful for verifying that your config file is being parsed correctly.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := config.Load(state.configPath)
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading config")
+			}
 
-		data, err := json.MarshalIndent(cfg, "", "  ")
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeSerializationFailed, "marshaling config")
-		}
+			data, err := json.MarshalIndent(cfg, "", "  ")
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeSerializationFailed, "marshaling config")
+			}
 
-		cmd.Println(string(data))
+			cmd.Println(string(data))
 
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
-var configReloadCmd = &cobra.Command{
-	Use:   "reload",
-	Short: "Reload configuration from disk",
-	Long:  "Reload the Mimi configuration file from disk without restarting the running daemon. Changes to hooks and settings take effect immediately.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load(configPath)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading config")
-		}
+func newConfigReloadCmd(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "reload",
+		Short: "Reload configuration from disk",
+		Long:  "Reload the Mimi configuration file from disk without restarting the running daemon. Changes to hooks and settings take effect immediately.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := config.Load(state.configPath)
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading config")
+			}
 
-		pid, err := readPID(cfg.Settings.PIDFile)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeInternal, "reading pid file")
-		}
+			pid, err := readPID(cfg.Settings.PIDFile)
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeInternal, "reading pid file")
+			}
 
-		proc, err := os.FindProcess(pid)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeInternal, "process %d not found", pid)
-		}
+			proc, err := os.FindProcess(pid)
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeInternal, "process %d not found", pid)
+			}
 
-		err = proc.Signal(syscall.SIGHUP)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeInternal, "signaling process %d", pid)
-		}
+			err = proc.Signal(syscall.SIGHUP)
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeInternal, "signaling process %d", pid)
+			}
 
-		cmd.Println("Configuration reload requested")
+			cmd.Println("Configuration reload requested")
 
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
-var configInitCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Create a default configuration file",
-	Long: `Writes the default config to the config path (default: ~/.config/mimi/config.toml).
+func newConfigInitCmd(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Create a default configuration file",
+		Long: `Writes the default config to the config path (default: ~/.config/mimi/config.toml).
 Safe to re-run — it will overwrite any existing config.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := config.WriteDefault(configPath)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeConfigIOFailed, "writing default config")
-		}
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := config.WriteDefault(state.configPath)
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeConfigIOFailed, "writing default config")
+			}
 
-		cmd.Printf("Default config written to %s\n", configPath)
-		cmd.Println("Edit it to customize hooks, then run 'mimi start'.")
+			cmd.Printf("Default config written to %s\n", state.configPath)
+			cmd.Println("Edit it to customize hooks, then run 'mimi start'.")
 
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
-var configValidateCmd = &cobra.Command{
-	Use:   "validate",
-	Short: "Parse and validate the config file, reporting any errors",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load(configPath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Config invalid:\n  %s\n", err)
-			os.Exit(1)
-		}
+func newConfigValidateCmd(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate",
+		Short: "Parse and validate the config file, reporting any errors",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := config.Load(state.configPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Config invalid:\n  %s\n", err)
+				os.Exit(1)
+			}
 
-		hookCount := countHooks(cfg)
-		cmd.Printf("Config valid (%d hook(s) defined)\n", hookCount)
+			hookCount := countHooks(cfg)
+			cmd.Printf("Config valid (%d hook(s) defined)\n", hookCount)
 
-		return nil
-	},
-}
-
-func init() {
-	addConfigPreRun(configCmd)
-	configCmd.AddCommand(configDumpCmd)
-	configCmd.AddCommand(configReloadCmd)
-	configCmd.AddCommand(configInitCmd)
-	configCmd.AddCommand(configValidateCmd)
+			return nil
+		},
+	}
 }
 
 func countHooks(cfg *config.Config) int {

--- a/cmd/mimi/cmd/configpath.go
+++ b/cmd/mimi/cmd/configpath.go
@@ -1,22 +1,17 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/y3owk1n/mimi/internal/config"
 )
 
-func resolveConfigPath() {
-	configPath = config.ResolvePath(configPath)
+// cliState holds the state one command tree shares between its commands — the
+// config path the persistent --config flag writes into, resolved to a real
+// path before any command runs.
+type cliState struct {
+	configPath string
 }
 
-func addConfigPreRun(cmd *cobra.Command) {
-	existing := cmd.PreRun
-	cmd.PreRun = func(c *cobra.Command, args []string) {
-		resolveConfigPath()
-
-		if existing != nil {
-			existing(c, args)
-		}
-	}
+// resolveConfigPath replaces an empty --config with the default config path.
+func (s *cliState) resolveConfigPath() {
+	s.configPath = config.ResolvePath(s.configPath)
 }

--- a/cmd/mimi/cmd/root.go
+++ b/cmd/mimi/cmd/root.go
@@ -7,8 +7,6 @@ import (
 )
 
 var (
-	configPath string
-	verbose    bool
 	// Version is set via ldflags at build time.
 	Version = "dev"
 	// GitCommit is set via ldflags at build time.
@@ -18,23 +16,32 @@ var (
 )
 
 // RootCmd is the root cobra command for the mimi CLI.
-var RootCmd = &cobra.Command{
-	Use:   "mimi",
-	Short: "macOS window and space utility",
-	Long: `mimi provides macOS-native window and space management without disabling SIP.
+var RootCmd = newRootCmd()
+
+// newRootCmd builds a complete mimi command tree.
+//
+// Every tree owns its flag state, so two trees never share a config path and a
+// test can drive one without leaking into the next.
+func newRootCmd() *cobra.Command {
+	state := &cliState{}
+
+	root := &cobra.Command{
+		Use:   "mimi",
+		Short: "macOS window and space utility",
+		Long: `mimi provides macOS-native window and space management without disabling SIP.
 
 Use "mimi action" for immediate commands (focus window, switch space, move window).
 Use "mimi start" to run the background daemon and react to window/space events via hooks.`,
-}
+		Version: Version,
+		// Cobra runs the nearest persistent pre-run it finds walking up from the
+		// command that executes, so resolving here covers every command in the
+		// tree — including leaves under a parent that has no RunE of its own.
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+			state.resolveConfigPath()
+		},
+	}
 
-// Execute runs the root command and returns any error.
-func Execute() error {
-	return RootCmd.Execute()
-}
-
-func init() {
-	RootCmd.Version = Version
-	RootCmd.SetVersionTemplate(
+	root.SetVersionTemplate(
 		fmt.Sprintf(
 			"Mimi version %s\nGit commit: %s\nBuild date: %s\n",
 			Version,
@@ -43,15 +50,22 @@ func init() {
 		),
 	)
 
-	RootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "",
+	root.PersistentFlags().StringVarP(&state.configPath, "config", "c", "",
 		"path to config file")
-	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false,
+	root.PersistentFlags().BoolP("verbose", "v", false,
 		"verbose output")
 
-	RootCmd.AddCommand(startCmd)
-	RootCmd.AddCommand(stopCmd)
-	RootCmd.AddCommand(statusCmd)
-	RootCmd.AddCommand(configCmd)
-	RootCmd.AddCommand(servicesCmd)
-	RootCmd.AddCommand(actionCmd)
+	root.AddCommand(newStartCmd(state))
+	root.AddCommand(newStopCmd(state))
+	root.AddCommand(newStatusCmd(state))
+	root.AddCommand(newConfigCmd(state))
+	root.AddCommand(newServicesCmd(state))
+	root.AddCommand(newActionCmd(state))
+
+	return root
+}
+
+// Execute runs the root command and returns any error.
+func Execute() error {
+	return RootCmd.Execute()
 }

--- a/cmd/mimi/cmd/root_test.go
+++ b/cmd/mimi/cmd/root_test.go
@@ -1,0 +1,267 @@
+//nolint:testpackage
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	testDirPerm  = 0o755
+	testFilePerm = 0o600
+)
+
+// isolateConfigHome points HOME, XDG_CONFIG_HOME and the working directory at
+// throwaway directories, so no test in this file can read or write the config
+// of whoever is running it. It returns the XDG config directory.
+func isolateConfigHome(t *testing.T) string {
+	t.Helper()
+
+	home := t.TempDir()
+	xdg := filepath.Join(home, ".config")
+
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Chdir(t.TempDir())
+
+	return xdg
+}
+
+// writeConfig writes a minimal valid config whose log_file marks which file a
+// command actually loaded.
+func writeConfig(t *testing.T, path, logFile string) {
+	t.Helper()
+
+	err := os.MkdirAll(filepath.Dir(path), testDirPerm)
+	if err != nil {
+		t.Fatalf("creating config directory: %v", err)
+	}
+
+	body := fmt.Sprintf("[settings]\nlog_file = %q\n", logFile)
+
+	err = os.WriteFile(path, []byte(body), testFilePerm)
+	if err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+}
+
+// runCommand runs args against a fresh command tree and returns everything the
+// tree printed.
+func runCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var out bytes.Buffer
+
+	root := newRootCmd()
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(args)
+
+	err := root.Execute()
+
+	return out.String(), err
+}
+
+// configFlagValue reports the config path the tree holds, which the persistent
+// --config flag and the resolved path share.
+func configFlagValue(root *cobra.Command) string {
+	return root.PersistentFlags().Lookup("config").Value.String()
+}
+
+// runnableCommandPaths lists the argument path of every command in the tree
+// that has something to run.
+func runnableCommandPaths(root *cobra.Command) [][]string {
+	var paths [][]string
+
+	var walk func(parent *cobra.Command, prefix []string)
+
+	walk = func(parent *cobra.Command, prefix []string) {
+		for _, child := range parent.Commands() {
+			// Cobra's own generated commands are not mimi's to test.
+			if child.Name() == "help" || child.Name() == "completion" {
+				continue
+			}
+
+			path := append(append([]string{}, prefix...), child.Name())
+			if child.Runnable() {
+				paths = append(paths, path)
+			}
+
+			walk(child, path)
+		}
+	}
+
+	walk(root, nil)
+
+	return paths
+}
+
+func TestConfigDump_WithoutConfigFlag_LoadsTheDefaultConfigPath(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
+
+	out, err := runCommand(t, "config", "dump")
+	if err != nil {
+		t.Fatalf("config dump: %v", err)
+	}
+
+	if !strings.Contains(out, "/marker/default.log") {
+		t.Errorf("config dump did not load the default config, got: %s", out)
+	}
+}
+
+func TestConfigValidate_WithoutConfigFlag_ValidatesTheDefaultConfigPath(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
+
+	out, err := runCommand(t, "config", "validate")
+	if err != nil {
+		t.Fatalf("config validate: %v", err)
+	}
+
+	if !strings.Contains(out, "Config valid") {
+		t.Errorf("config validate did not accept the default config, got: %s", out)
+	}
+}
+
+func TestConfigInit_WithoutConfigFlag_WritesToTheDefaultConfigPath(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	want := filepath.Join(xdg, "mimi", "config.toml")
+
+	out, err := runCommand(t, "config", "init")
+	if err != nil {
+		t.Fatalf("config init: %v", err)
+	}
+
+	_, err = os.Stat(want)
+	if err != nil {
+		t.Fatalf("config init wrote no config at %s: %v (output: %s)", want, err, out)
+	}
+}
+
+func TestConfigReload_WithoutConfigFlag_GetsPastTheConfigPath(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
+
+	// The daemon is not running under this test's temporary HOME, so reload is
+	// expected to fail — but on the missing PID file, never on the config path.
+	_, err := runCommand(t, "config", "reload")
+	if err == nil {
+		t.Fatal("expected config reload to fail without a running daemon")
+	}
+
+	if !strings.Contains(err.Error(), "reading pid file") {
+		t.Errorf("config reload failed before reaching the PID file: %v", err)
+	}
+}
+
+func TestConfigDump_WithExplicitConfigFlag_PrefersTheGivenFile(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
+
+	explicit := filepath.Join(t.TempDir(), "explicit.toml")
+	writeConfig(t, explicit, "/marker/explicit.log")
+
+	out, err := runCommand(t, "config", "dump", "-c", explicit)
+	if err != nil {
+		t.Fatalf("config dump -c: %v", err)
+	}
+
+	if !strings.Contains(out, "/marker/explicit.log") {
+		t.Errorf("config dump ignored the explicit -c file, got: %s", out)
+	}
+
+	if strings.Contains(out, "/marker/default.log") {
+		t.Errorf("config dump loaded the default config despite -c, got: %s", out)
+	}
+}
+
+func TestNewRootCmd_KeepsNoStateBetweenTrees(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
+
+	explicit := filepath.Join(t.TempDir(), "explicit.toml")
+	writeConfig(t, explicit, "/marker/explicit.log")
+
+	mutated := newRootCmd()
+	mutated.SetArgs([]string{"config", "dump", "-c", explicit})
+	mutated.SetOut(io.Discard)
+	mutated.SetErr(io.Discard)
+
+	err := mutated.Execute()
+	if err != nil {
+		t.Fatalf("config dump -c: %v", err)
+	}
+
+	fresh := newRootCmd()
+	if got := configFlagValue(fresh); got != "" {
+		t.Fatalf("a fresh tree started with config %q, want an empty flag", got)
+	}
+
+	out, err := runCommand(t, "config", "dump")
+	if err != nil {
+		t.Fatalf("config dump: %v", err)
+	}
+
+	if !strings.Contains(out, "/marker/default.log") {
+		t.Errorf("the previous tree's -c leaked into the next tree, got: %s", out)
+	}
+}
+
+// TestNewRootCmd_EveryCommandResolvesTheConfigPath is the guard the config
+// family lacked: it walks the whole tree rather than one family, because a
+// command whose config path is never resolved fails the same way anywhere.
+//
+// Each command's own work is stubbed out — running it for real would start a
+// daemon, move windows or call launchctl — so what is under test is that the
+// tree hands the command a resolved config path before it runs.
+func TestNewRootCmd_EveryCommandResolvesTheConfigPath(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	want := filepath.Join(xdg, "mimi", "config.toml")
+	writeConfig(t, want, "/marker/default.log")
+
+	paths := runnableCommandPaths(newRootCmd())
+	if len(paths) == 0 {
+		t.Fatal("found no runnable commands in the tree")
+	}
+
+	for _, path := range paths {
+		t.Run(strings.Join(path, " "), func(t *testing.T) {
+			root := newRootCmd()
+
+			target, _, err := root.Find(path)
+			if err != nil {
+				t.Fatalf("finding command: %v", err)
+			}
+
+			var seen string
+
+			target.Args = cobra.ArbitraryArgs
+			target.RunE = func(_ *cobra.Command, _ []string) error {
+				seen = configFlagValue(root)
+
+				return nil
+			}
+
+			root.SetArgs(path)
+			root.SetOut(io.Discard)
+			root.SetErr(io.Discard)
+
+			err = root.Execute()
+			if err != nil {
+				t.Fatalf("running command: %v", err)
+			}
+
+			if seen != want {
+				t.Errorf("command saw config path %q, want %q", seen, want)
+			}
+		})
+	}
+}

--- a/cmd/mimi/cmd/runtime_paths.go
+++ b/cmd/mimi/cmd/runtime_paths.go
@@ -4,10 +4,10 @@ import (
 	"github.com/y3owk1n/mimi/internal/config"
 )
 
-func resolveRuntimePaths() (string, string) {
-	resolvedConfig := config.ResolvePath(configPath)
-
-	cfg, err := config.Load(resolvedConfig)
+// runtimePaths returns the PID and socket paths the configured daemon uses,
+// falling back to the defaults when the config cannot be read.
+func (s *cliState) runtimePaths() (string, string) {
+	cfg, err := config.Load(s.configPath)
 	if err == nil {
 		return cfg.Settings.PIDFile, cfg.Settings.SocketFile
 	}

--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -13,14 +13,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// servicesCmd manages the system service used for automatic startup.
+// newServicesCmd builds the command tree that manages the system service used
+// for automatic startup.
 //
 // macOS: backed by launchd.
 // Other platforms: stubbed and returns CodeNotSupported until implemented.
-var servicesCmd = &cobra.Command{
-	Use:   "services",
-	Short: "Manage the Mimi system service (macOS launchd)",
-	Long: `Manage the Mimi system service for automatic startup on login.
+func newServicesCmd(state *cliState) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "services",
+		Short: "Manage the Mimi system service (macOS launchd)",
+		Long: `Manage the Mimi system service for automatic startup on login.
 
 On macOS, this manages a launchd plist so Mimi starts automatically
 when you log in. Available on macOS only.
@@ -32,107 +34,119 @@ Subcommands:
   stop        Stop the system service
   restart     Restart the system service
   status      Check whether the service is loaded and running`,
+	}
+
+	cmd.AddCommand(newServicesInstallCmd(state))
+	cmd.AddCommand(newServicesUninstallCmd())
+	cmd.AddCommand(newServicesStartCmd())
+	cmd.AddCommand(newServicesStopCmd())
+	cmd.AddCommand(newServicesRestartCmd())
+	cmd.AddCommand(newServicesStatusCmd())
+
+	return cmd
 }
 
-var servicesInstallCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install and load the system service",
-	Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := installService()
-		if err != nil {
-			return err
-		}
+func newServicesInstallCmd(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "install",
+		Short: "Install and load the system service",
+		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := installService(state.configPath)
+			if err != nil {
+				return err
+			}
 
-		cmd.Println("Service installed and loaded successfully")
+			cmd.Println("Service installed and loaded successfully")
 
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
-var servicesUninstallCmd = &cobra.Command{
-	Use:   "uninstall",
-	Short: "Unload and remove the system service",
-	Long:  "Unload the Mimi launchd service and remove its plist file. Mimi will no longer start automatically on login.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := uninstallService()
-		if err != nil {
-			return err
-		}
+func newServicesUninstallCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "uninstall",
+		Short: "Unload and remove the system service",
+		Long:  "Unload the Mimi launchd service and remove its plist file. Mimi will no longer start automatically on login.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := uninstallService()
+			if err != nil {
+				return err
+			}
 
-		cmd.Println("Service uninstalled successfully")
+			cmd.Println("Service uninstalled successfully")
 
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
-var servicesStartCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start the system service",
-	Long:  "Start the Mimi launchd service. The daemon will begin running in the background.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := startService()
-		if err != nil {
-			return err
-		}
+func newServicesStartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start the system service",
+		Long:  "Start the Mimi launchd service. The daemon will begin running in the background.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := startService()
+			if err != nil {
+				return err
+			}
 
-		cmd.Println("Service started")
+			cmd.Println("Service started")
 
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
-var servicesStopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stop the system service",
-	Long:  "Stop the Mimi launchd service. The daemon process will be terminated.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := stopService()
-		if err != nil {
-			return err
-		}
+func newServicesStopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the system service",
+		Long:  "Stop the Mimi launchd service. The daemon process will be terminated.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := stopService()
+			if err != nil {
+				return err
+			}
 
-		cmd.Println("Service stopped")
+			cmd.Println("Service stopped")
 
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
-var servicesRestartCmd = &cobra.Command{
-	Use:   "restart",
-	Short: "Restart the system service",
-	Long:  "Stop then immediately start the Mimi launchd service. Useful after configuration changes or to recover from an unresponsive state.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := restartService()
-		if err != nil {
-			return err
-		}
+func newServicesRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart",
+		Short: "Restart the system service",
+		Long:  "Stop then immediately start the Mimi launchd service. Useful after configuration changes or to recover from an unresponsive state.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			err := restartService()
+			if err != nil {
+				return err
+			}
 
-		cmd.Println("Service restarted")
+			cmd.Println("Service restarted")
 
-		return nil
-	},
+			return nil
+		},
+	}
 }
 
-var servicesStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Check the status of the system service",
-	Long:  "Check whether the Mimi launchd service is currently loaded and running. Displays whether the service is active.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.Println(statusService())
+func newServicesStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Check the status of the system service",
+		Long:  "Check whether the Mimi launchd service is currently loaded and running. Displays whether the service is active.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.Println(statusService())
 
-		return nil
-	},
-}
-
-func init() {
-	addConfigPreRun(servicesInstallCmd)
-	servicesCmd.AddCommand(servicesInstallCmd)
-	servicesCmd.AddCommand(servicesUninstallCmd)
-	servicesCmd.AddCommand(servicesStartCmd)
-	servicesCmd.AddCommand(servicesStopCmd)
-	servicesCmd.AddCommand(servicesRestartCmd)
-	servicesCmd.AddCommand(servicesStatusCmd)
+			return nil
+		},
+	}
 }
 
 const (
@@ -200,7 +214,7 @@ func isServiceLoaded() bool {
 	return cmd.Run() == nil
 }
 
-func installService() error {
+func installService(configPath string) error {
 	if isServiceLoaded() {
 		return errServiceAlreadyLoaded
 	}

--- a/cmd/mimi/cmd/start.go
+++ b/cmd/mimi/cmd/start.go
@@ -10,36 +10,34 @@ import (
 	"github.com/y3owk1n/mimi/internal/permissions"
 )
 
-var startCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start the mimi hook daemon for window and space events",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if !config.Exists(configPath) {
-			choice := permissions.ShowConfigOnboardingAlert(configPath)
-			if choice == permissions.ConfigOnboardingQuit {
-				return nil
+func newStartCmd(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start the mimi hook daemon for window and space events",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !config.Exists(state.configPath) {
+				choice := permissions.ShowConfigOnboardingAlert(state.configPath)
+				if choice == permissions.ConfigOnboardingQuit {
+					return nil
+				}
+
+				err := config.WriteDefault(state.configPath)
+				if err != nil {
+					return err
+				}
+
+				cmd.Printf("Default config written to %s\n", state.configPath)
 			}
 
-			err := config.WriteDefault(configPath)
+			cfg, err := config.Load(state.configPath)
 			if err != nil {
-				return err
+				return derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading config")
 			}
 
-			cmd.Printf("Default config written to %s\n", configPath)
-		}
+			logger := logging.New(cfg)
+			logger.Infow("mimi starting", "version", Version, "config", state.configPath)
 
-		cfg, err := config.Load(configPath)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading config")
-		}
-
-		logger := logging.New(cfg)
-		logger.Infow("mimi starting", "version", Version, "config", configPath)
-
-		return daemon.Run(cfg, logger, configPath, Version)
-	},
-}
-
-func init() {
-	addConfigPreRun(startCmd)
+			return daemon.Run(cfg, logger, state.configPath, Version)
+		},
+	}
 }

--- a/cmd/mimi/cmd/status.go
+++ b/cmd/mimi/cmd/status.go
@@ -11,47 +11,49 @@ import (
 	"github.com/y3owk1n/mimi/internal/permissions"
 )
 
-var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show daemon and permission status",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		pidPath, socketPath := resolveRuntimePaths()
+func newStatusCmd(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show daemon and permission status",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			pidPath, socketPath := state.runtimePaths()
 
-		pid, err := readPID(pidPath)
-		if err != nil {
-			cmd.Println("mimi: not running")
-		} else {
-			proc, findErr := os.FindProcess(pid)
-
-			running := findErr == nil && proc.Signal(syscall.Signal(0)) == nil
-			if running {
-				cmd.Printf("mimi: running (pid %d)\n", pid)
+			pid, err := readPID(pidPath)
+			if err != nil {
+				cmd.Println("mimi: not running")
 			} else {
-				cmd.Println("mimi: not running (stale PID file)")
+				proc, findErr := os.FindProcess(pid)
+
+				running := findErr == nil && proc.Signal(syscall.Signal(0)) == nil
+				if running {
+					cmd.Printf("mimi: running (pid %d)\n", pid)
+				} else {
+					cmd.Println("mimi: not running (stale PID file)")
+				}
 			}
-		}
 
-		perm := permissions.Check()
-		if perm.Accessibility {
-			cmd.Println("accessibility: granted")
-		} else {
-			cmd.Println("accessibility: not granted (required for window hooks and actions)")
-		}
+			perm := permissions.Check()
+			if perm.Accessibility {
+				cmd.Println("accessibility: granted")
+			} else {
+				cmd.Println("accessibility: not granted (required for window hooks and actions)")
+			}
 
-		_, statErr := os.Stat(paths.ExpandHome(socketPath))
-		if statErr == nil {
-			cmd.Printf("ipc: socket available at %s\n", paths.ExpandHome(socketPath))
-		} else {
-			cmd.Println("ipc: socket not available (actions run directly until daemon starts)")
-		}
+			_, statErr := os.Stat(paths.ExpandHome(socketPath))
+			if statErr == nil {
+				cmd.Printf("ipc: socket available at %s\n", paths.ExpandHome(socketPath))
+			} else {
+				cmd.Println("ipc: socket not available (actions run directly until daemon starts)")
+			}
 
-		if dropped := native.EventDropCount(); dropped > 0 {
-			cmd.Printf(
-				"events dropped: %d (channel backpressure; check hook latency and log throttling)\n",
-				dropped,
-			)
-		}
+			if dropped := native.EventDropCount(); dropped > 0 {
+				cmd.Printf(
+					"events dropped: %d (channel backpressure; check hook latency and log throttling)\n",
+					dropped,
+				)
+			}
 
-		return nil
-	},
+			return nil
+		},
+	}
 }

--- a/cmd/mimi/cmd/stop.go
+++ b/cmd/mimi/cmd/stop.go
@@ -12,33 +12,36 @@ import (
 	"github.com/y3owk1n/mimi/internal/paths"
 )
 
-var stopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stop the running mimi daemon",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		pidPath, _ := resolveRuntimePaths()
+func newStopCmd(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the running mimi daemon",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			pidPath, _ := state.runtimePaths()
 
-		pid, err := readPID(pidPath)
-		if err != nil {
-			cmd.Println("mimi: not running (no PID file)")
+			pid, err := readPID(pidPath)
+			if err != nil {
+				cmd.Println("mimi: not running (no PID file)")
+
+				//nolint:nilerr // no PID file means the daemon is not running, which is not a failure.
+				return nil
+			}
+
+			proc, err := os.FindProcess(pid)
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeInternal, "process %d not found", pid)
+			}
+
+			err = proc.Signal(syscall.SIGTERM)
+			if err != nil {
+				return derrors.Wrapf(err, derrors.CodeInternal, "signaling process %d", pid)
+			}
+
+			cmd.Printf("Sent SIGTERM to mimi (pid %d)\n", pid)
 
 			return nil
-		}
-
-		proc, err := os.FindProcess(pid)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeInternal, "process %d not found", pid)
-		}
-
-		err = proc.Signal(syscall.SIGTERM)
-		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeInternal, "signaling process %d", pid)
-		}
-
-		cmd.Printf("Sent SIGTERM to mimi (pid %d)\n", pid)
-
-		return nil
-	},
+		},
+	}
 }
 
 func readPID(path string) (int, error) {


### PR DESCRIPTION
## Description

This PR fixes `mimi config dump`, `mimi config validate`, `mimi config reload` and `mimi config init` failing with `reading config: open : no such file or directory` whenever they were run without `-c`. The default config path was resolved by a hook attached to the parent `config` command, and that kind of hook only runs for the command that actually executes — `config` has nothing to run, and the hook was never inherited by its subcommands, so the subcommands received an empty path. Passing `-c` explicitly always worked, which is why it was easy to miss.

Resolution now happens once at the top of the command tree as a persistent hook, so every command — not just the four in the `config` family — is handed a resolved config path before it runs. An explicit `-c` still wins, exactly as before. The tree itself is now built by a factory rather than assembled from package-level state, which is what makes it testable: the new tests build a fresh CLI per run against a throwaway home directory, and one of them walks every command in the tree and asserts each one sees a resolved path, so this class of bug cannot come back quietly in a command added later.

## Related Issues

Closes #84

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, `docs/CLI.md` and `docs/CONFIGURATION.md` already describe the behaviour this restores.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command surface

No command, subcommand or flag is added, removed or renamed. `-c` / `--config` and `-v` / `--verbose` keep their names, shorthands and defaults, and existing invocations and config files keep working unchanged. What changes is only that the four `config` subcommands now fall back to the same default path the rest of the CLI already used:

```
mimi config dump        # was: reading config: open : no such file or directory
                        # now: reads ~/.config/mimi/config.toml (or $XDG_CONFIG_HOME/mimi/config.toml)
mimi config dump -c ./mimi.toml   # unchanged — an explicit path still wins
```

## Potential behaviour change for custom `socket_file`

Because the config path is now resolved for every command rather than only for `start` and `services install`, `mimi action …` run without `-c` now reads the config to find `settings.socket_file`, where it previously skipped that lookup and assumed the default socket. For the default socket path nothing changes. For someone who sets a custom `settings.socket_file`, actions now reach the running daemon over that socket, where before they silently fell back to executing directly in the CLI process — the documented behaviour, but a real change on a timing-sensitive path, so it is worth a look. Narrowing the hook to the `config` family alone would avoid it, at the cost of leaving the same bug latent everywhere else.

## Additional Context

The issue offered two ways to fix the resolution: attach the existing helper to the four `config` leaves, or make the parent's hook persistent so children inherit it. This takes the second, one level higher — the hook lives on the root command, so every command in the tree inherits it, which is what lets the tree-wide test assert something meaningful instead of re-listing the `config` family. One consequence is on record: a future subcommand that adds a persistent hook of its own would shadow the root's for its subtree; the tree-wide test is what catches that.

Tests never touch a real config: they point `HOME`, `XDG_CONFIG_HOME` and the working directory at temporary directories and write the config they need, so they pass on a machine that has no `~/.config/mimi/config.toml` and cannot modify one that exists. Commands are exercised through the real cobra tree, but each command's own work is stubbed in the tree-wide test — running it for real would start a daemon, move windows or call `launchctl`. The four `config` subcommands are additionally run end to end, since they are the ones the bug was reported against.
