### PR TITLE
fix(cli): count hooks of every kind in config validate

### DIFF
--- a/cmd/mimi/cmd/config.go
+++ b/cmd/mimi/cmd/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -130,16 +131,22 @@ func newConfigValidateCmd(state *cliState) *cobra.Command {
 	}
 }
 
+// countHooks totals the hooks the config carries, across every kind.
+//
+// The kinds come from the fields of config.HooksConfig rather than a list kept
+// here: the list this replaced was never extended when the app hook kinds
+// arrived, so half of a user's hooks went uncounted.
 func countHooks(cfg *config.Config) int {
+	hooks := reflect.ValueOf(cfg.Hooks)
+
 	count := 0
-	for _, entries := range [][]config.HookEntry{
-		cfg.Hooks.WindowFocus,
-		cfg.Hooks.WindowTitleChange,
-		cfg.Hooks.WindowCreated,
-		cfg.Hooks.WindowClosed,
-		cfg.Hooks.WindowResize,
-		cfg.Hooks.WorkspaceChanged,
-	} {
+
+	for _, value := range hooks.Fields() {
+		entries, ok := value.Interface().([]config.HookEntry)
+		if !ok {
+			continue
+		}
+
 		count += len(entries)
 	}
 

--- a/cmd/mimi/cmd/config_test.go
+++ b/cmd/mimi/cmd/config_test.go
@@ -1,0 +1,67 @@
+//nolint:testpackage
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/config"
+)
+
+// writeEveryHookKind writes a config carrying one hook of every kind the config
+// supports and returns how many kinds that is.
+//
+// The kinds come from config.HooksConfig itself rather than a list kept here,
+// so a hook kind added to the config is covered without anyone remembering to
+// update this test.
+func writeEveryHookKind(t *testing.T, path string) int {
+	t.Helper()
+
+	hooks := reflect.TypeFor[config.HooksConfig]()
+	entries := reflect.TypeFor[[]config.HookEntry]()
+	lines := []string{"[hooks]"}
+
+	for field := range hooks.Fields() {
+		if field.Type != entries {
+			continue
+		}
+
+		name, _, _ := strings.Cut(field.Tag.Get("toml"), ",")
+		if name == "" {
+			t.Fatalf("hook field %s carries no toml tag", field.Name)
+		}
+
+		lines = append(lines, fmt.Sprintf("%s = [%q]", name, "true"))
+	}
+
+	kinds := len(lines) - 1
+	if kinds == 0 {
+		t.Fatal("found no hook kinds on config.HooksConfig")
+	}
+
+	writeConfigFile(t, path, strings.Join(lines, "\n")+"\n")
+
+	return kinds
+}
+
+func TestConfigValidate_CountsAHookOfEveryKind(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	want := writeEveryHookKind(t, filepath.Join(xdg, "mimi", "config.toml"))
+
+	out, err := runCommand(t, "config", "validate")
+	if err != nil {
+		t.Fatalf("config validate: %v", err)
+	}
+
+	report := fmt.Sprintf("Config valid (%d hook(s) defined)", want)
+	if !strings.Contains(out, report) {
+		t.Errorf(
+			"config validate printed %q, want it to contain %q",
+			strings.TrimSpace(out),
+			report,
+		)
+	}
+}

--- a/cmd/mimi/cmd/root_test.go
+++ b/cmd/mimi/cmd/root_test.go
@@ -39,12 +39,17 @@ func isolateConfigHome(t *testing.T) string {
 func writeConfig(t *testing.T, path, logFile string) {
 	t.Helper()
 
+	writeConfigFile(t, path, fmt.Sprintf("[settings]\nlog_file = %q\n", logFile))
+}
+
+// writeConfigFile writes body to path, creating the directories above it.
+func writeConfigFile(t *testing.T, path, body string) {
+	t.Helper()
+
 	err := os.MkdirAll(filepath.Dir(path), testDirPerm)
 	if err != nil {
 		t.Fatalf("creating config directory: %v", err)
 	}
-
-	body := fmt.Sprintf("[settings]\nlog_file = %q\n", logFile)
 
 	err = os.WriteFile(path, []byte(body), testFilePerm)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR fixes `mimi config validate` reporting the wrong number of hooks. The count it printed only ever tallied the window and workspace hooks — every app hook a config defined was left out, so a config with four hooks, two of them app hooks, was reported as two.

The tally is now derived from the hooks section of the config itself rather than a list written out by hand, so it covers all twelve hook kinds today and picks up any kind added later without a second edit. The wording of the line is unchanged; only the number moves, and only upwards for configs that use app hooks.

## Related Issues

Closes #86

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes; the reported wording is the same.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command surface

No config key, command, subcommand, or flag changes. `mimi config validate` keeps its output format — `Config valid (N hook(s) defined)` — and only reports a truthful `N`. Existing configs and hook scripts are unaffected.

Against a config with four hooks, two of them app hooks:

```toml
[hooks]
on_app_activate = ["echo activated"]
on_app_quit = ["echo quit"]
on_window_focus = ["echo focused"]
on_workspace_changed = ["echo space"]
```

```
# before
$ mimi config validate -c demo.toml
Config valid (2 hook(s) defined)

# after
$ mimi config validate -c demo.toml
Config valid (4 hook(s) defined)
```

## Additional Context

The issue offered a choice: derive the tally from the config's hook fields, or just correct the hand-written list. This takes the derived route, by reflecting over the hooks config struct — about ten lines, no new package API, and nothing for a future hook kind to fall out of sync with. The alternative, a corrected list, would have been the same size and would have re-created the exact failure this fixes. The issue also notes the function is slated for deletion by the later change that gives event kinds a single table; nothing here gets in that change's way, and it deletes cleanly with the function.

The accompanying test drives the real `config validate` command against a temporary config carrying one hook of every kind, with `HOME`, `XDG_CONFIG_HOME` and the working directory pointed at throwaway directories so it can never read the config of whoever runs it. The config it writes is generated from the hook fields too, so a kind added to the config without reaching the parser or the tally fails the test rather than passing silently.

One thing left deliberately alone: `config validate` still exits the process directly when a config fails to parse, rather than returning the error like every other command in the tree. It is out of scope here — changing it would change the command's failure output — but it is worth a separate look.
