### PR TITLE
fix(daemon): report a failed config reload identically on every trigger

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,17 +11,43 @@ mimi config reload     # reload running daemon (SIGHUP)
 
 ---
 
+## Reloading
+
+`mimi config reload` (SIGHUP) and the systray's reload menu item both trigger
+the same reload, and the daemon also picks up an edit to the config file on
+disk automatically (fsnotify). All three routes reload `[hooks]` and the
+subset of `[settings]` listed below; a bad config (e.g. an invalid `title`
+regex) leaves the previous, working config in place and logs the failure
+rather than applying it partially.
+
+**Restart-only** — these fields are read once at daemon startup and are not
+picked up by a reload; changing them requires restarting the daemon
+(`mimi daemon stop && mimi daemon start`, or equivalent):
+
+- `[systray]` (both `enabled` and `show_workspace_number`)
+- `settings.log_file`
+- `settings.log_level`
+- `settings.pid_file`
+- `settings.socket_file`
+
+Everything else in `[settings]` (`log_format`, `hook_timeout_secs`,
+`hook_shell`, `max_hook_workers`, `resize_debounce_ms`) and all of `[hooks]`
+take effect on the next reload.
+
+---
+
 ## Settings
 
 ```toml
 [settings]
-log_file = "~/.local/share/mimi/mimi.log"   # optional; omit for console-only
-log_level = "info"                           # debug | info | warn | error
+log_file = "~/.local/share/mimi/mimi.log"   # optional; omit for console-only — restart-only
+log_level = "info"                           # debug | info | warn | error — restart-only
 log_format = "text"                          # text | json — console output only
 hook_timeout_secs = 10
 hook_shell = "/bin/sh"
 max_hook_workers = 4
-pid_file = "~/.local/share/mimi/mimi.pid"
+pid_file = "~/.local/share/mimi/mimi.pid"    # restart-only
+socket_file = "~/.local/share/mimi/mimi.sock" # restart-only
 resize_debounce_ms = 250                     # on_window_resize debounce window
 ```
 
@@ -37,8 +63,8 @@ unrecognized value logs a warning and falls back to `text`.
 
 ```toml
 [systray]
-enabled = true
-show_workspace_number = true   # show active space number in menu bar
+enabled = true                 # restart-only
+show_workspace_number = true   # show active space number in menu bar — restart-only
 ```
 
 ---

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -104,21 +104,21 @@ func runCore(
 		return nil
 	}
 
-	bus, axTracker, router, reg, executor, logSub, hookSub, ctx, cancel, err := setupEventPipeline(
-		cfg,
-		logger,
-		accessibilityGranted,
-	)
+	pipeline, ctx, cancel, err := setupEventPipeline(cfg, logger, accessibilityGranted)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	go router.Run(ctx)
-	go executor.Run(ctx, hookSub)
-	go logging.WriteEventLog(ctx, logSub, cfg.Settings.LogFile, logger)
+	go pipeline.router.Run(ctx)
+	go pipeline.executor.Run(ctx, pipeline.hookSub)
+	go logging.WriteEventLog(ctx, pipeline.logSub, cfg.Settings.LogFile, logger)
 
-	onChange := newReloadHandler(reg, executor, axTracker, router, logger)
+	cfgReloader := newReloader(pipeline.reg, pipeline.executor, pipeline.axTracker, pipeline.router)
+
+	onChange := func(newCfg *config.Config) {
+		applyReload(cfgReloader, newCfg, reloadTriggerFsnotify, logger)
+	}
 
 	watcher := config.NewWatcher(configPath, onChange, logger)
 	go func() { _ = watcher.Run(ctx) }()
@@ -133,19 +133,7 @@ func runCore(
 		}
 	}()
 
-	runSignalLoop(
-		cancel,
-		quitCh,
-		reg,
-		executor,
-		axTracker,
-		router,
-		logger,
-		configPath,
-		bus,
-		logSub,
-		hookSub,
-	)
+	runSignalLoop(cancel, quitCh, cfgReloader, pipeline, logger, configPath)
 
 	return nil
 }
@@ -179,13 +167,28 @@ func setupObservers(cfg *config.Config, logger *zap.SugaredLogger) (*native.Obse
 	return &obsCfg, accessibilityGranted
 }
 
+// eventPipeline bundles the dependencies setupEventPipeline wires together:
+// the event bus, the hook registry and its executor, the AX tracker and
+// router that react to window state, and the two subscribers that drain the
+// bus. Packaging them here means callers — runCore and, in turn, the
+// reloader — pass the bundle once instead of threading the same handful of
+// pointers by hand through every call site, which is how the fsnotify and
+// SIGHUP reload paths drifted from each other in the first place.
+type eventPipeline struct {
+	bus       *events.Bus
+	axTracker *observe.AXTracker
+	router    *observe.Router
+	reg       *hooks.Registry
+	executor  *hooks.Executor
+	logSub    events.Subscriber
+	hookSub   events.Subscriber
+}
+
 func setupEventPipeline(
 	cfg *config.Config,
 	logger *zap.SugaredLogger,
 	accessibilityGranted bool,
-) (*events.Bus, *observe.AXTracker, *observe.Router, *hooks.Registry, *hooks.Executor,
-	events.Subscriber, events.Subscriber, context.Context, context.CancelFunc, error,
-) {
+) (*eventPipeline, context.Context, context.CancelFunc, error) {
 	axEnabled := accessibilityGranted && hasWindowEvents(cfg)
 
 	bus := events.NewBus()
@@ -201,8 +204,7 @@ func setupEventPipeline(
 
 	err := reg.Reload(cfg)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading hooks")
+		return nil, nil, nil, derrors.Wrapf(err, derrors.CodeInvalidConfig, "loading hooks")
 	}
 
 	executor := hooks.NewExecutor(reg, &cfg.Settings, logger)
@@ -231,50 +233,57 @@ func setupEventPipeline(
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return bus, axTracker, router, reg, executor, logSub, hookSub, ctx, cancel, nil
+	pipeline := &eventPipeline{
+		bus:       bus,
+		axTracker: axTracker,
+		router:    router,
+		reg:       reg,
+		executor:  executor,
+		logSub:    logSub,
+		hookSub:   hookSub,
+	}
+
+	return pipeline, ctx, cancel, nil
 }
 
-func newReloadHandler(
-	reg *hooks.Registry,
-	executor *hooks.Executor,
-	axTracker *observe.AXTracker,
-	router *observe.Router,
+// reloadTrigger names which route into the daemon fired a reload. It closes
+// the set of triggers that can call applyReload — fsnotify and SIGHUP today
+// — over a bare string so a new call site can't drift in an ad hoc label.
+type reloadTrigger string
+
+const (
+	reloadTriggerFsnotify reloadTrigger = "fsnotify"
+	reloadTriggerSighup   reloadTrigger = "sighup"
+)
+
+// applyReload runs cfgReloader.Apply against newCfg and logs the outcome. fsnotify's
+// onChange and the SIGHUP handler both funnel through this one function, so
+// a bad config is reported identically regardless of which trigger noticed
+// it — previously the fsnotify path logged and stopped on a hook-reload
+// error while the SIGHUP path discarded it and logged success anyway.
+func applyReload(
+	cfgReloader *reloader,
+	newCfg *config.Config,
+	trigger reloadTrigger,
 	logger *zap.SugaredLogger,
-) func(*config.Config) {
-	return func(newCfg *config.Config) {
-		if newCfg == nil {
-			return
-		}
+) {
+	err := cfgReloader.Apply(newCfg)
+	if err != nil {
+		logger.Warnw("config reload failed", "trigger", trigger, "err", err)
 
-		err := reg.Reload(newCfg)
-		if err != nil {
-			logger.Warnw("hook registry reload failed", "err", err)
-
-			return
-		}
-
-		executor.UpdateSettings(&newCfg.Settings)
-		native.UpdateObservers(getObserverConfig(newCfg))
-		router.SetDebounceWindow(time.Duration(newCfg.Settings.ResizeDebounceMS) * time.Millisecond)
-
-		perm := permissions.Check()
-		axTracker.Update(perm.Accessibility && hasWindowEvents(newCfg))
-		logger.Info("hooks reloaded from config")
+		return
 	}
+
+	logger.Infow("config reloaded", "trigger", trigger)
 }
 
 func runSignalLoop(
 	cancel context.CancelFunc,
 	quitCh <-chan struct{},
-	reg *hooks.Registry,
-	executor *hooks.Executor,
-	axTracker *observe.AXTracker,
-	router *observe.Router,
+	cfgReloader *reloader,
+	pipeline *eventPipeline,
 	logger *zap.SugaredLogger,
 	configPath string,
-	bus *events.Bus,
-	logSub events.Subscriber,
-	hookSub events.Subscriber,
 ) {
 	sigCh := make(chan os.Signal, 1)
 
@@ -285,59 +294,40 @@ func runSignalLoop(
 		select {
 		case <-quitCh:
 			logger.Info("shutting down from systray")
-			shutdown(cancel, bus, logSub, hookSub)
+			shutdown(cancel, pipeline)
 
 			return
 		case sig := <-sigCh:
 			if sig == syscall.SIGHUP {
-				reloadConfig(configPath, reg, executor, axTracker, router, logger)
+				reloadConfig(configPath, cfgReloader, logger)
 
 				continue
 			}
 
 			logger.Infow("shutting down", "signal", sig)
-			shutdown(cancel, bus, logSub, hookSub)
+			shutdown(cancel, pipeline)
 
 			return
 		}
 	}
 }
 
-func reloadConfig(
-	configPath string,
-	reg *hooks.Registry,
-	executor *hooks.Executor,
-	axTracker *observe.AXTracker,
-	router *observe.Router,
-	logger *zap.SugaredLogger,
-) {
+func reloadConfig(configPath string, cfgReloader *reloader, logger *zap.SugaredLogger) {
 	newCfg, err := config.Load(configPath)
 	if err != nil {
-		logger.Warnw("SIGHUP reload failed", "err", err)
+		logger.Warnw("config reload failed", "trigger", reloadTriggerSighup, "err", err)
 
 		return
 	}
 
-	_ = reg.Reload(newCfg)
-	executor.UpdateSettings(&newCfg.Settings)
-	native.UpdateObservers(getObserverConfig(newCfg))
-	router.SetDebounceWindow(time.Duration(newCfg.Settings.ResizeDebounceMS) * time.Millisecond)
-
-	perm := permissions.Check()
-	axTracker.Update(perm.Accessibility && hasWindowEvents(newCfg))
-	logger.Info("reloaded config via SIGHUP")
+	applyReload(cfgReloader, newCfg, reloadTriggerSighup, logger)
 }
 
-func shutdown(
-	cancel context.CancelFunc,
-	bus *events.Bus,
-	logSub events.Subscriber,
-	hookSub events.Subscriber,
-) {
+func shutdown(cancel context.CancelFunc, pipeline *eventPipeline) {
 	cancel()
 	native.StopObservers()
-	bus.Unsubscribe(logSub)
-	bus.Unsubscribe(hookSub)
+	pipeline.bus.Unsubscribe(pipeline.logSub)
+	pipeline.bus.Unsubscribe(pipeline.hookSub)
 }
 
 func writePID(path string) error {

--- a/internal/daemon/reloader.go
+++ b/internal/daemon/reloader.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/hooks"
+	"github.com/y3owk1n/mimi/internal/native"
+	"github.com/y3owk1n/mimi/internal/observe"
+	"github.com/y3owk1n/mimi/internal/permissions"
+)
+
+// reloader is the single path by which a new config is applied to a running
+// daemon. fsnotify, SIGHUP, and the systray's reload menu item all end up
+// calling Apply, so a failed reload is reported the same way regardless of
+// which trigger fired it — previously the fsnotify path returned the error
+// from hooks.Registry.Reload while the SIGHUP path discarded it, leaving an
+// invalid config's stale hooks in place with no signal to the user.
+//
+// reloader itself never logs — Apply reports outcomes purely through its
+// return value, and the caller (applyReload, in daemon.go) is the single
+// place that turns that into a log line, so every trigger logs identically.
+type reloader struct {
+	reg       *hooks.Registry
+	executor  *hooks.Executor
+	axTracker *observe.AXTracker
+	router    *observe.Router
+}
+
+// newReloader bundles the dependencies a reload touches — the hook
+// registry, its executor, the AX tracker, and the router's debounce window —
+// so callers pass them once at construction instead of threading the same
+// four pointers by hand through every reload call site.
+func newReloader(
+	reg *hooks.Registry,
+	executor *hooks.Executor,
+	axTracker *observe.AXTracker,
+	router *observe.Router,
+) *reloader {
+	return &reloader{
+		reg:       reg,
+		executor:  executor,
+		axTracker: axTracker,
+		router:    router,
+	}
+}
+
+// Apply reloads hooks from cfg and, only once that succeeds, updates
+// executor settings, native observers, the router's debounce window, and AX
+// tracking to match. hooks.Registry.Reload is transactional — it leaves the
+// existing hook map untouched on error — so returning immediately on
+// failure means a bad config leaves every dependency exactly as it was
+// rather than reloading some values but not others.
+//
+// Settings outside [hooks] and the fields read here — systray, log_file,
+// log_level, pid_file, socket_file — are restart-only: Apply never touches
+// them, and nothing else in the daemon reads a fresh value for them after
+// startup.
+func (rl *reloader) Apply(cfg *config.Config) error {
+	if cfg == nil {
+		return derrors.New(derrors.CodeInvalidInput, "nil config")
+	}
+
+	err := rl.reg.Reload(cfg)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeInvalidConfig, "reloading hooks")
+	}
+
+	rl.executor.UpdateSettings(&cfg.Settings)
+	native.UpdateObservers(getObserverConfig(cfg))
+	rl.router.SetDebounceWindow(time.Duration(cfg.Settings.ResizeDebounceMS) * time.Millisecond)
+
+	perm := permissions.Check()
+	rl.axTracker.Update(perm.Accessibility && hasWindowEvents(cfg))
+
+	return nil
+}

--- a/internal/daemon/reloader_test.go
+++ b/internal/daemon/reloader_test.go
@@ -1,0 +1,139 @@
+//nolint:testpackage // tests reloader, an unexported type
+package daemon
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/events"
+	"github.com/y3owk1n/mimi/internal/hooks"
+	"github.com/y3owk1n/mimi/internal/observe"
+)
+
+const (
+	reloaderHookRunOld   = "echo old"
+	reloaderHookRunNew   = "echo new"
+	reloaderInvalidRegex = "["
+)
+
+// newTestReloader wires up a reloader against real (non-nil) collaborators,
+// mirroring what setupEventPipeline hands to the daemon at startup, so
+// Apply's tests exercise the same objects every trigger shares in
+// production.
+func newTestReloader(
+	t *testing.T,
+	initialCfg *config.Config,
+) (*reloader, *hooks.Registry, *events.Bus) {
+	t.Helper()
+
+	logger := zap.NewNop().Sugar()
+
+	reg := hooks.NewRegistry()
+
+	err := reg.Reload(initialCfg)
+	if err != nil {
+		t.Fatalf("failed to seed registry with initial config: %v", err)
+	}
+
+	bus := events.NewBus()
+	axTracker := observe.NewAXTracker(false)
+	router := observe.NewRouterWithDebounce(
+		bus,
+		axTracker,
+		logger,
+		time.Duration(initialCfg.Settings.ResizeDebounceMS)*time.Millisecond,
+	)
+	executor := hooks.NewExecutor(reg, &initialCfg.Settings, logger)
+
+	cfgReloader := newReloader(reg, executor, axTracker, router)
+
+	return cfgReloader, reg, bus
+}
+
+func TestReloader_Apply_ValidConfigReloadsHooksAndDependencies(t *testing.T) {
+	oldCfg := &config.Config{Settings: baseSettings()}
+	oldCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunOld}}
+
+	cfgReloader, reg, bus := newTestReloader(t, oldCfg)
+
+	newCfg := &config.Config{Settings: baseSettings()}
+	newCfg.Settings.ResizeDebounceMS = 750
+	newCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunNew}}
+
+	err := cfgReloader.Apply(newCfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := reg.HooksFor(events.WindowFocus)
+	if len(got) != 1 || got[0].Entry.Run != reloaderHookRunNew {
+		t.Errorf("expected registry to hold the new hook, got %+v", got)
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	wantRouter := observe.NewRouterWithDebounce(
+		bus,
+		cfgReloader.axTracker,
+		logger,
+		750*time.Millisecond,
+	)
+	if !reflect.DeepEqual(wantRouter, cfgReloader.router) {
+		t.Errorf("expected router debounce window to be updated to 750ms")
+	}
+
+	wantTracker := observe.NewAXTracker(true)
+	if !reflect.DeepEqual(wantTracker, cfgReloader.axTracker) {
+		t.Errorf("expected AX tracker enabled state to follow the new config's window hooks")
+	}
+}
+
+func TestReloader_Apply_InvalidHookRegexLeavesPreviousStateUntouched(t *testing.T) {
+	oldCfg := &config.Config{Settings: baseSettings()}
+	oldCfg.Settings.ResizeDebounceMS = 250
+	oldCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunOld}}
+
+	cfgReloader, reg, bus := newTestReloader(t, oldCfg)
+
+	logger := zap.NewNop().Sugar()
+	wantRouterBefore := observe.NewRouterWithDebounce(
+		bus,
+		cfgReloader.axTracker,
+		logger,
+		250*time.Millisecond,
+	)
+	wantTrackerBefore := observe.NewAXTracker(false)
+
+	newCfg := &config.Config{Settings: baseSettings()}
+	newCfg.Settings.ResizeDebounceMS = 999
+	newCfg.Hooks.WindowFocus = []config.HookEntry{
+		{Run: reloaderHookRunNew, Title: reloaderInvalidRegex},
+	}
+
+	err := cfgReloader.Apply(newCfg)
+	if err == nil {
+		t.Fatal("expected an error for an invalid hook regex, got nil")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidConfig) {
+		t.Errorf("expected CodeInvalidConfig, got %v", derrors.GetCode(err))
+	}
+
+	got := reg.HooksFor(events.WindowFocus)
+	if len(got) != 1 || got[0].Entry.Run != reloaderHookRunOld {
+		t.Errorf("expected registry to still hold the old hook after a failed reload, got %+v", got)
+	}
+
+	if !reflect.DeepEqual(wantRouterBefore, cfgReloader.router) {
+		t.Error("expected router debounce window to be left untouched by a failed reload")
+	}
+
+	if !reflect.DeepEqual(wantTrackerBefore, cfgReloader.axTracker) {
+		t.Error("expected AX tracker state to be left untouched by a failed reload")
+	}
+}

--- a/internal/daemon/setup_event_pipeline_test.go
+++ b/internal/daemon/setup_event_pipeline_test.go
@@ -22,8 +22,9 @@ const (
 	pipelineWaitWindow = time.Second
 )
 
-// pipelineResult names setupEventPipeline's ten-value return so test bodies
-// can address the piece they care about instead of a wall of blanks.
+// pipelineResult flattens setupEventPipeline's *eventPipeline return (plus
+// its ctx/cancel/err) so test bodies can address the piece they care about
+// instead of a wall of blanks.
 type pipelineResult struct {
 	bus       *events.Bus
 	axTracker *observe.AXTracker
@@ -42,20 +43,24 @@ func runSetupEventPipeline(
 	logger *zap.SugaredLogger,
 	accessibilityGranted bool,
 ) pipelineResult {
-	bus, axTracker, router, reg, executor, logSub, hookSub, ctx, cancel, err := setupEventPipeline(
+	pipeline, ctx, cancel, err := setupEventPipeline(
 		cfg,
 		logger,
 		accessibilityGranted,
 	)
 
+	if pipeline == nil {
+		return pipelineResult{ctx: ctx, cancel: cancel, err: err}
+	}
+
 	return pipelineResult{
-		bus:       bus,
-		axTracker: axTracker,
-		router:    router,
-		reg:       reg,
-		executor:  executor,
-		logSub:    logSub,
-		hookSub:   hookSub,
+		bus:       pipeline.bus,
+		axTracker: pipeline.axTracker,
+		router:    pipeline.router,
+		reg:       pipeline.reg,
+		executor:  pipeline.executor,
+		logSub:    pipeline.logSub,
+		hookSub:   pipeline.hookSub,
 		ctx:       ctx,
 		cancel:    cancel,
 		err:       err,


### PR DESCRIPTION
## Description

This PR fixes a config reload that silently discarded errors on one of its two trigger paths, and consolidates both into one.

Config reload was implemented twice in the daemon: the file-watch path reported a failed hook reload, but the SIGHUP path (used by `mimi config reload` and by the systray's reload menu item, which signals itself SIGHUP) discarded the error and logged success anyway. An invalid hook `title` regex reloaded that way left the previous, working hooks in place with no signal that the edit hadn't taken effect. Both paths now call the same `Apply`, which is transactional — a bad config aborts before touching anything, so a failure never leaves hooks and the rest of the daemon's runtime config out of sync with each other.

`docs/CONFIGURATION.md` gained a "Reloading" section documenting which settings are restart-only (`systray`, `log_file`, `log_level`, `pid_file`, `socket_file`) — none of them become hot-reloadable in this PR; that would be a separate, deliberate decision.

## Related Issues

Closes #96

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

No config keys, commands, or `mimi_*` hook variables changed — this only touches internal daemon wiring plus the restart-only documentation note. `setupEventPipeline`'s ten-value return is now a single `*eventPipeline` struct; the tests added by #101/#102 that pinned its old signature (`internal/daemon/setup_event_pipeline_test.go`) were updated to unwrap the struct, with every original assertion preserved unweakened.
