### PR TITLE
fix(action,ipc): refresh the systray title on the direct-execution path too

### DIFF
--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -81,4 +81,11 @@ type Desktop interface {
 	// space at the given 1-based index, which the caller has already checked
 	// against SpaceCount.
 	MoveWindowToSpace(index int) error
+
+	// RefreshWorkspaceTitle brings any on-screen UI for the active space (the
+	// systray's title, on the desktop macOS itself runs) up to date after a
+	// space change. It is a no-op wherever there is nothing on screen to
+	// update, so every caller of FocusSpace or MoveWindowToSpace may call it
+	// unconditionally on success.
+	RefreshWorkspaceTitle()
 }

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -93,6 +93,8 @@ func (e *Executor) FocusSpace(index int) error {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to focus space")
 	}
 
+	e.desktop.RefreshWorkspaceTitle()
+
 	return nil
 }
 
@@ -120,6 +122,8 @@ func (e *Executor) MoveWindowToSpace(index int) error {
 	if err != nil {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to move window")
 	}
+
+	e.desktop.RefreshWorkspaceTitle()
 
 	return nil
 }

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -45,6 +45,10 @@ type fakeDesktop struct {
 	// windowSpace is the space the frontmost window sits on, which is what
 	// move_window_to_space is observed through.
 	windowSpace int
+
+	// refreshWorkspaceTitleCalls counts how many times the desktop's systray
+	// title was asked to catch up with the active space.
+	refreshWorkspaceTitleCalls int
 }
 
 func (d *fakeDesktop) EnsureAccessible() error {
@@ -160,6 +164,10 @@ func (d *fakeDesktop) MoveWindowToSpace(index int) error {
 	return nil
 }
 
+func (d *fakeDesktop) RefreshWorkspaceTitle() {
+	d.refreshWorkspaceTitleCalls++
+}
+
 // indexOf resolves a window id the way the real adapter's handle table does:
 // an id it never handed out is not a window.
 func (d *fakeDesktop) indexOf(windowID action.WindowID) (int, error) {
@@ -196,6 +204,16 @@ func desktopWithWindows(count, focused int) *fakeDesktop {
 	}
 
 	return desktop
+}
+
+// wantRefreshCalls fails unless the desktop's systray title was refreshed
+// exactly want times.
+func wantRefreshCalls(t *testing.T, desktop *fakeDesktop, want int) {
+	t.Helper()
+
+	if got := desktop.refreshWorkspaceTitleCalls; got != want {
+		t.Fatalf("refreshWorkspaceTitleCalls = %d, want %d", got, want)
+	}
 }
 
 // wantFocused fails unless the desktop ended up focused on want.

--- a/internal/action/focus_test.go
+++ b/internal/action/focus_test.go
@@ -47,6 +47,23 @@ func TestExecutor_FocusWindow_BackwardCyclingWrapsToLast(t *testing.T) {
 	wantFocused(t, desktop, 3)
 }
 
+// TestExecutor_FocusWindow_DoesNotRefreshWorkspaceTitle guards the scope of
+// mimi#98's fix: focusing a window never moves it between spaces, so it must
+// not touch the systray's workspace title the way space and
+// move_window_to_space do.
+func TestExecutor_FocusWindow_DoesNotRefreshWorkspaceTitle(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithWindows(3, 2)
+
+	err := action.NewExecutor(desktop).FocusWindow(false, "")
+	if err != nil {
+		t.Fatalf("FocusWindow() error = %v, want nil", err)
+	}
+
+	wantRefreshCalls(t, desktop, 0)
+}
+
 func TestExecutor_FocusWindow_UnfocusedDesktopFallsBackToFirstWindow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -7,6 +7,7 @@ import (
 	"github.com/y3owk1n/mimi/internal/geometry"
 	"github.com/y3owk1n/mimi/internal/native"
 	"github.com/y3owk1n/mimi/internal/permissions"
+	"github.com/y3owk1n/mimi/internal/systray"
 )
 
 // nativeDesktop is the Desktop macOS itself: the adapter between the actions'
@@ -168,6 +169,14 @@ func (d *nativeDesktop) FocusSpace(index int) error {
 // 1-based index.
 func (d *nativeDesktop) MoveWindowToSpace(index int) error {
 	return native.MoveWindowToSpace(index)
+}
+
+// RefreshWorkspaceTitle brings the systray's title up to date with the active
+// space. internal/systray already no-ops this when the tray is disabled or
+// was never started, which is what keeps it harmless to call from a CLI
+// invocation with no daemon running.
+func (d *nativeDesktop) RefreshWorkspaceTitle() {
+	systray.RefreshWorkspaceTitle()
 }
 
 // withWindow runs apply against the reference behind windowID, holding the lock

--- a/internal/action/resize_desktop_test.go
+++ b/internal/action/resize_desktop_test.go
@@ -41,6 +41,10 @@ func TestExecutor_ResizeWindow_WritesTheResizedFrame(t *testing.T) {
 	if got := desktop.windows[0].frame.W; got != 400 {
 		t.Fatalf("window width = %v, want 400", got)
 	}
+
+	// Resizing never moves a window between spaces, so it must not touch the
+	// systray's workspace title the way space and move_window_to_space do.
+	wantRefreshCalls(t, desktop, 0)
 }
 
 func TestExecutor_ResizeWindow_ErrorPaths(t *testing.T) {

--- a/internal/action/space_test.go
+++ b/internal/action/space_test.go
@@ -153,3 +153,95 @@ func TestExecutor_MoveWindowToSpace_MovesTheWindow(t *testing.T) {
 		t.Fatalf("window space = %d, want 3", desktop.windowSpace)
 	}
 }
+
+// TestExecutor_Space_RefreshesWorkspaceTitleOnSuccess pins the fix for
+// mimi#98: a successful space switch or window move refreshes the systray's
+// workspace title through the same Desktop seam regardless of which path
+// (daemon or direct execution) drove the desktop.
+func TestExecutor_Space_RefreshesWorkspaceTitleOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		action action.Name
+	}{
+		{name: string(action.NameSpace), action: action.NameSpace},
+		{name: string(action.NameMoveWindowToSpace), action: action.NameMoveWindowToSpace},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := desktopWithSpaces(1)
+
+			err := action.NewExecutor(desktop).Execute(string(testCase.action), []string{"2"})
+			if err != nil {
+				t.Fatalf("Execute(%s) error = %v, want nil", testCase.name, err)
+			}
+
+			wantRefreshCalls(t, desktop, 1)
+		})
+	}
+}
+
+// TestExecutor_Space_DoesNotRefreshWorkspaceTitleOnFailure checks the refresh
+// is tied to a change actually landing: neither an out-of-range space number
+// nor Mission Control refusing the action should touch the systray title.
+func TestExecutor_Space_DoesNotRefreshWorkspaceTitleOnFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("out of range", func(t *testing.T) {
+		t.Parallel()
+
+		for _, name := range []action.Name{action.NameSpace, action.NameMoveWindowToSpace} {
+			desktop := desktopWithSpaces(2)
+
+			err := action.NewExecutor(desktop).Execute(string(name), []string{"9"})
+			if err == nil {
+				t.Fatalf("Execute(%s) error = nil, want an error", name)
+			}
+
+			wantRefreshCalls(t, desktop, 0)
+		}
+	})
+
+	t.Run("mission control active", func(t *testing.T) {
+		t.Parallel()
+
+		desktop := desktopWithSpaces(2)
+		desktop.missionControlActive = true
+
+		err := action.NewExecutor(desktop).FocusSpace(3)
+		if err == nil {
+			t.Fatal("FocusSpace() error = nil, want an error")
+		}
+
+		err = action.NewExecutor(desktop).MoveWindowToSpace(3)
+		if err == nil {
+			t.Fatal("MoveWindowToSpace() error = nil, want an error")
+		}
+
+		wantRefreshCalls(t, desktop, 0)
+	})
+
+	t.Run("underlying desktop error", func(t *testing.T) {
+		t.Parallel()
+
+		desktop := desktopWithSpaces(2)
+		desktop.focusSpaceErr = derrors.New(derrors.CodeActionFailed, "boom")
+		desktop.moveErr = derrors.New(derrors.CodeActionFailed, "boom")
+
+		err := action.NewExecutor(desktop).FocusSpace(3)
+		if err == nil {
+			t.Fatal("FocusSpace() error = nil, want an error")
+		}
+
+		err = action.NewExecutor(desktop).MoveWindowToSpace(3)
+		if err == nil {
+			t.Fatal("MoveWindowToSpace() error = nil, want an error")
+		}
+
+		wantRefreshCalls(t, desktop, 0)
+	})
+}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/paths"
-	"github.com/y3owk1n/mimi/internal/systray"
 )
 
 // actionEnqueueTimeout caps how long handleConn will block waiting for the
@@ -153,10 +152,6 @@ func (s *Server) handleConn(conn net.Conn) {
 	}
 
 	err = <-done
-	if err == nil &&
-		(req.Action == string(action.NameSpace) || req.Action == string(action.NameMoveWindowToSpace)) {
-		systray.RefreshWorkspaceTitle()
-	}
 
 	_ = writeResponse(conn, responseFromError(err))
 }


### PR DESCRIPTION
## Description

This PR fixes the menu bar title staying on the previous space after
`mimi action space …` or `mimi action move-window-to-space …`, whenever the
CLI ran the action directly instead of through a running daemon.

The refresh used to live in the IPC server, which only fired it after an
action it had routed over the socket. A direct in-process run — the CLI's
fallback whenever it can't reach the daemon's socket — never went near that
code, so the tray silently fell out of sync with the actual space. The
refresh now happens inside the action itself, through the same seam that
already carries every other native effect, so the daemon path and the direct
path produce the same visible result. The refresh remains a no-op wherever
there is no systray on screen to update, so a plain CLI invocation with no
daemon running is unaffected either way.

## Related Issues

Closes #98

Related: #90. That issue documents the routing divergence between the daemon
and direct-execution paths and explicitly notes that the systray-refresh gap
"is slated to be resolved by a later change that gives both paths one shared
behaviour" — this PR is that change. #90's wording (and its acceptance
criterion about documenting the divergence) should be revisited once this
lands, since the two paths no longer diverge on this point. This PR does not
touch #90's files (`docs/CONFIGURATION.md`, the `ResolveSocketPath` tests) —
that stays in #90's own scope.

## Type of Change

- [x] `fix` — Bug fix

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing config, command, or doc surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The fix adds one method, `RefreshWorkspaceTitle()`, to the existing `Desktop`
interface in `internal/action` (per the interface's own contract of being
everything an action needs from macOS), rather than opening a second seam or
letting `internal/action` call into cgo directly. The real adapter forwards
to `internal/systray`'s existing exported function; a fake in the test suite
counts calls instead. `FocusSpace` and `MoveWindowToSpace` call it once, only
after their own desktop call succeeds — new tests pin that it fires exactly
once per successful space change and never on a failure path (out-of-range
space, Mission Control active, or an underlying desktop error), and that
unrelated actions (`focus_window`, `resize_window`) never trigger it.

No screenshot/recording: this is a timing fix to when an existing,
already-shipped tray update fires, not a change to what the tray looks like.
