### PR TITLE
refactor(cli,service): put the launchd service behind a launcher seam

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -1,23 +1,21 @@
 package cmd
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"os/user"
-	"path/filepath"
-	"strings"
-
 	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/mimi/internal/service"
 )
+
+// defaultService is what the services commands run on: there is one launchd
+// service mimi manages on this machine.
+//
+//nolint:gochecknoglobals // there is one machine, and one service on it
+var defaultService = service.New()
 
 // newServicesCmd builds the command tree that manages the system service used
 // for automatic startup.
 //
-// macOS: backed by launchd.
-// Other platforms: stubbed and returns CodeNotSupported until implemented.
+// macOS: backed by launchd, via internal/service.
 func newServicesCmd(state *cliState) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "services",
@@ -52,7 +50,7 @@ func newServicesInstallCmd(state *cliState) *cobra.Command {
 		Short: "Install and load the system service",
 		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := installService(state.configPath)
+			err := defaultService.Install(state.configPath)
 			if err != nil {
 				return err
 			}
@@ -70,7 +68,7 @@ func newServicesUninstallCmd() *cobra.Command {
 		Short: "Unload and remove the system service",
 		Long:  "Unload the Mimi launchd service and remove its plist file. Mimi will no longer start automatically on login.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := uninstallService()
+			err := defaultService.Uninstall()
 			if err != nil {
 				return err
 			}
@@ -88,7 +86,7 @@ func newServicesStartCmd() *cobra.Command {
 		Short: "Start the system service",
 		Long:  "Start the Mimi launchd service. The daemon will begin running in the background.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := startService()
+			err := defaultService.Start()
 			if err != nil {
 				return err
 			}
@@ -106,7 +104,7 @@ func newServicesStopCmd() *cobra.Command {
 		Short: "Stop the system service",
 		Long:  "Stop the Mimi launchd service. The daemon process will be terminated.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := stopService()
+			err := defaultService.Stop()
 			if err != nil {
 				return err
 			}
@@ -124,7 +122,7 @@ func newServicesRestartCmd() *cobra.Command {
 		Short: "Restart the system service",
 		Long:  "Stop then immediately start the Mimi launchd service. Useful after configuration changes or to recover from an unresponsive state.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := restartService()
+			err := defaultService.Restart()
 			if err != nil {
 				return err
 			}
@@ -142,230 +140,20 @@ func newServicesStatusCmd() *cobra.Command {
 		Short: "Check the status of the system service",
 		Long:  "Check whether the Mimi launchd service is currently loaded and running. Displays whether the service is active.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.Println(statusService())
+			cmd.Println(formatStatus(defaultService.Status()))
 
 			return nil
 		},
 	}
 }
 
-const (
-	serviceLabel     = "com.y3owk1n.mimi"
-	launchAgentsDir  = "~/Library/LaunchAgents"
-	servicePlistFile = launchAgentsDir + "/" + serviceLabel + ".plist"
-)
-
-const servicePlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>com.y3owk1n.mimi</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>MIMI_BINARY_PATH</string>
-        <string>start</string>
-        <string>--config</string>
-        <string>MIMI_CONFIG_PATH</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <true/>
-    <key>StandardOutPath</key>
-    <string>/tmp/mimi.log</string>
-    <key>StandardErrorPath</key>
-    <string>/tmp/mimi.err.log</string>
-    <key>ProcessType</key>
-    <string>Interactive</string>
-    <key>LimitLoadToSessionType</key>
-    <string>Aqua</string>
-    <key>Nice</key>
-    <integer>-10</integer>
-    <key>ThrottleInterval</key>
-    <integer>10</integer>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-    </dict>
-</dict>
-</plist>`
-
-var (
-	errServiceAlreadyLoaded = errors.New(
-		"service is already loaded; check for existing installations (e.g., nix-darwin, home-manager) and uninstall them first",
-	)
-	errPlistAlreadyExists = errors.New("plist file already exists")
-)
-
-func getBinaryPath() (string, error) {
-	execPath, err := os.Executable()
-	if err != nil {
-		return "", err
+// formatStatus renders a service.Status the way the CLI has always printed
+// it, so nothing that scripts against the old string output sees a
+// difference now that Status is a typed result.
+func formatStatus(status service.Status) string {
+	if status.Loaded {
+		return "Service loaded"
 	}
 
-	return filepath.EvalSymlinks(execPath)
-}
-
-func isServiceLoaded() bool {
-	cmd := exec.CommandContext(context.Background(), "launchctl", "list", serviceLabel)
-
-	return cmd.Run() == nil
-}
-
-func installService(configPath string) error {
-	if isServiceLoaded() {
-		return errServiceAlreadyLoaded
-	}
-
-	binPath, err := getBinaryPath()
-	if err != nil {
-		return fmt.Errorf("failed to get binary path: %w", err)
-	}
-
-	plistContent := strings.ReplaceAll(servicePlistTemplate, "MIMI_BINARY_PATH", binPath)
-	plistContent = strings.ReplaceAll(plistContent, "MIMI_CONFIG_PATH", configPath)
-
-	expandedDir, err := expandPath(launchAgentsDir)
-	if err != nil {
-		return fmt.Errorf("failed to expand LaunchAgents path: %w", err)
-	}
-
-	const dirPerm = 0o755
-
-	err = os.MkdirAll(expandedDir, dirPerm)
-	if err != nil {
-		return fmt.Errorf("failed to create LaunchAgents directory: %w", err)
-	}
-
-	expandedPlist := filepath.Join(expandedDir, serviceLabel+".plist")
-
-	const filePerm = 0o644
-
-	// Use O_EXCL to atomically create the file, avoiding TOCTOU between Stat and WriteFile.
-	plistFile, err := os.OpenFile(expandedPlist, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
-	if err != nil {
-		if os.IsExist(err) {
-			return fmt.Errorf(
-				"%w at %s; remove it manually or uninstall first",
-				errPlistAlreadyExists,
-				expandedPlist,
-			)
-		}
-
-		return fmt.Errorf("failed to create plist: %w", err)
-	}
-
-	_, err = plistFile.WriteString(plistContent)
-	if err != nil {
-		_ = plistFile.Close()
-		_ = os.Remove(expandedPlist)
-
-		return fmt.Errorf("failed to write plist: %w", err)
-	}
-
-	err = plistFile.Close()
-	if err != nil {
-		return fmt.Errorf("failed to close plist: %w", err)
-	}
-
-	currentUser, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("failed to get current user: %w", err)
-	}
-
-	cmd := exec.CommandContext(
-		context.Background(),
-		"launchctl",
-		"bootstrap",
-		"gui/"+currentUser.Uid,
-		expandedPlist,
-	)
-
-	err = cmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to load service: %w", err)
-	}
-
-	return nil
-}
-
-func uninstallService() error {
-	expandedPlist, err := expandPath(servicePlistFile)
-	if err != nil {
-		return fmt.Errorf("failed to expand plist path: %w", err)
-	}
-
-	currentUser, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("failed to get current user: %w", err)
-	}
-
-	cmd := exec.CommandContext(
-		context.Background(),
-		"launchctl",
-		"bootout",
-		"gui/"+currentUser.Uid+"/"+serviceLabel,
-	)
-	_ = cmd.Run()
-
-	err = os.Remove(expandedPlist)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove plist: %w", err)
-	}
-
-	return nil
-}
-
-func startService() error {
-	cmd := exec.CommandContext(context.Background(), "launchctl", "start", serviceLabel)
-
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to start service: %w", err)
-	}
-
-	return nil
-}
-
-func stopService() error {
-	cmd := exec.CommandContext(context.Background(), "launchctl", "stop", serviceLabel)
-
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to stop service: %w", err)
-	}
-
-	return nil
-}
-
-func restartService() error {
-	_ = stopService()
-
-	return startService()
-}
-
-func statusService() string {
-	cmd := exec.CommandContext(context.Background(), "launchctl", "list", serviceLabel)
-
-	_, err := cmd.Output()
-	if err != nil {
-		return "Service not loaded"
-	}
-
-	return "Service loaded"
-}
-
-func expandPath(path string) (string, error) {
-	if strings.HasPrefix(path, "~") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-
-		return filepath.Join(home, path[1:]), nil
-	}
-
-	return path, nil
+	return "Service not loaded"
 }

--- a/cmd/mimi/cmd/services_test.go
+++ b/cmd/mimi/cmd/services_test.go
@@ -1,0 +1,28 @@
+//nolint:testpackage
+package cmd
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/service"
+)
+
+func TestFormatStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status service.Status
+		want   string
+	}{
+		{name: "loaded", status: service.Status{Loaded: true}, want: "Service loaded"},
+		{name: "not loaded", status: service.Status{Loaded: false}, want: "Service not loaded"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatStatus(tt.status)
+			if got != tt.want {
+				t.Errorf("formatStatus(%+v) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -52,6 +52,10 @@ const (
 	// CodeIPCFailed indicates a failure in IPC communication.
 	CodeIPCFailed Code = "IPCF_FAILED"
 
+	// CodeServiceFailed indicates a failure managing the launchd service:
+	// rendering or writing its plist, or a launchctl invocation.
+	CodeServiceFailed Code = "SERVICE_FAILED"
+
 	// CodeNotSupported indicates the operation is not supported on the current platform.
 	// Use this in stub implementations so callers can distinguish "not implemented yet"
 	// from "actually failed". Example:

--- a/internal/service/doc.go
+++ b/internal/service/doc.go
@@ -1,0 +1,10 @@
+// Package service manages the mimi launchd service: rendering its plist,
+// installing and removing it, and driving launchctl to load, start, stop and
+// query it.
+//
+// Every launchctl invocation runs through the launcher a [Service] holds,
+// which is what lets install/uninstall/start/stop/status be exercised
+// without a real launchctl underneath them. renderPlist sits beside that seam
+// as a pure function, so the exact bytes mimi writes to disk are covered
+// without touching the filesystem either.
+package service

--- a/internal/service/launcher.go
+++ b/internal/service/launcher.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"context"
+	"os/exec"
+)
+
+// launcher is the seam between [Service] and launchctl. The production
+// implementation shells out; tests fake it so install/uninstall/start/stop/
+// status can be exercised without a real launchctl underneath them.
+type launcher interface {
+	// list reports whether label is currently loaded. Every caller here only
+	// cares whether it succeeded, so its stdout is never surfaced.
+	list(ctx context.Context, label string) error
+	// bootstrap loads the plist at plistPath into domain (e.g. "gui/501").
+	bootstrap(ctx context.Context, domain, plistPath string) error
+	// bootout unloads target (e.g. "gui/501/com.y3owk1n.mimi").
+	bootout(ctx context.Context, target string) error
+	// start starts the already-loaded service named label.
+	start(ctx context.Context, label string) error
+	// stop stops the already-loaded service named label.
+	stop(ctx context.Context, label string) error
+}
+
+// execLauncher is the launcher backed by the real launchctl binary on PATH.
+type execLauncher struct{}
+
+func (execLauncher) list(ctx context.Context, label string) error {
+	return exec.CommandContext(ctx, "launchctl", "list", label).Run()
+}
+
+func (execLauncher) bootstrap(ctx context.Context, domain, plistPath string) error {
+	return exec.CommandContext(ctx, "launchctl", "bootstrap", domain, plistPath).Run()
+}
+
+func (execLauncher) bootout(ctx context.Context, target string) error {
+	return exec.CommandContext(ctx, "launchctl", "bootout", target).Run()
+}
+
+func (execLauncher) start(ctx context.Context, label string) error {
+	return exec.CommandContext(ctx, "launchctl", "start", label).Run()
+}
+
+func (execLauncher) stop(ctx context.Context, label string) error {
+	return exec.CommandContext(ctx, "launchctl", "stop", label).Run()
+}

--- a/internal/service/plist.go
+++ b/internal/service/plist.go
@@ -1,0 +1,64 @@
+package service
+
+import "strings"
+
+// Label is the launchd service identifier mimi installs itself under.
+const Label = "com.y3owk1n.mimi"
+
+// launchAgentsDir is where launchd expects a per-user agent's plist, in the
+// form [paths.ExpandHome] accepts.
+const launchAgentsDir = "~/Library/LaunchAgents"
+
+// plistTemplate is the launchd plist mimi installs, with the binary and
+// config paths left as tokens for renderPlist to fill in.
+//
+// StandardOutPath/StandardErrorPath are intentionally fixed at /tmp/mimi.log
+// and /tmp/mimi.err.log rather than settings.log_file: that path only ever
+// affects the captured stdout/stderr stream, and the file log sink honors
+// settings.log_file independently. See issue #99.
+const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.y3owk1n.mimi</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>MIMI_BINARY_PATH</string>
+        <string>start</string>
+        <string>--config</string>
+        <string>MIMI_CONFIG_PATH</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/mimi.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/mimi.err.log</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>LimitLoadToSessionType</key>
+    <string>Aqua</string>
+    <key>Nice</key>
+    <integer>-10</integer>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>`
+
+// renderPlist fills plistTemplate with the binary and config paths mimi was
+// given. It touches no filesystem and makes no system call: the same inputs
+// always render the same bytes, which is what lets it be pinned with a plain
+// table test instead of an integration one.
+func renderPlist(binPath, configPath string) string {
+	content := strings.ReplaceAll(plistTemplate, "MIMI_BINARY_PATH", binPath)
+
+	return strings.ReplaceAll(content, "MIMI_CONFIG_PATH", configPath)
+}

--- a/internal/service/plist_test.go
+++ b/internal/service/plist_test.go
@@ -1,0 +1,82 @@
+//nolint:testpackage // renderPlist and plistTemplate are unexported; the seam under test is intentionally internal.
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+// wantGoldenPlist is what the pre-refactor cmd/mimi/cmd implementation
+// produced for binPath "/usr/local/bin/mimi" and configPath
+// "/Users/test/.config/mimi/config.toml" — captured from that code before it
+// moved, so this pins renderPlist to byte-identical output rather than to a
+// value this test derives the same way the code does.
+const wantGoldenPlist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>com.y3owk1n.mimi</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>/usr/local/bin/mimi</string>\n        <string>start</string>\n        <string>--config</string>\n        <string>/Users/test/.config/mimi/config.toml</string>\n    </array>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>StandardOutPath</key>\n    <string>/tmp/mimi.log</string>\n    <key>StandardErrorPath</key>\n    <string>/tmp/mimi.err.log</string>\n    <key>ProcessType</key>\n    <string>Interactive</string>\n    <key>LimitLoadToSessionType</key>\n    <string>Aqua</string>\n    <key>Nice</key>\n    <integer>-10</integer>\n    <key>ThrottleInterval</key>\n    <integer>10</integer>\n    <key>EnvironmentVariables</key>\n    <dict>\n        <key>PATH</key>\n        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>\n    </dict>\n</dict>\n</plist>"
+
+func TestRenderPlist_MatchesThePreRefactorOutputByteForByte(t *testing.T) {
+	got := renderPlist("/usr/local/bin/mimi", "/Users/test/.config/mimi/config.toml")
+	if got != wantGoldenPlist {
+		t.Errorf("renderPlist() =\n%q\nwant\n%q", got, wantGoldenPlist)
+	}
+}
+
+func TestRenderPlist_Table(t *testing.T) {
+	tests := []struct {
+		name       string
+		binPath    string
+		configPath string
+	}{
+		{
+			name:       "typical paths",
+			binPath:    "/opt/homebrew/bin/mimi",
+			configPath: "~/.config/mimi/config.toml",
+		},
+		{
+			name:       "empty inputs",
+			binPath:    "",
+			configPath: "",
+		},
+		{
+			name:       "path containing the token-like substring MIMI",
+			binPath:    "/Users/mimi-user/bin/mimi",
+			configPath: "/Users/mimi-user/MIMI_CONFIG_PATH-lookalike/config.toml",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := renderPlist(testCase.binPath, testCase.configPath)
+
+			wantBin := "<string>" + testCase.binPath + "</string>"
+			if !strings.Contains(got, wantBin) {
+				t.Errorf(
+					"renderPlist(%q, %q) does not contain %q:\n%s",
+					testCase.binPath,
+					testCase.configPath,
+					wantBin,
+					got,
+				)
+			}
+
+			wantConfig := "<string>" + testCase.configPath + "</string>"
+			if !strings.Contains(got, wantConfig) {
+				t.Errorf(
+					"renderPlist(%q, %q) does not contain %q:\n%s",
+					testCase.binPath,
+					testCase.configPath,
+					wantConfig,
+					got,
+				)
+			}
+
+			// The template's own literal Label must survive untouched.
+			if !strings.Contains(got, "<string>com.y3owk1n.mimi</string>") {
+				t.Errorf(
+					"renderPlist(%q, %q) lost the Label string",
+					testCase.binPath,
+					testCase.configPath,
+				)
+			}
+		})
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,180 @@
+package service
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/paths"
+)
+
+const (
+	dirPerm  = 0o755
+	filePerm = 0o644
+)
+
+// Status is what checking the launchd service reports: a typed result a
+// caller can act on, in place of a formatted string only a human can read.
+type Status struct {
+	// Loaded reports whether launchctl currently has the service loaded.
+	Loaded bool
+}
+
+// Service manages the mimi launchd service. Every launchctl invocation runs
+// through the launcher it holds.
+type Service struct {
+	launcher launcher
+}
+
+// New returns a Service backed by the real launchctl binary on PATH.
+func New() *Service {
+	return &Service{launcher: execLauncher{}}
+}
+
+// Install renders the plist for the running binary and configPath, writes it
+// to ~/Library/LaunchAgents, and loads it with launchctl bootstrap.
+func (s *Service) Install(configPath string) error {
+	ctx := context.Background()
+
+	if s.launcher.list(ctx, Label) == nil {
+		return derrors.New(
+			derrors.CodeServiceFailed,
+			"service is already loaded; check for existing installations (e.g., nix-darwin, home-manager) and uninstall them first",
+		)
+	}
+
+	binPath, err := binaryPath()
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "getting binary path")
+	}
+
+	plistContent := renderPlist(binPath, configPath)
+
+	expandedDir := paths.ExpandHome(launchAgentsDir)
+
+	err = os.MkdirAll(expandedDir, dirPerm)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "creating LaunchAgents directory")
+	}
+
+	expandedPlist := filepath.Join(expandedDir, Label+".plist")
+
+	err = writePlist(expandedPlist, plistContent)
+	if err != nil {
+		return err
+	}
+
+	currentUser, err := user.Current()
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "getting current user")
+	}
+
+	err = s.launcher.bootstrap(ctx, "gui/"+currentUser.Uid, expandedPlist)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "loading service")
+	}
+
+	return nil
+}
+
+// writePlist creates path with content, using O_EXCL to create it atomically
+// and avoid a TOCTOU race between checking for and writing the file. A
+// partial write is rolled back rather than left behind.
+func writePlist(path, content string) error {
+	plistFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
+	if err != nil {
+		if os.IsExist(err) {
+			return derrors.Newf(
+				derrors.CodeServiceFailed,
+				"plist file already exists at %s; remove it manually or uninstall first",
+				path,
+			)
+		}
+
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "creating plist")
+	}
+
+	_, err = plistFile.WriteString(content)
+	if err != nil {
+		_ = plistFile.Close()
+		_ = os.Remove(path)
+
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "writing plist")
+	}
+
+	err = plistFile.Close()
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "closing plist")
+	}
+
+	return nil
+}
+
+// Uninstall unloads the service and removes its plist. A launchctl bootout
+// failure is not fatal — the service may already be unloaded, e.g. after a
+// prior partial uninstall — so it only removes the plist file.
+func (s *Service) Uninstall() error {
+	ctx := context.Background()
+
+	expandedPlist := filepath.Join(paths.ExpandHome(launchAgentsDir), Label+".plist")
+
+	currentUser, err := user.Current()
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "getting current user")
+	}
+
+	_ = s.launcher.bootout(ctx, "gui/"+currentUser.Uid+"/"+Label)
+
+	err = os.Remove(expandedPlist)
+	if err != nil && !os.IsNotExist(err) {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "removing plist")
+	}
+
+	return nil
+}
+
+// Start starts the already-installed service.
+func (s *Service) Start() error {
+	err := s.launcher.start(context.Background(), Label)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "starting service")
+	}
+
+	return nil
+}
+
+// Stop stops the running service.
+func (s *Service) Stop() error {
+	err := s.launcher.stop(context.Background(), Label)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "stopping service")
+	}
+
+	return nil
+}
+
+// Restart stops then starts the service. A failure to stop (e.g. it was not
+// running) does not prevent the start that follows.
+func (s *Service) Restart() error {
+	_ = s.Stop()
+
+	return s.Start()
+}
+
+// Status reports whether the service is currently loaded.
+func (s *Service) Status() Status {
+	return Status{Loaded: s.launcher.list(context.Background(), Label) == nil}
+}
+
+// binaryPath resolves the real, symlink-free path to the running mimi
+// binary, which is what the installed plist must invoke.
+func binaryPath() (string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.EvalSymlinks(execPath)
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,237 @@
+//nolint:testpackage // launcher and Service's internals are unexported; the seam under test is intentionally internal.
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// fakeLauncher is a launcher made of plain values: every call it sees lands
+// in a field a test can assert against, and every call it returns is a field
+// a test can set up in advance.
+type fakeLauncher struct {
+	loaded bool
+
+	bootstrapErr error
+	bootstrapped bool
+	bootoutErr   error
+	booted       bool
+	startErr     error
+	started      bool
+	stopErr      error
+	stopped      bool
+}
+
+func (f *fakeLauncher) list(_ context.Context, _ string) error {
+	if f.loaded {
+		return nil
+	}
+
+	return derrors.New(derrors.CodeServiceFailed, "not loaded")
+}
+
+func (f *fakeLauncher) bootstrap(_ context.Context, _, _ string) error {
+	f.bootstrapped = true
+
+	return f.bootstrapErr
+}
+
+func (f *fakeLauncher) bootout(_ context.Context, _ string) error {
+	f.booted = true
+
+	return f.bootoutErr
+}
+
+func (f *fakeLauncher) start(_ context.Context, _ string) error {
+	f.started = true
+
+	return f.startErr
+}
+
+func (f *fakeLauncher) stop(_ context.Context, _ string) error {
+	f.stopped = true
+
+	return f.stopErr
+}
+
+func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
+	tests := []struct {
+		name   string
+		loaded bool
+		want   Status
+	}{
+		{name: "loaded", loaded: true, want: Status{Loaded: true}},
+		{name: "not loaded", loaded: false, want: Status{Loaded: false}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := &Service{launcher: &fakeLauncher{loaded: testCase.loaded}}
+
+			got := svc.Status()
+			if got != testCase.want {
+				t.Errorf("Status() = %+v, want %+v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestService_Start_RunsLaunchctlStart(t *testing.T) {
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	err := svc.Start()
+	if err != nil {
+		t.Fatalf("Start() = %v, want nil", err)
+	}
+
+	if !fake.started {
+		t.Error("Start() did not call the launcher's start")
+	}
+}
+
+func TestService_Start_WrapsTheLauncherErrorWithADerrorsCode(t *testing.T) {
+	fake := &fakeLauncher{startErr: derrors.New(derrors.CodeServiceFailed, "boom")}
+	svc := &Service{launcher: fake}
+
+	err := svc.Start()
+	if err == nil {
+		t.Fatal("Start() = nil, want an error")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Start() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+}
+
+func TestService_Stop_RunsLaunchctlStop(t *testing.T) {
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	err := svc.Stop()
+	if err != nil {
+		t.Fatalf("Stop() = %v, want nil", err)
+	}
+
+	if !fake.stopped {
+		t.Error("Stop() did not call the launcher's stop")
+	}
+}
+
+func TestService_Restart_StopsThenStartsEvenWhenStopFails(t *testing.T) {
+	fake := &fakeLauncher{stopErr: derrors.New(derrors.CodeServiceFailed, "wasn't running")}
+	svc := &Service{launcher: fake}
+
+	err := svc.Restart()
+	if err != nil {
+		t.Fatalf("Restart() = %v, want nil (start succeeded)", err)
+	}
+
+	if !fake.stopped || !fake.started {
+		t.Errorf("Restart() stopped=%v started=%v, want both true", fake.stopped, fake.started)
+	}
+}
+
+func TestService_Uninstall_BootsOutEvenWhenNotLoaded(t *testing.T) {
+	fake := &fakeLauncher{bootoutErr: derrors.New(derrors.CodeServiceFailed, "not loaded")}
+	svc := &Service{launcher: fake}
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	err := svc.Uninstall()
+	if err != nil {
+		t.Fatalf("Uninstall() = %v, want nil (a bootout failure is not fatal)", err)
+	}
+
+	if !fake.booted {
+		t.Error("Uninstall() did not call the launcher's bootout")
+	}
+}
+
+func TestService_Install_WritesThePlistAndBootstraps(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	err := svc.Install("/Users/test/.config/mimi/config.toml")
+	if err != nil {
+		t.Fatalf("Install() = %v, want nil", err)
+	}
+
+	if !fake.bootstrapped {
+		t.Error("Install() did not call the launcher's bootstrap")
+	}
+
+	plistPath := filepath.Join(dir, "Library", "LaunchAgents", Label+".plist")
+
+	content, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	if !strings.Contains(string(content), "/Users/test/.config/mimi/config.toml") {
+		t.Errorf("installed plist does not carry the config path:\n%s", content)
+	}
+}
+
+func TestService_Install_FailsWhenAlreadyLoaded(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{loaded: true}
+	svc := &Service{launcher: fake}
+
+	err := svc.Install("/Users/test/.config/mimi/config.toml")
+	if err == nil {
+		t.Fatal("Install() = nil, want an error")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	if fake.bootstrapped {
+		t.Error("Install() bootstrapped an already-loaded service")
+	}
+}
+
+func TestService_Install_FailsWhenThePlistAlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	agentsDir := filepath.Join(dir, "Library", "LaunchAgents")
+
+	err := os.MkdirAll(agentsDir, 0o755)
+	if err != nil {
+		t.Fatalf("creating LaunchAgents dir: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(agentsDir, Label+".plist"), []byte("existing"), 0o644)
+	if err != nil {
+		t.Fatalf("seeding existing plist: %v", err)
+	}
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	err = svc.Install("/Users/test/.config/mimi/config.toml")
+	if err == nil {
+		t.Fatal("Install() = nil, want an error")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	if fake.bootstrapped {
+		t.Error("Install() bootstrapped despite a pre-existing plist")
+	}
+}


### PR DESCRIPTION
## Description

This PR moves the launchd service management logic out of the CLI package and into a new `internal/service` package, leaving `cmd/mimi/cmd/services.go` as a thin Cobra wrapper.

Plist rendering is now a pure function with no filesystem or exec calls, pinned by a test to the exact bytes the pre-refactor code produced for the same inputs. Every `launchctl` invocation (list, bootstrap, bootout, start, stop) now runs through a small launcher interface, so install/uninstall/start/stop/status can be exercised in tests without a real `launchctl` or a real filesystem write. Errors crossing the new package boundary carry a `derrors` code (`CodeServiceFailed`) instead of the bare `errors.New` the old file used, and the duplicated local path-expansion helper is gone in favor of the shared `paths.ExpandHome`.

The service status check now returns a typed `service.Status{Loaded bool}` internally rather than a formatted string, but the CLI still prints exactly `Service loaded` / `Service not loaded` as before — no user-visible output changed.

## Related Issues

Closes #97

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing config/command/flag/hook surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Out of scope, deliberately: the plist's hardcoded `/tmp/mimi.log` and `/tmp/mimi.err.log` stdout/stderr paths move into `internal/service/plist.go` unchanged. They are not wired to `settings.log_file` — that setting is honored independently by the file log sink, and reconsidering the plist's captured-stream paths is tracked separately as #99.

One small known trade-off: `paths.ExpandHome` (the shared helper this PR adopts per the issue) silently ignores an `os.UserHomeDir()` failure rather than surfacing it, where the old locally-duplicated `expandPath` returned that error to the caller. This only matters if `$HOME` is unresolvable, and using the shared helper is what the issue asked for, so I left it rather than fork a variant just for this package.
