### PR TITLE
test(hooks,native): pin the hook registry and the C-enum to Go-kind mapping

### DIFF
--- a/internal/hooks/registry_test.go
+++ b/internal/hooks/registry_test.go
@@ -1,0 +1,414 @@
+package hooks //nolint:testpackage // tests unexported buildMap/compileGlob alongside the exported API
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+// Shared literals for hook entries and events built throughout this file.
+const (
+	testHookRun      = "true"
+	testAppGlob      = "Fire*"
+	testAppName      = "Firefox"
+	testAppNameMiss  = "Terminal"
+	testTitleRegex   = "^Inbox"
+	testWindowTitle  = "Inbox - Mail"
+	testWindowTitle2 = "Sent - Mail"
+	testBundleGlob   = "org.example.*"
+	testBundleIDHit  = "org.example.App"
+	testBundleIDMiss = "com.other.App"
+)
+
+// allHookableKinds mirrors the twelve entries buildMap's literal map wires
+// up. Kept local (rather than reusing events.AllKinds) so a future kind
+// added to events.AllKinds without a matching buildMap entry fails loudly
+// here instead of silently expanding both lists together.
+var allHookableKinds = []events.EventKind{
+	events.AppActivate,
+	events.AppDeactivate,
+	events.AppLaunch,
+	events.AppQuit,
+	events.AppHide,
+	events.AppUnhide,
+	events.WindowFocus,
+	events.WindowTitleChange,
+	events.WindowCreated,
+	events.WindowClosed,
+	events.WindowResize,
+	events.WorkspaceChanged,
+}
+
+// cfgWithHook returns a *config.Config with a single hook entry registered
+// for the given kind. Panics on an unknown kind since that's a test bug,
+// not a runtime condition.
+func cfgWithHook(kind events.EventKind, entry config.HookEntry) *config.Config {
+	cfg := &config.Config{}
+
+	switch kind { //nolint:exhaustive // events.WindowResizing has no HooksConfig field; it's internal-only
+	case events.AppActivate:
+		cfg.Hooks.AppActivate = []config.HookEntry{entry}
+	case events.AppDeactivate:
+		cfg.Hooks.AppDeactivate = []config.HookEntry{entry}
+	case events.AppLaunch:
+		cfg.Hooks.AppLaunch = []config.HookEntry{entry}
+	case events.AppQuit:
+		cfg.Hooks.AppQuit = []config.HookEntry{entry}
+	case events.AppHide:
+		cfg.Hooks.AppHide = []config.HookEntry{entry}
+	case events.AppUnhide:
+		cfg.Hooks.AppUnhide = []config.HookEntry{entry}
+	case events.WindowFocus:
+		cfg.Hooks.WindowFocus = []config.HookEntry{entry}
+	case events.WindowTitleChange:
+		cfg.Hooks.WindowTitleChange = []config.HookEntry{entry}
+	case events.WindowCreated:
+		cfg.Hooks.WindowCreated = []config.HookEntry{entry}
+	case events.WindowClosed:
+		cfg.Hooks.WindowClosed = []config.HookEntry{entry}
+	case events.WindowResize:
+		cfg.Hooks.WindowResize = []config.HookEntry{entry}
+	case events.WorkspaceChanged:
+		cfg.Hooks.WorkspaceChanged = []config.HookEntry{entry}
+	default:
+		panic("cfgWithHook: unknown kind " + string(kind))
+	}
+
+	return cfg
+}
+
+func TestBuildMap_EveryKindProducesHooks(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range allHookableKinds {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+
+			cfg := cfgWithHook(kind, config.HookEntry{Run: testHookRun})
+
+			hookMap, err := buildMap(cfg)
+			if err != nil {
+				t.Fatalf("buildMap() unexpected error: %v", err)
+			}
+
+			hooks, ok := hookMap[kind]
+			if !ok || len(hooks) != 1 {
+				t.Fatalf("buildMap()[%s] = %v (ok=%v), want exactly 1 hook", kind, hooks, ok)
+			}
+
+			if hooks[0].Entry.Run != testHookRun {
+				t.Errorf("hook.Entry.Run = %q, want %q", hooks[0].Entry.Run, testHookRun)
+			}
+		})
+	}
+}
+
+func TestBuildMap_InvalidTitleRegexReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithHook(events.AppActivate, config.HookEntry{Run: testHookRun, Title: "["})
+
+	hookMap, err := buildMap(cfg)
+	if err == nil {
+		t.Fatal("buildMap() expected error for invalid title regex, got nil")
+	}
+
+	if hookMap != nil {
+		t.Errorf("buildMap() expected nil map on error, got %v", hookMap)
+	}
+}
+
+func TestBuildMap_InvalidAppGlobReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// compileGlob quotes the input with regexp.QuoteMeta before compiling,
+	// which escapes every regex metacharacter into a valid literal (and
+	// only unescapes "*" back into ".*", itself always valid), so ordinary
+	// glob punctuation like "[" or "(" can never make the compiled pattern
+	// invalid. The one input regexp.Compile rejects downstream of that
+	// quoting is invalid UTF-8.
+	cfg := cfgWithHook(events.AppActivate, config.HookEntry{Run: testHookRun, App: "\xff\xfe"})
+
+	hookMap, err := buildMap(cfg)
+	if err == nil {
+		t.Fatal("buildMap() expected error for invalid app glob, got nil")
+	}
+
+	if hookMap != nil {
+		t.Errorf("buildMap() expected nil map on error, got %v", hookMap)
+	}
+}
+
+func TestBuildMap_ErrorReturnsNoPartialMap(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	// A valid hook on one kind and an invalid one on another: buildMap must
+	// not return the valid half.
+	cfg.Hooks.AppActivate = []config.HookEntry{{Run: testHookRun}}
+	cfg.Hooks.AppQuit = []config.HookEntry{{Run: testHookRun, Title: "("}}
+
+	hookMap, err := buildMap(cfg)
+	if err == nil {
+		t.Fatal("buildMap() expected error, got nil")
+	}
+
+	if hookMap != nil {
+		t.Errorf("buildMap() expected nil map on error, got %v", hookMap)
+	}
+}
+
+func TestHookMatches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		entry config.HookEntry
+		evt   events.Event
+		want  bool
+	}{
+		{
+			name:  "empty filters match everything",
+			entry: config.HookEntry{Run: testHookRun},
+			evt: events.Event{
+				AppName:     "Anything",
+				BundleID:    "com.anything",
+				WindowTitle: "anything",
+			},
+			want: true,
+		},
+		{
+			name:  "app glob hit",
+			entry: config.HookEntry{Run: testHookRun, App: testAppGlob},
+			evt:   events.Event{AppName: testAppName},
+			want:  true,
+		},
+		{
+			name:  "app glob miss",
+			entry: config.HookEntry{Run: testHookRun, App: testAppGlob},
+			evt:   events.Event{AppName: testAppNameMiss},
+			want:  false,
+		},
+		{
+			name:  "title regexp hit",
+			entry: config.HookEntry{Run: testHookRun, Title: testTitleRegex},
+			evt:   events.Event{WindowTitle: testWindowTitle},
+			want:  true,
+		},
+		{
+			name:  "title regexp miss",
+			entry: config.HookEntry{Run: testHookRun, Title: testTitleRegex},
+			evt:   events.Event{WindowTitle: testWindowTitle2},
+			want:  false,
+		},
+		{
+			name:  "bundle_id glob hit",
+			entry: config.HookEntry{Run: testHookRun, BundleID: testBundleGlob},
+			evt:   events.Event{BundleID: testBundleIDHit},
+			want:  true,
+		},
+		{
+			name:  "bundle_id glob miss",
+			entry: config.HookEntry{Run: testHookRun, BundleID: testBundleGlob},
+			evt:   events.Event{BundleID: testBundleIDMiss},
+			want:  false,
+		},
+		{
+			name:  "app and title filters both match",
+			entry: config.HookEntry{Run: testHookRun, App: testAppGlob, Title: testTitleRegex},
+			evt:   events.Event{AppName: testAppName, WindowTitle: testWindowTitle},
+			want:  true,
+		},
+		{
+			name:  "app matches but title does not: overall miss",
+			entry: config.HookEntry{Run: testHookRun, App: testAppGlob, Title: testTitleRegex},
+			evt:   events.Event{AppName: testAppName, WindowTitle: testWindowTitle2},
+			want:  false,
+		},
+		{
+			name:  "title matches but app does not: overall miss",
+			entry: config.HookEntry{Run: testHookRun, App: testAppGlob, Title: testTitleRegex},
+			evt:   events.Event{AppName: testAppNameMiss, WindowTitle: testWindowTitle},
+			want:  false,
+		},
+	}
+
+	for _, matchCase := range tests {
+		t.Run(matchCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := cfgWithHook(events.AppActivate, matchCase.entry)
+
+			hookMap, err := buildMap(cfg)
+			if err != nil {
+				t.Fatalf("buildMap() unexpected error: %v", err)
+			}
+
+			hook := hookMap[events.AppActivate][0]
+
+			got, reason := hook.Matches(matchCase.evt)
+			if got != matchCase.want {
+				t.Errorf("Matches() = %v (reason=%q), want %v", got, reason, matchCase.want)
+			}
+
+			if got && reason != "" {
+				t.Errorf("Matches() returned reason %q on a match, want empty", reason)
+			}
+
+			if !got && reason == "" {
+				t.Error("Matches() returned empty reason on a mismatch, want a reason string")
+			}
+		})
+	}
+}
+
+func TestRegistry_ReloadReplacesMapWholesale(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+
+	firstCfg := cfgWithHook(events.AppActivate, config.HookEntry{Run: "first"})
+
+	err := reg.Reload(firstCfg)
+	if err != nil {
+		t.Fatalf("Reload() unexpected error: %v", err)
+	}
+
+	if hooks := reg.HooksFor(events.AppActivate); len(hooks) != 1 || hooks[0].Entry.Run != "first" {
+		t.Fatalf("HooksFor(AppActivate) after first reload = %v, want [first]", hooks)
+	}
+
+	secondCfg := cfgWithHook(events.AppQuit, config.HookEntry{Run: "second"})
+
+	err = reg.Reload(secondCfg)
+	if err != nil {
+		t.Fatalf("Reload() unexpected error: %v", err)
+	}
+
+	// The second config has no AppActivate hooks: reload must have replaced
+	// the map wholesale rather than merging into the old one.
+	if hooks := reg.HooksFor(events.AppActivate); len(hooks) != 0 {
+		t.Errorf(
+			"HooksFor(AppActivate) after second reload = %v, want empty (map replaced, not merged)",
+			hooks,
+		)
+	}
+
+	if hooks := reg.HooksFor(events.AppQuit); len(hooks) != 1 || hooks[0].Entry.Run != "second" {
+		t.Fatalf("HooksFor(AppQuit) after second reload = %v, want [second]", hooks)
+	}
+}
+
+func TestRegistry_FailedReloadLeavesPriorMapIntact(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+
+	goodCfg := cfgWithHook(events.AppActivate, config.HookEntry{Run: "good"})
+
+	err := reg.Reload(goodCfg)
+	if err != nil {
+		t.Fatalf("Reload() unexpected error: %v", err)
+	}
+
+	badCfg := cfgWithHook(events.AppActivate, config.HookEntry{Run: "bad", Title: "("})
+
+	err = reg.Reload(badCfg)
+	if err == nil {
+		t.Fatal("Reload() expected error for invalid title regex, got nil")
+	}
+
+	hooks := reg.HooksFor(events.AppActivate)
+	if len(hooks) != 1 || hooks[0].Entry.Run != "good" {
+		t.Fatalf(
+			"HooksFor(AppActivate) after failed reload = %v, want the prior map [good] intact",
+			hooks,
+		)
+	}
+}
+
+func TestRegistry_HooksForUnknownKindReturnsEmptyNotPanic(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+
+	err := reg.Reload(
+		cfgWithHook(events.AppActivate, config.HookEntry{Run: testHookRun}),
+	)
+	if err != nil {
+		t.Fatalf("Reload() unexpected error: %v", err)
+	}
+
+	hooks := reg.HooksFor(events.EventKind("does_not_exist"))
+	if len(hooks) != 0 {
+		t.Errorf("HooksFor(unknown) = %v, want empty", hooks)
+	}
+}
+
+func TestRegistry_HooksForOnFreshRegistryReturnsEmptyNotPanic(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+
+	hooks := reg.HooksFor(events.AppActivate)
+	if len(hooks) != 0 {
+		t.Errorf("HooksFor() on fresh registry = %v, want empty", hooks)
+	}
+}
+
+func TestRegistry_KindFilter(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+
+	err := reg.Reload(
+		cfgWithHook(events.AppActivate, config.HookEntry{Run: testHookRun}),
+	)
+	if err != nil {
+		t.Fatalf("Reload() unexpected error: %v", err)
+	}
+
+	filter := reg.KindFilter()
+
+	if !filter(events.AppActivate) {
+		t.Error("KindFilter()(AppActivate) = false, want true: registry has a hook for this kind")
+	}
+
+	if filter(events.AppQuit) {
+		t.Error("KindFilter()(AppQuit) = true, want false: registry has no hook for this kind")
+	}
+
+	if filter(events.EventKind("does_not_exist")) {
+		t.Error("KindFilter()(unknown kind) = true, want false")
+	}
+}
+
+func TestRegistry_KindFilterReflectsReload(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+
+	err := reg.Reload(
+		cfgWithHook(events.AppActivate, config.HookEntry{Run: testHookRun}),
+	)
+	if err != nil {
+		t.Fatalf("Reload() unexpected error: %v", err)
+	}
+
+	filter := reg.KindFilter()
+	if !filter(events.AppActivate) {
+		t.Fatal("KindFilter()(AppActivate) = false before reload, want true")
+	}
+
+	// Reload to a config with no hooks for AppActivate; the filter closure
+	// reads the registry live, so it must reflect the new (empty) map.
+	err = reg.Reload(&config.Config{})
+	if err != nil {
+		t.Fatalf("Reload() unexpected error: %v", err)
+	}
+
+	if filter(events.AppActivate) {
+		t.Error("KindFilter()(AppActivate) = true after reload dropped the hook, want false")
+	}
+}

--- a/internal/native/eventkinds_test.go
+++ b/internal/native/eventkinds_test.go
@@ -1,0 +1,209 @@
+package native //nolint:testpackage // tests unexported kindFromInt against the eventkinds.h fixture
+
+// This file pins the one boundary the compiler cannot check: eventkinds.h's
+// C enum and events/types.go's Go constants are two independently
+// hand-maintained sources of truth, tied together only by a comment ("Keep
+// in sync with events/types.go") in the header and by kindFromInt's switch
+// in bridge.go. If a future edit renumbers a MIMI_KIND_* constant, renames
+// an events.EventKind, or drops (or adds) a case in kindFromInt's switch
+// without updating the other side, this test fails instead of the drift
+// surfacing as a hook that silently never fires.
+//
+// It reads eventkinds.h as a plain text fixture rather than importing it via
+// cgo: `go test` rejects `import "C"` in _test.go files outright ("use of
+// cgo in test .go files not supported"), so a cgo-based version of this test
+// cannot compile.
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+var defineRe = regexp.MustCompile(`(?m)^#define\s+(MIMI_KIND_\w+)\s+(\d+)\s*$`)
+
+// parseEventKindsHeader extracts every "#define MIMI_KIND_X N" line from
+// eventkinds.h into a name->value map.
+func parseEventKindsHeader(t *testing.T) map[string]int {
+	t.Helper()
+
+	// go test runs with the package directory as the working directory, so
+	// this relative path is stable regardless of the caller's cwd.
+	data, err := os.ReadFile("eventkinds.h")
+	if err != nil {
+		t.Fatalf("reading eventkinds.h: %v", err)
+	}
+
+	matches := defineRe.FindAllStringSubmatch(string(data), -1)
+	if len(matches) == 0 {
+		t.Fatal("eventkinds.h: found no #define MIMI_KIND_* lines; parser regex may be stale")
+	}
+
+	defines := make(map[string]int, len(matches))
+
+	for _, m := range matches {
+		name, rawValue := m[1], m[2]
+
+		value, err := strconv.Atoi(rawValue)
+		if err != nil {
+			t.Fatalf("eventkinds.h: %s has non-numeric value %q: %v", name, rawValue, err)
+		}
+
+		if _, dup := defines[name]; dup {
+			t.Fatalf("eventkinds.h: %s is defined more than once", name)
+		}
+
+		defines[name] = value
+	}
+
+	return defines
+}
+
+// mappedKinds are the eventkinds.h symbols that kindFromInt routes to an
+// events.EventKind, keyed by the header's own symbol name so a mismatch
+// names the constant that drifted.
+var mappedKinds = map[string]events.EventKind{
+	"MIMI_KIND_APP_ACTIVATE":        events.AppActivate,
+	"MIMI_KIND_APP_DEACTIVATE":      events.AppDeactivate,
+	"MIMI_KIND_APP_LAUNCH":          events.AppLaunch,
+	"MIMI_KIND_APP_QUIT":            events.AppQuit,
+	"MIMI_KIND_APP_HIDE":            events.AppHide,
+	"MIMI_KIND_APP_UNHIDE":          events.AppUnhide,
+	"MIMI_KIND_WINDOW_FOCUS":        events.WindowFocus,
+	"MIMI_KIND_WINDOW_TITLE_CHANGE": events.WindowTitleChange,
+	"MIMI_KIND_WINDOW_CREATED":      events.WindowCreated,
+	"MIMI_KIND_WINDOW_CLOSED":       events.WindowClosed,
+	"MIMI_KIND_WINDOW_RESIZING":     events.WindowResizing,
+	"MIMI_KIND_WORKSPACE_CHANGED":   events.WorkspaceChanged,
+}
+
+// unmappedKinds are eventkinds.h symbols that are deliberately NOT part of
+// the hookable events.EventKind set kindFromInt produces (power/session/
+// volume/appearance events, handled outside the hook-eligible event path).
+// A symbol missing from both this set and mappedKinds fails
+// TestEventKindsHeader_EveryDefineIsAccountedFor, forcing a conscious choice
+// when a new C kind is added.
+var unmappedKinds = map[string]struct{}{
+	"MIMI_KIND_WILL_SLEEP":         {},
+	"MIMI_KIND_DID_WAKE":           {},
+	"MIMI_KIND_SESSION_RESIGN":     {},
+	"MIMI_KIND_SESSION_BECOME":     {},
+	"MIMI_KIND_WILL_POWER_OFF":     {},
+	"MIMI_KIND_VOLUME_MOUNT":       {},
+	"MIMI_KIND_VOLUME_UNMOUNT":     {},
+	"MIMI_KIND_APPEARANCE_CHANGED": {},
+}
+
+func TestEventKindsHeader_MappedConstantsAgreeWithKindFromInt(t *testing.T) {
+	t.Parallel()
+
+	defines := parseEventKindsHeader(t)
+
+	for name, want := range mappedKinds {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			value, ok := defines[name]
+			if !ok {
+				t.Fatalf("eventkinds.h has no #define for %s", name)
+			}
+
+			if got := kindFromInt(value); got != want {
+				t.Errorf("kindFromInt(%s=%d) = %q, want %q", name, value, got, want)
+			}
+		})
+	}
+}
+
+func TestEventKindsHeader_EveryHookableKindHasAConstant(t *testing.T) {
+	t.Parallel()
+
+	// Every hookable events.EventKind must have a matching header constant
+	// wired through kindFromInt -- a Go-side addition with no MIMI_KIND_*
+	// counterpart would otherwise never be reachable from a real event.
+	//
+	// The one deliberate exception is events.WindowResize: it is never
+	// produced by kindFromInt. internal/observe/router.go debounces the raw
+	// MIMI_KIND_WINDOW_RESIZING stream (-> events.WindowResizing) and
+	// synthesizes WindowResize itself once resizing settles, so it has no
+	// C-side constant to agree with.
+	for _, kind := range events.AllKinds {
+		if kind == events.WindowResize {
+			continue
+		}
+
+		found := false
+
+		for _, mapped := range mappedKinds {
+			if mapped == kind {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			t.Errorf("events.EventKind %q has no eventkinds.h constant in mappedKinds", kind)
+		}
+	}
+}
+
+func TestEventKindsHeader_EveryDefineIsAccountedFor(t *testing.T) {
+	t.Parallel()
+
+	defines := parseEventKindsHeader(t)
+
+	for name := range defines {
+		_, isMapped := mappedKinds[name]
+		_, isUnmapped := unmappedKinds[name]
+
+		if !isMapped && !isUnmapped {
+			t.Errorf(
+				"eventkinds.h defines %s, which is neither in mappedKinds nor unmappedKinds in this test -- "+
+					"add it to whichever set matches whether kindFromInt should route it to an events.EventKind",
+				name,
+			)
+		}
+
+		if isMapped && isUnmapped {
+			t.Errorf("%s appears in both mappedKinds and unmappedKinds", name)
+		}
+	}
+
+	for name := range mappedKinds {
+		if _, ok := defines[name]; !ok {
+			t.Errorf("mappedKinds references %s, which eventkinds.h no longer defines", name)
+		}
+	}
+
+	for name := range unmappedKinds {
+		if _, ok := defines[name]; !ok {
+			t.Errorf("unmappedKinds references %s, which eventkinds.h no longer defines", name)
+		}
+	}
+}
+
+func TestEventKindsHeader_UnmappedConstantsReturnUnknown(t *testing.T) {
+	t.Parallel()
+
+	defines := parseEventKindsHeader(t)
+
+	for name := range unmappedKinds {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			value, ok := defines[name]
+			if !ok {
+				t.Fatalf("eventkinds.h has no #define for %s", name)
+			}
+
+			if got := kindFromInt(value); got != events.EventKind("unknown") {
+				t.Errorf("kindFromInt(%s=%d) = %q, want %q (not yet wired to an events.EventKind)",
+					name, value, got, events.EventKind("unknown"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR adds test coverage for `internal/hooks/registry.go`, which had none beyond what `executor_test.go` exercised incidentally, and pins the one boundary the compiler can't check: `internal/native/eventkinds.h`'s C enum against the Go event-kind constants in `internal/events/types.go`.

`internal/hooks/registry_test.go` covers `buildMap` (every kind it wires up, an invalid `title` regex and an invalid `app` glob each failing without leaving a partial map), `Hook.Matches` (app/bundle_id/title filter hit and miss, all filters together, and the empty-filter "matches everything" case), `Registry.Reload` (replaces the hook map wholesale and leaves the prior map intact on a failed reload), `HooksFor` (unknown kind and a never-reloaded registry both return empty rather than panicking), and `KindFilter` (true only for kinds with a registered hook, and reflects a later reload live).

`internal/native/eventkinds_test.go` reads `eventkinds.h` as a text fixture — cgo can't be used in `_test.go` files at all in this toolchain — and asserts the unexported `kindFromInt` routes every mapped `MIMI_KIND_*` constant to the right `events.EventKind`, that every hookable kind has a matching constant, and that every constant the header defines is accounted for as either mapped or deliberately unmapped, so a newly added C-side kind can't silently slip past this test uncategorized.

This is a tests-only change; no production code was touched.

## Related Issues

Closes #91

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, tests-only change, no user-facing surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The issue's kind-identity test left the fixture-vs-cgo choice open ("either is fine"). This PR reads the header as a plain-text fixture rather than importing it via cgo: `go test` rejects `import "C"` in any `_test.go` file outright ("use of cgo in test .go files not supported"), so a cgo-based version can't compile in this repo's toolchain (go1.26.4) regardless of package placement.

Two things worth a close look:

- `compileGlob` runs `regexp.QuoteMeta` before compiling an `app`/`bundle_id` glob, which escapes every regex metacharacter into a valid literal and only unescapes `*` back into `.*` (itself always valid). That means ordinary glob punctuation like `[` or `(` can never make the compiled pattern invalid — the only input that reaches `regexp.Compile`'s error path is invalid UTF-8. `TestBuildMap_InvalidAppGlobReturnsError` uses an invalid-UTF-8 `App` value for that reason, with a comment explaining why more "obviously wrong" glob syntax doesn't work.
- `events.WindowResize` (the debounced kind) has no `eventkinds.h` constant at all — `internal/observe/router.go` synthesizes it in Go from the raw `WindowResizing` stream, so `kindFromInt` never produces it directly. `eventkinds_test.go`'s "every hookable kind has a header constant" check excludes it explicitly, with a comment.
