### PR TITLE
test(daemon): cover setupEventPipeline's wiring

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/y3owk1n/mimi/internal/config"
 )
 
-const hookRunEcho = "echo"
+const (
+	hookRunEcho             = "echo"
+	testCaseNameEmptyConfig = "empty config"
+)
 
 func TestHasWindowEvents(t *testing.T) {
 	tests := []struct {
@@ -16,7 +19,7 @@ func TestHasWindowEvents(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "empty config",
+			name:     testCaseNameEmptyConfig,
 			cfg:      &config.Config{},
 			expected: false,
 		},
@@ -45,6 +48,97 @@ func TestHasWindowEvents(t *testing.T) {
 			result := hasWindowEvents(tt.cfg)
 			if result != tt.expected {
 				t.Errorf("hasWindowEvents() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasAppEvents(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		expected bool
+	}{
+		{
+			name:     testCaseNameEmptyConfig,
+			cfg:      &config.Config{},
+			expected: false,
+		},
+		{
+			name: "app activate only",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					AppActivate: []config.HookEntry{{Run: hookRunEcho}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "app quit only",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					AppQuit: []config.HookEntry{{Run: hookRunEcho}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "window events do not count as app events",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					WindowFocus: []config.HookEntry{{Run: hookRunEcho}},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasAppEvents(tt.cfg)
+			if result != tt.expected {
+				t.Errorf("hasAppEvents() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasWorkspaceEvents(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		expected bool
+	}{
+		{
+			name:     testCaseNameEmptyConfig,
+			cfg:      &config.Config{},
+			expected: false,
+		},
+		{
+			name: "workspace changed only",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					WorkspaceChanged: []config.HookEntry{{Run: hookRunEcho}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "window events do not count as workspace events",
+			cfg: &config.Config{
+				Hooks: config.HooksConfig{
+					WindowFocus: []config.HookEntry{{Run: hookRunEcho}},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasWorkspaceEvents(tt.cfg)
+			if result != tt.expected {
+				t.Errorf("hasWorkspaceEvents() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}
@@ -84,5 +178,18 @@ func TestGetObserverConfig(t *testing.T) {
 
 	if !workspaceOnlyObs.Workspace {
 		t.Error("expected Workspace enabled for workspace-only config")
+	}
+
+	appOnlyObs := getObserverConfig(&config.Config{
+		Hooks: config.HooksConfig{
+			AppActivate: []config.HookEntry{{Run: hookRunEcho}},
+		},
+	})
+	if !appOnlyObs.AppLifecycle {
+		t.Error("expected AppLifecycle enabled for app-only config")
+	}
+
+	if appOnlyObs.Workspace {
+		t.Error("expected Workspace disabled for app-only config")
 	}
 }

--- a/internal/daemon/setup_event_pipeline_test.go
+++ b/internal/daemon/setup_event_pipeline_test.go
@@ -1,0 +1,300 @@
+//nolint:testpackage // tests setupEventPipeline, an unexported function
+package daemon
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/events"
+	"github.com/y3owk1n/mimi/internal/hooks"
+	"github.com/y3owk1n/mimi/internal/observe"
+)
+
+const (
+	pipelineHookRun    = "echo"
+	pipelineInvalidRe  = "["
+	pipelineWaitWindow = time.Second
+)
+
+// pipelineResult names setupEventPipeline's ten-value return so test bodies
+// can address the piece they care about instead of a wall of blanks.
+type pipelineResult struct {
+	bus       *events.Bus
+	axTracker *observe.AXTracker
+	router    *observe.Router
+	reg       *hooks.Registry
+	executor  *hooks.Executor
+	logSub    events.Subscriber
+	hookSub   events.Subscriber
+	ctx       context.Context //nolint:containedctx // captured from setupEventPipeline for assertions
+	cancel    context.CancelFunc
+	err       error
+}
+
+func runSetupEventPipeline(
+	cfg *config.Config,
+	logger *zap.SugaredLogger,
+	accessibilityGranted bool,
+) pipelineResult {
+	bus, axTracker, router, reg, executor, logSub, hookSub, ctx, cancel, err := setupEventPipeline(
+		cfg,
+		logger,
+		accessibilityGranted,
+	)
+
+	return pipelineResult{
+		bus:       bus,
+		axTracker: axTracker,
+		router:    router,
+		reg:       reg,
+		executor:  executor,
+		logSub:    logSub,
+		hookSub:   hookSub,
+		ctx:       ctx,
+		cancel:    cancel,
+		err:       err,
+	}
+}
+
+// mustSetupPipeline runs setupEventPipeline, fails the test on error, and
+// registers the returned cancel func for cleanup. It exists so the tests
+// below that expect success don't each repeat the same error-check and
+// cleanup boilerplate.
+func mustSetupPipeline(
+	t *testing.T,
+	cfg *config.Config,
+	logger *zap.SugaredLogger,
+	accessibilityGranted bool,
+) pipelineResult {
+	t.Helper()
+
+	result := runSetupEventPipeline(cfg, logger, accessibilityGranted)
+	if result.err != nil {
+		t.Fatalf("unexpected error: %v", result.err)
+	}
+
+	t.Cleanup(result.cancel)
+
+	return result
+}
+
+// baseSettings returns a SettingsConfig with the fields setupEventPipeline
+// and its collaborators need populated to avoid degenerate zero values
+// (e.g. an unbuffered executor semaphore).
+func baseSettings() config.SettingsConfig {
+	return config.SettingsConfig{
+		HookShell:       "/bin/sh",
+		HookTimeoutSecs: 5,
+		MaxHookWorkers:  1,
+	}
+}
+
+func TestSetupEventPipeline_AXTrackerEnabledState(t *testing.T) {
+	scenarios := []struct {
+		name                 string
+		windowHooks          bool
+		accessibilityGranted bool
+		wantEnabled          bool
+	}{
+		{
+			name:                 "window hooks and accessibility granted enables AX",
+			windowHooks:          true,
+			accessibilityGranted: true,
+			wantEnabled:          true,
+		},
+		{
+			name:                 "window hooks without accessibility disables AX",
+			windowHooks:          true,
+			accessibilityGranted: false,
+			wantEnabled:          false,
+		},
+		{
+			name:                 "accessibility without window hooks disables AX",
+			windowHooks:          false,
+			accessibilityGranted: true,
+			wantEnabled:          false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			cfg := &config.Config{Settings: baseSettings()}
+			if scenario.windowHooks {
+				cfg.Hooks.WindowFocus = []config.HookEntry{{Run: pipelineHookRun}}
+			}
+
+			logger := zap.NewNop().Sugar()
+
+			result := mustSetupPipeline(t, cfg, logger, scenario.accessibilityGranted)
+
+			// AXTracker exposes no getter for its enabled state, so compare
+			// the returned tracker against a freshly constructed one: both
+			// are unused (empty tracked map, zero-value mutex), so the
+			// comparison isolates the enabled flag setupEventPipeline chose.
+			want := observe.NewAXTracker(scenario.wantEnabled)
+			if !reflect.DeepEqual(want, result.axTracker) {
+				t.Errorf("AX tracker enabled state mismatch: want enabled=%v", scenario.wantEnabled)
+			}
+		})
+	}
+}
+
+func TestSetupEventPipeline_ResizeDebounceReachesRouter(t *testing.T) {
+	scenarios := []struct {
+		name         string
+		debounceMS   int
+		wantDebounce time.Duration
+	}{
+		{
+			name:         "explicit debounce is threaded through",
+			debounceMS:   500,
+			wantDebounce: 500 * time.Millisecond,
+		},
+		{
+			name:         "zero debounce falls back to the router default",
+			debounceMS:   0,
+			wantDebounce: 0, // NewRouterWithDebounce(..., 0) applies its own default
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			cfg := &config.Config{Settings: baseSettings()}
+			cfg.Settings.ResizeDebounceMS = scenario.debounceMS
+
+			logger := zap.NewNop().Sugar()
+
+			result := mustSetupPipeline(t, cfg, logger, false)
+
+			// Router exposes no getter for its debounce window. Build a
+			// comparison router from the exact same bus/AX-tracker pointers
+			// and logger so every other field is trivially identical, which
+			// isolates the debounceWindow field in the comparison.
+			want := observe.NewRouterWithDebounce(
+				result.bus,
+				result.axTracker,
+				logger,
+				scenario.wantDebounce,
+			)
+			if !reflect.DeepEqual(want, result.router) {
+				t.Errorf(
+					"router debounce window was not built from settings.resize_debounce_ms=%d",
+					scenario.debounceMS,
+				)
+			}
+		})
+	}
+}
+
+func TestSetupEventPipeline_InvalidHookRegexSurfacesInvalidConfig(t *testing.T) {
+	cfg := &config.Config{Settings: baseSettings()}
+	cfg.Hooks.WindowFocus = []config.HookEntry{{Run: pipelineHookRun, Title: pipelineInvalidRe}}
+
+	logger := zap.NewNop().Sugar()
+
+	result := runSetupEventPipeline(cfg, logger, true)
+	if result.err == nil {
+		t.Fatal("expected an error for an invalid hook regex, got nil")
+	}
+
+	if !derrors.IsCode(result.err, derrors.CodeInvalidConfig) {
+		t.Errorf("expected CodeInvalidConfig, got %v", derrors.GetCode(result.err))
+	}
+
+	if result.bus != nil || result.axTracker != nil || result.router != nil ||
+		result.reg != nil || result.executor != nil {
+		t.Error("expected all pointer results to be nil on error")
+	}
+
+	if result.logSub != nil || result.hookSub != nil {
+		t.Error("expected both subscribers to be nil on error")
+	}
+
+	if result.ctx != nil || result.cancel != nil {
+		t.Error("expected context and cancel to be nil on error")
+	}
+}
+
+func TestSetupEventPipeline_LogSubscriber(t *testing.T) {
+	// This event kind has no registered hook in either subtest's config, so
+	// hookSub's registry filter would reject it — a useful control to make
+	// sure the log subscriber's own filter (not the hook registry's) is
+	// what's under test.
+	const unhookedKind = events.AppQuit
+
+	t.Run("log_file set subscribes a real subscriber", func(t *testing.T) {
+		cfg := &config.Config{Settings: baseSettings()}
+		cfg.Settings.LogFile = "/tmp/mimi-test-event-log.jsonl"
+
+		logger := zap.NewNop().Sugar()
+
+		result := mustSetupPipeline(t, cfg, logger, false)
+
+		result.bus.Publish(events.Event{Kind: unhookedKind, At: time.Now()})
+
+		select {
+		case evt := <-result.logSub:
+			if evt.Kind != unhookedKind {
+				t.Errorf("expected kind %s, got %s", unhookedKind, evt.Kind)
+			}
+		case <-time.After(pipelineWaitWindow):
+			t.Fatal("expected log subscriber to receive the published event")
+		}
+	})
+
+	t.Run("log_file unset subscribes a subscriber that rejects everything", func(t *testing.T) {
+		cfg := &config.Config{Settings: baseSettings()}
+
+		logger := zap.NewNop().Sugar()
+
+		result := mustSetupPipeline(t, cfg, logger, false)
+
+		for _, kind := range events.AllKinds {
+			result.bus.Publish(events.Event{Kind: kind, At: time.Now()})
+		}
+
+		select {
+		case evt := <-result.logSub:
+			t.Fatalf("expected no-op log subscriber to receive nothing, got kind %s", evt.Kind)
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+}
+
+func TestSetupEventPipeline_HookSubUsesRegistryKindFilter(t *testing.T) {
+	cfg := &config.Config{Settings: baseSettings()}
+	cfg.Hooks.WindowFocus = []config.HookEntry{{Run: pipelineHookRun}}
+
+	logger := zap.NewNop().Sugar()
+
+	result := mustSetupPipeline(t, cfg, logger, true)
+
+	// WindowFocus has a registered hook: the registry's KindFilter should
+	// let it through.
+	result.bus.Publish(events.Event{Kind: events.WindowFocus, At: time.Now()})
+
+	select {
+	case evt := <-result.hookSub:
+		if evt.Kind != events.WindowFocus {
+			t.Errorf("expected kind %s, got %s", events.WindowFocus, evt.Kind)
+		}
+	case <-time.After(pipelineWaitWindow):
+		t.Fatal("expected hook subscriber to receive an event kind with a registered hook")
+	}
+
+	// AppQuit has no registered hook: the registry's KindFilter should drop
+	// it before it reaches the channel.
+	result.bus.Publish(events.Event{Kind: events.AppQuit, At: time.Now()})
+
+	select {
+	case evt := <-result.hookSub:
+		t.Fatalf("expected hook subscriber to reject an unregistered kind, got %s", evt.Kind)
+	case <-time.After(100 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## Description

This PR adds unit tests for the daemon's event-pipeline setup, which was previously untested. It covers the AX-tracker enabled/disabled decision (accessibility permission combined with whether window hooks are configured), `resize_debounce_ms` reaching the resize router, an invalid hook regex surfacing as a config error with nothing left half-built, the log subscriber's on/off behavior driven by whether `log_file` is set, and the hook subscriber's use of the hook registry's kind filter. It also adds direct coverage for the app-event and workspace-event detection helpers and extends the existing observer-config test with an app-only case.

No behavior changes — this is tests only.

## Related Issues

Closes #93

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing behavior changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Two of the internal collaborators (`observe.AXTracker`'s enabled flag and `observe.Router`'s debounce window) expose no getter, and this PR does not add one — it stays test-only per scope. Instead, the tests compare the returned object against one built fresh through the same exported constructor (and, for the router, the same bus/AX-tracker/logger instances) via `reflect.DeepEqual`, which pins down just the field under test without reaching into unexported state. This is a bit more fragile than a getter would be — worth knowing about before adding new mutable fields to those two types.
