### PR TITLE
test(observe,events,daemon): cover the event bus and the router's event handling

### DIFF
--- a/internal/daemon/reloader_test.go
+++ b/internal/daemon/reloader_test.go
@@ -87,9 +87,20 @@ func TestReloader_Apply_ValidConfigReloadsHooksAndDependencies(t *testing.T) {
 		t.Errorf("expected router debounce window to be updated to 750ms")
 	}
 
-	wantTracker := observe.NewAXTracker(true)
-	if !reflect.DeepEqual(wantTracker, cfgReloader.axTracker) {
-		t.Errorf("expected AX tracker enabled state to follow the new config's window hooks")
+	// A whole-struct reflect.DeepEqual against a freshly built
+	// observe.NewAXTracker(true) doesn't work here: AXTracker carries
+	// unexported installAX/removeAX func fields, and Go only treats two func
+	// values as deeply equal when both are nil, so two independently
+	// constructed trackers are never DeepEqual regardless of their enabled
+	// state. axTrackerEnabled (setup_event_pipeline_test.go) reads the
+	// unexported field directly instead.
+	const wantEnabled = true
+	if got := axTrackerEnabled(cfgReloader.axTracker); got != wantEnabled {
+		t.Errorf(
+			"expected AX tracker enabled state to follow the new config's window hooks, got enabled=%v want %v",
+			got,
+			wantEnabled,
+		)
 	}
 }
 
@@ -107,7 +118,7 @@ func TestReloader_Apply_InvalidHookRegexLeavesPreviousStateUntouched(t *testing.
 		logger,
 		250*time.Millisecond,
 	)
-	wantTrackerBefore := observe.NewAXTracker(false)
+	wantEnabledBefore := axTrackerEnabled(cfgReloader.axTracker)
 
 	newCfg := &config.Config{Settings: baseSettings()}
 	newCfg.Settings.ResizeDebounceMS = 999
@@ -133,7 +144,16 @@ func TestReloader_Apply_InvalidHookRegexLeavesPreviousStateUntouched(t *testing.
 		t.Error("expected router debounce window to be left untouched by a failed reload")
 	}
 
-	if !reflect.DeepEqual(wantTrackerBefore, cfgReloader.axTracker) {
-		t.Error("expected AX tracker state to be left untouched by a failed reload")
+	// See the comment on the first axTrackerEnabled call above: AXTracker's
+	// unexported func fields make whole-struct reflect.DeepEqual against a
+	// freshly built tracker always false, so compare the enabled flag
+	// directly instead — captured before Apply so this asserts "unchanged",
+	// not a hardcoded value.
+	if got := axTrackerEnabled(cfgReloader.axTracker); got != wantEnabledBefore {
+		t.Errorf(
+			"expected AX tracker state to be left untouched by a failed reload, got enabled=%v want %v",
+			got,
+			wantEnabledBefore,
+		)
 	}
 }

--- a/internal/daemon/setup_event_pipeline_test.go
+++ b/internal/daemon/setup_event_pipeline_test.go
@@ -100,6 +100,19 @@ func baseSettings() config.SettingsConfig {
 	}
 }
 
+// axTrackerEnabled reads AXTracker's unexported enabled field via
+// reflection. AXTracker exposes no getter for it (internal/observe/ax.go),
+// and comparing a freshly built comparison tracker against the real one with
+// whole-struct reflect.DeepEqual no longer works: AXTracker carries
+// unexported installAX/removeAX func fields (the cgo-free test seam), and Go
+// only treats two func values as deeply equal when both are nil — so two
+// independently constructed trackers are never DeepEqual regardless of
+// their enabled state. Reading the field directly sidesteps that without
+// needing a getter on AXTracker.
+func axTrackerEnabled(tracker *observe.AXTracker) bool {
+	return reflect.ValueOf(tracker).Elem().FieldByName("enabled").Bool()
+}
+
 func TestSetupEventPipeline_AXTrackerEnabledState(t *testing.T) {
 	scenarios := []struct {
 		name                 string
@@ -138,13 +151,8 @@ func TestSetupEventPipeline_AXTrackerEnabledState(t *testing.T) {
 
 			result := mustSetupPipeline(t, cfg, logger, scenario.accessibilityGranted)
 
-			// AXTracker exposes no getter for its enabled state, so compare
-			// the returned tracker against a freshly constructed one: both
-			// are unused (empty tracked map, zero-value mutex), so the
-			// comparison isolates the enabled flag setupEventPipeline chose.
-			want := observe.NewAXTracker(scenario.wantEnabled)
-			if !reflect.DeepEqual(want, result.axTracker) {
-				t.Errorf("AX tracker enabled state mismatch: want enabled=%v", scenario.wantEnabled)
+			if got := axTrackerEnabled(result.axTracker); got != scenario.wantEnabled {
+				t.Errorf("AX tracker enabled state = %v, want %v", got, scenario.wantEnabled)
 			}
 		})
 	}

--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -1,0 +1,173 @@
+package events_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+const (
+	testKindA = events.EventKind("kind_a")
+	testKindB = events.EventKind("kind_b")
+	testKindC = events.EventKind("kind_c")
+
+	testEvtID1 = "evt-1"
+)
+
+// onlyKind returns a KindFilter that admits a single kind.
+func onlyKind(kind events.EventKind) events.KindFilter {
+	return func(k events.EventKind) bool {
+		return k == kind
+	}
+}
+
+func recv(t *testing.T, sub events.Subscriber) (events.Event, bool) {
+	t.Helper()
+
+	select {
+	case evt, ok := <-sub:
+		return evt, ok
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+
+		return events.Event{}, false
+	}
+}
+
+func expectEmpty(t *testing.T, sub events.Subscriber, msg string) {
+	t.Helper()
+
+	select {
+	case evt, ok := <-sub:
+		t.Errorf("%s: got event=%+v ok=%v, want nothing", msg, evt, ok)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestBus_Publish_FansOutToMultipleSubscribers(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewBus()
+	sub1 := bus.Subscribe(1)
+	sub2 := bus.Subscribe(1)
+
+	evt := events.Event{ID: testEvtID1, Kind: testKindA}
+	bus.Publish(evt)
+
+	got1, ok1 := recv(t, sub1)
+	if !ok1 || got1.ID != testEvtID1 {
+		t.Errorf("sub1 got %+v ok=%v, want %s", got1, ok1, testEvtID1)
+	}
+
+	got2, ok2 := recv(t, sub2)
+	if !ok2 || got2.ID != testEvtID1 {
+		t.Errorf("sub2 got %+v ok=%v, want %s", got2, ok2, testEvtID1)
+	}
+}
+
+func TestBus_SubscribeWithFilter_SkipsNonMatchingKinds(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewBus()
+	sub := bus.SubscribeWithFilter(1, onlyKind(testKindA))
+
+	bus.Publish(events.Event{ID: "skip-me", Kind: testKindB})
+
+	expectEmpty(t, sub, "filtered subscriber received a non-matching kind")
+
+	bus.Publish(events.Event{ID: "keep-me", Kind: testKindA})
+
+	got, ok := recv(t, sub)
+	if !ok || got.ID != "keep-me" {
+		t.Errorf("got %+v ok=%v, want keep-me", got, ok)
+	}
+}
+
+func TestBus_Publish_AfterUnsubscribeNoDelivery(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewBus()
+	sub := bus.Subscribe(1)
+
+	bus.Unsubscribe(sub)
+	bus.Publish(events.Event{ID: testEvtID1, Kind: testKindA})
+
+	// Unsubscribe closes the channel, so a receive after it must return
+	// immediately with ok=false rather than blocking or delivering anything.
+	select {
+	case evt, ok := <-sub:
+		if ok {
+			t.Errorf("received %+v after Unsubscribe, want closed channel", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading from an unsubscribed channel; want it closed")
+	}
+}
+
+func TestBus_Publish_DropsWhenSubscriberBufferFull(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewBus()
+	sub := bus.Subscribe(1)
+
+	bus.Publish(events.Event{ID: "first", Kind: testKindA})
+	bus.Publish(events.Event{ID: "dropped", Kind: testKindA}) // buffer full; Publish must not block
+
+	got, ok := recv(t, sub)
+	if !ok || got.ID != "first" {
+		t.Errorf("got %+v ok=%v, want first", got, ok)
+	}
+
+	expectEmpty(t, sub, "buffer-full publish should have been dropped, not queued")
+}
+
+// TestBus_Unsubscribe_KeepsRemainingFiltersAligned pins the invariant that
+// Bus's subs and filters slices are spliced together on Unsubscribe.
+// Removing a middle subscriber must not shift a later subscriber's filter
+// out of step with its channel — that failure mode would look like a hook
+// that "sometimes doesn't fire" with nothing in a diff to point at.
+func TestBus_Unsubscribe_KeepsRemainingFiltersAligned(t *testing.T) {
+	t.Parallel()
+
+	bus := events.NewBus()
+	subA := bus.SubscribeWithFilter(1, onlyKind(testKindA))
+	subB := bus.SubscribeWithFilter(1, onlyKind(testKindB))
+	subC := bus.SubscribeWithFilter(1, onlyKind(testKindC))
+
+	bus.Unsubscribe(subB)
+
+	// subB must be closed.
+	select {
+	case _, ok := <-subB:
+		if ok {
+			t.Error("subB received a value after Unsubscribe, want closed channel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading from unsubscribed subB; want it closed")
+	}
+
+	// Publishing kindC must still reach subC under subC's own filter. If the
+	// splice desynced subs from filters, subC would now be paired with
+	// subB's old filter (kindB-only) and silently miss this event.
+	bus.Publish(events.Event{ID: "for-c", Kind: testKindC})
+
+	gotC, okC := recv(t, subC)
+	if !okC || gotC.ID != "for-c" {
+		t.Fatalf(
+			"subC got %+v ok=%v, want for-c: its filter likely inherited subB's after Unsubscribe",
+			gotC,
+			okC,
+		)
+	}
+
+	// subA's filter must also be untouched by the splice.
+	expectEmpty(t, subA, "subA should not receive a kindC event under its own kindA-only filter")
+
+	bus.Publish(events.Event{ID: "for-a", Kind: testKindA})
+
+	gotA, okA := recv(t, subA)
+	if !okA || gotA.ID != "for-a" {
+		t.Fatalf("subA got %+v ok=%v, want for-a", gotA, okA)
+	}
+}

--- a/internal/observe/ax.go
+++ b/internal/observe/ax.go
@@ -11,13 +11,21 @@ type AXTracker struct {
 	mu      sync.Mutex
 	tracked map[int]struct{}
 	enabled bool
+
+	// installAX and removeAX default to the native cgo bridge and are
+	// reassigned directly by in-package tests so they can exercise
+	// Install/Remove without calling into cgo.
+	installAX func(pid int) bool
+	removeAX  func(pid int)
 }
 
 // NewAXTracker creates a tracker with the enabled flag.
 func NewAXTracker(enabled bool) *AXTracker {
 	return &AXTracker{
-		tracked: make(map[int]struct{}),
-		enabled: enabled,
+		tracked:   make(map[int]struct{}),
+		enabled:   enabled,
+		installAX: native.InstallAXObserver,
+		removeAX:  native.RemoveAXObserver,
 	}
 }
 
@@ -29,7 +37,7 @@ func (t *AXTracker) Update(enabled bool) {
 	t.enabled = enabled
 	if !enabled {
 		for pid := range t.tracked {
-			native.RemoveAXObserver(pid)
+			t.removeAX(pid)
 			delete(t.tracked, pid)
 		}
 	}
@@ -48,7 +56,7 @@ func (t *AXTracker) Install(pid int) bool {
 		return true
 	}
 
-	if ok := native.InstallAXObserver(pid); ok {
+	if ok := t.installAX(pid); ok {
 		t.tracked[pid] = struct{}{}
 
 		return true
@@ -66,6 +74,6 @@ func (t *AXTracker) Remove(pid int) {
 		return
 	}
 
-	native.RemoveAXObserver(pid)
+	t.removeAX(pid)
 	delete(t.tracked, pid)
 }

--- a/internal/observe/ax_test.go
+++ b/internal/observe/ax_test.go
@@ -1,0 +1,176 @@
+//nolint:testpackage // needs direct access to AXTracker's unexported installAX/removeAX/tracked fields
+package observe
+
+import "testing"
+
+// fakeAXCalls records calls made through the installAX/removeAX seams so
+// tests can assert on them without touching cgo.
+type fakeAXCalls struct {
+	installed []int
+	removed   []int
+	installOK bool
+}
+
+func (f *fakeAXCalls) install(pid int) bool {
+	f.installed = append(f.installed, pid)
+
+	return f.installOK
+}
+
+func (f *fakeAXCalls) remove(pid int) {
+	f.removed = append(f.removed, pid)
+}
+
+func newFakeTracker(enabled bool, installOK bool) (*AXTracker, *fakeAXCalls) {
+	calls := &fakeAXCalls{installOK: installOK}
+	tracker := NewAXTracker(enabled)
+	tracker.installAX = calls.install
+	tracker.removeAX = calls.remove
+
+	return tracker, calls
+}
+
+func TestAXTracker_Install_DisabledNeverCallsNative(t *testing.T) {
+	tracker, calls := newFakeTracker(false, true)
+
+	if ok := tracker.Install(42); ok {
+		t.Error("Install() on a disabled tracker = true, want false")
+	}
+
+	if len(calls.installed) != 0 {
+		t.Errorf("installAX called %d times on a disabled tracker, want 0", len(calls.installed))
+	}
+}
+
+func TestAXTracker_Install_EnabledTracksOnSuccess(t *testing.T) {
+	tracker, calls := newFakeTracker(true, true)
+
+	if ok := tracker.Install(42); !ok {
+		t.Fatal("Install() = false, want true")
+	}
+
+	if len(calls.installed) != 1 || calls.installed[0] != 42 {
+		t.Errorf("installAX calls = %v, want [42]", calls.installed)
+	}
+
+	// A second Install for the same PID must be a no-op: no repeat call to
+	// installAX, since the PID is already tracked.
+	if ok := tracker.Install(42); !ok {
+		t.Error("Install() on an already-tracked PID = false, want true")
+	}
+
+	if len(calls.installed) != 1 {
+		t.Errorf(
+			"installAX called %d times for a repeated Install, want 1 (deduped)",
+			len(calls.installed),
+		)
+	}
+}
+
+func TestAXTracker_Install_FailureNotTracked(t *testing.T) {
+	tracker, calls := newFakeTracker(true, false)
+
+	if ok := tracker.Install(42); ok {
+		t.Error("Install() = true when installAX reports failure, want false")
+	}
+
+	if len(calls.installed) != 1 {
+		t.Errorf("installAX calls = %d, want 1", len(calls.installed))
+	}
+
+	tracker.mu.Lock()
+	_, tracked := tracker.tracked[42]
+	tracker.mu.Unlock()
+
+	if tracked {
+		t.Error("PID marked tracked despite installAX reporting failure")
+	}
+}
+
+// TestAXTracker_Remove_HasNoEnabledGuard pins the asymmetry the ticket flags:
+// unlike Install, Remove does not check t.enabled. That is safe today only
+// because a disabled tracker can never populate tracked (Install's own
+// !t.enabled guard prevents it) — so this test forces the otherwise
+// unreachable state (disabled tracker, non-empty tracked) directly, to prove
+// Remove's behavior rests on "nothing is tracked", not on "we're enabled".
+func TestAXTracker_Remove_HasNoEnabledGuard(t *testing.T) {
+	tracker, calls := newFakeTracker(false, true)
+
+	// Seed tracked directly: Install can't do this while disabled, and that
+	// is exactly the point.
+	tracker.mu.Lock()
+	tracker.tracked[42] = struct{}{}
+	tracker.mu.Unlock()
+
+	tracker.Remove(42)
+
+	if len(calls.removed) != 1 || calls.removed[0] != 42 {
+		t.Errorf(
+			"removeAX calls = %v, want [42]: Remove must act regardless of the enabled flag",
+			calls.removed,
+		)
+	}
+
+	tracker.mu.Lock()
+	_, tracked := tracker.tracked[42]
+	tracker.mu.Unlock()
+
+	if tracked {
+		t.Error("PID still tracked after Remove")
+	}
+}
+
+func TestAXTracker_Remove_UntrackedPIDNoOp(t *testing.T) {
+	tracker, calls := newFakeTracker(true, true)
+
+	tracker.Remove(99)
+
+	if len(calls.removed) != 0 {
+		t.Errorf("removeAX called %d times for an untracked PID, want 0", len(calls.removed))
+	}
+}
+
+func TestAXTracker_Update_DisableRemovesAllTracked(t *testing.T) {
+	tracker, calls := newFakeTracker(true, true)
+
+	tracker.Install(1)
+	tracker.Install(2)
+	tracker.Install(3)
+
+	tracker.Update(false)
+
+	if len(calls.removed) != 3 {
+		t.Errorf("removeAX called %d times after disabling, want 3", len(calls.removed))
+	}
+
+	tracker.mu.Lock()
+	remaining := len(tracker.tracked)
+	tracker.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("tracked has %d entries after disabling, want 0", remaining)
+	}
+
+	// With the tracker now disabled, Install must refuse again.
+	if ok := tracker.Install(4); ok {
+		t.Error("Install() after Update(false) = true, want false")
+	}
+}
+
+func TestAXTracker_Update_EnableAgainAllowsInstall(t *testing.T) {
+	tracker, calls := newFakeTracker(false, true)
+
+	if ok := tracker.Install(7); ok {
+		t.Fatal("Install() before Update(true) = true, want false")
+	}
+
+	tracker.Update(true)
+
+	if ok := tracker.Install(7); !ok {
+		t.Error("Install() after Update(true) = false, want true")
+	}
+
+	if len(calls.installed) != 1 {
+		t.Errorf("installAX calls = %d, want 1", len(calls.installed))
+	}
+}

--- a/internal/observe/router_test.go
+++ b/internal/observe/router_test.go
@@ -2,6 +2,7 @@
 package observe
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -15,6 +16,22 @@ const (
 	testAppShort    = "App"
 	testWindowTitle = "Win"
 	testBundleID    = "com.test.app"
+
+	// testDebounceWindow keeps the debounce suite's wall-clock down: short
+	// enough that a real fire is fast, long enough that scheduling jitter
+	// under `-race` doesn't produce a flake.
+	testDebounceWindow = 50 * time.Millisecond
+	// testFireTimeout is how long a test waits for a debounced event to
+	// arrive; comfortably above testDebounceWindow.
+	testFireTimeout = 500 * time.Millisecond
+	// testNoFireWait is how long a test waits to confirm nothing arrives;
+	// comfortably above testDebounceWindow so a wrongly-still-running timer
+	// would be caught.
+	testNoFireWait = 200 * time.Millisecond
+	// testCoalesceSpacing is the gap between successive resize events in the
+	// coalescing test; it must stay well under testDebounceWindow so each
+	// event resets the timer instead of letting it fire early.
+	testCoalesceSpacing = 15 * time.Millisecond
 )
 
 func newTestRouter(t *testing.T) (*Router, <-chan events.Event) {
@@ -24,9 +41,52 @@ func newTestRouter(t *testing.T) (*Router, <-chan events.Event) {
 	sub := bus.Subscribe(16)
 	ax := NewAXTracker(false)
 	logger := zap.NewNop().Sugar()
-	router := NewRouter(bus, ax, logger)
+	router := NewRouterWithDebounce(bus, ax, logger, testDebounceWindow)
 
 	return router, sub
+}
+
+// newHandleTestRouter returns a Router wired to an enabled AXTracker whose
+// native calls are faked (via newFakeTracker, shared with ax_test.go), for
+// exercising Router.handle's AX install/remove branches.
+func newHandleTestRouter(t *testing.T) (*Router, <-chan events.Event, *AXTracker, *fakeAXCalls) {
+	t.Helper()
+
+	bus := events.NewBus()
+	sub := bus.Subscribe(16)
+	axTracker, fake := newFakeTracker(true, true)
+	logger := zap.NewNop().Sugar()
+	router := NewRouterWithDebounce(bus, axTracker, logger, testDebounceWindow)
+
+	return router, sub, axTracker, fake
+}
+
+// hookableKinds is a hardcoded mirror of buildMap's literal kind→config map
+// (internal/hooks/registry.go), kept deliberately independent of
+// events.AllKinds: if a future internal kind were mistakenly added to
+// AllKinds, a filter built from AllKinds would pick up the same mistake and
+// this test would stop catching it. Hardcoding the list here means the test
+// only passes if `_`-prefixed and unrecognized kinds are excluded on their
+// own merits.
+var hookableKinds = []events.EventKind{
+	events.AppActivate,
+	events.AppDeactivate,
+	events.AppLaunch,
+	events.AppQuit,
+	events.AppHide,
+	events.AppUnhide,
+	events.WindowFocus,
+	events.WindowTitleChange,
+	events.WindowCreated,
+	events.WindowClosed,
+	events.WindowResize,
+	events.WorkspaceChanged,
+}
+
+// isHookableKind is a hookSub-style filter built from hookableKinds, mirroring
+// registry.KindFilter() (internal/hooks/registry.go) without depending on it.
+func isHookableKind(kind events.EventKind) bool {
+	return slices.Contains(hookableKinds, kind)
 }
 
 func TestDebounceResize_SingleEvent(t *testing.T) {
@@ -56,7 +116,7 @@ func TestDebounceResize_SingleEvent(t *testing.T) {
 		if _evt.PID != 42 {
 			t.Errorf("expected PID 42, got %d", _evt.PID)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(testFireTimeout):
 		t.Fatal("timed out waiting for debounced resize event")
 	}
 
@@ -83,7 +143,7 @@ func TestDebounceResize_MultipleEventsCoalesce(t *testing.T) {
 			Extra:       map[string]string{"seq": string(rune('0' + index))},
 		}
 		router.debounceResize(evt)
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(testCoalesceSpacing)
 	}
 
 	select {
@@ -91,14 +151,14 @@ func TestDebounceResize_MultipleEventsCoalesce(t *testing.T) {
 		if e.Kind != events.WindowResize {
 			t.Errorf("expected WindowResize, got %s", e.Kind)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(testFireTimeout):
 		t.Fatal("timed out waiting for debounced resize event")
 	}
 
 	select {
 	case e := <-sub:
 		t.Errorf("unexpected second event: %+v", e)
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(testNoFireWait):
 	}
 }
 
@@ -118,7 +178,7 @@ func TestDebounceResize_DifferentWindows(t *testing.T) {
 		select {
 		case e := <-sub:
 			received[e.AppName] = true
-		case <-time.After(2 * time.Second):
+		case <-time.After(testFireTimeout):
 			t.Fatal("timed out waiting for debounced resize events")
 		}
 	}
@@ -140,7 +200,7 @@ func TestDebounceResize_CancelTimersForPID(t *testing.T) {
 	select {
 	case e := <-sub:
 		t.Errorf("expected no event after cancel, got: %+v", e)
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(testNoFireWait):
 	}
 
 	router.mu.Lock()
@@ -169,7 +229,7 @@ func TestDebounceResize_StopAllTimers(t *testing.T) {
 	select {
 	case e := <-sub:
 		t.Errorf("expected no events after stopAllTimers, got: %+v", e)
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(testNoFireWait):
 	}
 
 	router.mu.Lock()
@@ -198,6 +258,227 @@ func TestDebounceResize_NoPublishAfterStop(t *testing.T) {
 	select {
 	case e := <-sub:
 		t.Errorf("expected no events after stop, got: %+v", e)
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(testNoFireWait):
+	}
+}
+
+func TestHandle_AppActivate_InstallsAXObserverAndPublishes(t *testing.T) {
+	router, sub, _, fake := newHandleTestRouter(t)
+
+	router.handle(events.Event{Kind: events.AppActivate, PID: 7, AppName: testAppName})
+
+	if len(fake.installed) != 1 || fake.installed[0] != 7 {
+		t.Errorf("installAX calls = %v, want [7]", fake.installed)
+	}
+
+	select {
+	case evt := <-sub:
+		if evt.Kind != events.AppActivate || evt.PID != 7 {
+			t.Errorf("published event = %+v, want kind=app_activate pid=7", evt)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for app_activate to publish")
+	}
+}
+
+func TestHandle_AppLaunch_InstallsAXObserverAndPublishes(t *testing.T) {
+	router, sub, _, fake := newHandleTestRouter(t)
+
+	router.handle(events.Event{Kind: events.AppLaunch, PID: 11, AppName: testAppName})
+
+	if len(fake.installed) != 1 || fake.installed[0] != 11 {
+		t.Errorf("installAX calls = %v, want [11]", fake.installed)
+	}
+
+	select {
+	case evt := <-sub:
+		if evt.Kind != events.AppLaunch || evt.PID != 11 {
+			t.Errorf("published event = %+v, want kind=app_launch pid=11", evt)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for app_launch to publish")
+	}
+}
+
+func TestHandle_AppActivate_ZeroPIDSkipsInstallButStillPublishes(t *testing.T) {
+	router, sub, _, fake := newHandleTestRouter(t)
+
+	router.handle(events.Event{Kind: events.AppActivate, PID: 0, AppName: testAppName})
+
+	if len(fake.installed) != 0 {
+		t.Errorf("installAX calls = %v, want none for PID 0", fake.installed)
+	}
+
+	select {
+	case evt := <-sub:
+		if evt.Kind != events.AppActivate {
+			t.Errorf("published event kind = %s, want app_activate", evt.Kind)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for app_activate to publish")
+	}
+}
+
+func TestHandle_AppQuit_RemovesAXObserverAndCancelsTimers(t *testing.T) {
+	router, sub, ax, fake := newHandleTestRouter(t)
+
+	const pid = 21
+
+	if ok := ax.Install(pid); !ok {
+		t.Fatalf("ax.Install(%d) = false, want true (test setup)", pid)
+	}
+
+	router.debounceResize(
+		events.Event{Kind: events.WindowResizing, PID: pid, WindowTitle: testWindowTitle},
+	)
+
+	router.mu.Lock()
+	before := len(router.timers)
+	router.mu.Unlock()
+
+	if before != 1 {
+		t.Fatalf("timers before quit = %d, want 1 (test setup)", before)
+	}
+
+	router.handle(events.Event{Kind: events.AppQuit, PID: pid, AppName: testAppName})
+
+	if len(fake.removed) != 1 || fake.removed[0] != pid {
+		t.Errorf("removeAX calls = %v, want [%d]", fake.removed, pid)
+	}
+
+	router.mu.Lock()
+	after := len(router.timers)
+	router.mu.Unlock()
+
+	if after != 0 {
+		t.Errorf("timers after quit = %d, want 0 (cancelTimersForPID should have run)", after)
+	}
+
+	select {
+	case evt := <-sub:
+		if evt.Kind != events.AppQuit || evt.PID != pid {
+			t.Errorf("published event = %+v, want kind=app_quit pid=%d", evt, pid)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for app_quit to publish")
+	}
+
+	// The canceled resize timer must never fire a debounced event.
+	select {
+	case evt := <-sub:
+		t.Errorf("unexpected second event after quit, got: %+v", evt)
+	case <-time.After(testNoFireWait):
+	}
+}
+
+func TestHandle_AppQuit_ZeroPIDSkipsRemoveAndCancel(t *testing.T) {
+	router, sub, _, fake := newHandleTestRouter(t)
+
+	router.handle(events.Event{Kind: events.AppQuit, PID: 0, AppName: testAppName})
+
+	if len(fake.removed) != 0 {
+		t.Errorf("removeAX calls = %v, want none for PID 0", fake.removed)
+	}
+
+	select {
+	case evt := <-sub:
+		if evt.Kind != events.AppQuit {
+			t.Errorf("published event kind = %s, want app_quit", evt.Kind)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for app_quit to publish")
+	}
+}
+
+func TestHandle_WindowResizing_DebouncesWithoutImmediatePublish(t *testing.T) {
+	router, sub := newTestRouter(t)
+
+	router.handle(events.Event{
+		Kind: events.WindowResizing, PID: 5, WindowTitle: testWindowTitle, AppName: testAppShort,
+	})
+
+	// handle() must route WindowResizing through debounceResize and return
+	// before publishing anything immediately.
+	select {
+	case evt := <-sub:
+		t.Errorf("unexpected immediate publish for _window_resizing, got: %+v", evt)
+	case <-time.After(testCoalesceSpacing):
+	}
+
+	select {
+	case evt := <-sub:
+		if evt.Kind != events.WindowResize {
+			t.Errorf("debounced event kind = %s, want window_resize", evt.Kind)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for the debounced resize to publish")
+	}
+}
+
+func TestHandle_DefaultCase_LogsAndPublishesVerbatim(t *testing.T) {
+	router, sub := newTestRouter(t)
+
+	evt := events.Event{
+		Kind:     events.WindowFocus,
+		AppName:  testAppName,
+		BundleID: testBundleID,
+		PID:      3,
+	}
+	router.handle(evt)
+
+	select {
+	case got := <-sub:
+		if got.Kind != events.WindowFocus || got.PID != 3 || got.AppName != testAppName {
+			t.Errorf("published event = %+v, want %+v", got, evt)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for the default-case publish")
+	}
+}
+
+// TestHandle_InternalKindReachesLogSubButNotHookFilteredSub pins the
+// invariant that `_`-prefixed (and otherwise unrecognized) kinds never reach
+// a hook subscriber. handle() itself applies no such guard — the default
+// case logs and publishes every kind unconditionally, exactly like
+// native.StartObservers' inline "_startup_" event (bridge.go:68). The
+// invariant holds only because a hookSub-style filter (built from
+// events.AllKinds, mirroring buildMap in internal/hooks/registry.go) never
+// admits it, while an unfiltered logSub-style subscriber sees everything.
+func TestHandle_InternalKindReachesLogSubButNotHookFilteredSub(t *testing.T) {
+	bus := events.NewBus()
+	logSub := bus.Subscribe(16)
+	hookSub := bus.SubscribeWithFilter(16, isHookableKind)
+	ax := NewAXTracker(false)
+	logger := zap.NewNop().Sugar()
+	router := NewRouterWithDebounce(bus, ax, logger, testDebounceWindow)
+
+	router.handle(events.Event{Kind: events.EventKind("_startup_"), AppName: "mimi"})
+
+	select {
+	case evt := <-logSub:
+		if evt.Kind != events.EventKind("_startup_") {
+			t.Errorf("logSub got kind %s, want _startup_", evt.Kind)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for logSub to receive the internal-kind event")
+	}
+
+	select {
+	case evt := <-hookSub:
+		t.Errorf("hookSub received an internal-kind event, want it filtered out: %+v", evt)
+	case <-time.After(testNoFireWait):
+	}
+
+	// Sanity check: the same filter does admit a real hookable kind, so the
+	// prior assertion is proof of filtering, not of a wedged subscriber.
+	router.handle(events.Event{Kind: events.AppActivate, PID: 1})
+
+	select {
+	case evt := <-hookSub:
+		if evt.Kind != events.AppActivate {
+			t.Errorf("hookSub got kind %s, want app_activate", evt.Kind)
+		}
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for hookSub to receive a real hookable kind")
 	}
 }


### PR DESCRIPTION
## Description

This PR adds test coverage for the hook daemon's event bus and event
router, which had none: `internal/events.Bus` sat at 0% coverage, and
`internal/observe.Router.handle` — the switch that installs/removes AX
observers on app activate/launch/quit, debounces window resizes, and
publishes everything else — had never executed under test.

To make `Router.handle`'s AX branches testable without touching cgo,
`AXTracker` gains two unexported func fields (`installAX`, `removeAX`)
that default to the real native bridge and are reassigned directly by
in-package tests. No exported signature changes anywhere in
`internal/observe` or `internal/events`.

New tests cover: `Bus` fan-out, filter skip, publish-after-unsubscribe,
drop-on-full-buffer, and specifically the `Unsubscribe` splice that
must keep `subs` and `filters` index-aligned (verified by hand-injecting
a misaligned-splice bug and confirming the new test catches it, then
reverting — `bus.go` itself is unchanged in this PR). `AXTracker`
Install/Remove/Update tests, including one that pins the existing
asymmetry that `Remove` has no `enabled` guard (unlike `Install`) — that
asymmetry is intentionally preserved, not fixed. One `Router.handle`
test per branch, plus a test pinning that internal (`_`-prefixed) event
kinds reach an unfiltered subscriber but never a hook-style filtered
one. The pre-existing debounce tests were switched from the 250ms
`NewRouter` default to `NewRouterWithDebounce` with a short window,
cutting the suite's wall-clock.

Coverage: `internal/observe` 44.6% → 80.4%, `internal/events` 0% → 100%.
`Router.Run` (the 15-line native-events select loop) stays untested —
the issue explicitly defers it, since `handle` was reachable in-package
without touching `Run`.

### Why this also touches `internal/daemon`

Three assertions in `internal/daemon/{reloader_test.go,setup_event_pipeline_test.go}`
worked around `AXTracker` having no getter for its `enabled` state by
comparing a freshly built `observe.NewAXTracker(...)` against the real
one with `reflect.DeepEqual`. Go only treats two non-nil `func` values
as deeply equal when both are `nil` — never when they're the same
function — so `AXTracker`'s new `installAX`/`removeAX` fields make any
two independently constructed trackers permanently unequal, regardless
of their actual `enabled` state. That's a direct, unavoidable
consequence of the seam this issue asked for, not scope creep: a
production change that breaks existing tests carries the obligation to
fix them.

Fixed minimally by adding a small reflection helper
(`axTrackerEnabled`) that reads just the unexported `enabled` field, so
each assertion still checks exactly what it checked before — just
without dragging the func fields into a whole-struct comparison. This
lives entirely in the daemon test file; it is not a getter added to
`AXTracker`. Three sibling `reflect.DeepEqual` calls that compare
`*Router` structs were left untouched — they still pass, because in
every case the comparison router is built from the exact same
`*AXTracker`/`*Bus` pointers as the real one, so `DeepEqual`
short-circuits on pointer identity before it would ever recurse into
`AXTracker`'s fields.

## Related Issues

Closes #92

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing config/command/hook surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The only production (non-test) change in this PR is
`internal/observe/ax.go`: two unexported func fields on `AXTracker`,
defaulted inside `NewAXTracker`. Everything else is test files. `git
diff origin/main --stat`:

```
 internal/daemon/reloader_test.go             |  32 ++-
 internal/daemon/setup_event_pipeline_test.go |  22 +-
 internal/events/bus_test.go                  | 173 ++++++++++++++++
 internal/observe/ax.go                       |  18 +-
 internal/observe/ax_test.go                  | 176 ++++++++++++++++
 internal/observe/router_test.go              | 299 ++++++++++++++++++++++++++-
 6 files changed, 693 insertions(+), 27 deletions(-)
```
