### PR TITLE
fix(action,cli): reject a negative --width or --height instead of ignoring it

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -72,28 +72,21 @@ in that direction based on screen position.
 Only windows that are focusable (not minimized, not hidden) and on the
 current space are included.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			args := []string{}
-			if backward {
-				args = append(args, "--backward")
+			focusArgs, err := action.NewFocusWindowArgs(
+				backward,
+				focusUp,
+				focusDown,
+				focusLeft,
+				focusRight,
+			)
+			if err != nil {
+				return err
 			}
 
-			if focusUp {
-				args = append(args, "--up")
-			}
-
-			if focusDown {
-				args = append(args, "--down")
-			}
-
-			if focusLeft {
-				args = append(args, "--left")
-			}
-
-			if focusRight {
-				args = append(args, "--right")
-			}
-
-			return state.runAction(string(action.NameFocusWindow), args)
+			return state.runAction(action.Command{
+				Name:        action.NameFocusWindow,
+				FocusWindow: focusArgs,
+			})
 		},
 	}
 
@@ -138,7 +131,12 @@ Examples:
   mimi action space prev     Cycle to the previous space (with wrap)`,
 		Args: validateActionSpaceArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return state.runAction(string(action.NameSpace), []string{strings.TrimSpace(args[0])})
+			spaceArg, err := action.ParseSpaceArg([]string{strings.TrimSpace(args[0])})
+			if err != nil {
+				return err
+			}
+
+			return state.runAction(action.Command{Name: action.NameSpace, Space: spaceArg})
 		},
 	}
 }
@@ -166,27 +164,20 @@ Examples:
   mimi action move_window_to_space prev     Move window to previous space (with wrap)`,
 		Args: validateActionMoveWindowToSpaceArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return state.runAction(
-				string(action.NameMoveWindowToSpace),
-				[]string{strings.TrimSpace(args[0])},
-			)
+			spaceArg, err := action.ParseSpaceArg([]string{strings.TrimSpace(args[0])})
+			if err != nil {
+				return err
+			}
+
+			return state.runAction(action.Command{
+				Name:              action.NameMoveWindowToSpace,
+				MoveWindowToSpace: spaceArg,
+			})
 		},
 	}
 }
 
 func buildResizeWindowCommand(state *cliState) *cobra.Command {
-	var (
-		width     int
-		height    int
-		widthPct  float64
-		heightPct float64
-		xCoord    int
-		yCoord    int
-		anchor    string
-		useMargin bool
-		noMargin  bool
-	)
-
 	cmd := &cobra.Command{
 		Use:   "resize_window [preset]",
 		Short: "Resize and reposition the frontmost window",
@@ -230,13 +221,11 @@ Examples:
   mimi action resize_window center --width-percent 80 --height-percent 90`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			cmdArgs := []string{}
+			preset := ""
 
 			if len(args) > 0 {
-				preset := strings.TrimSpace(args[0])
-				if action.IsResizePreset(preset) {
-					cmdArgs = append(cmdArgs, preset)
-				} else {
+				preset = strings.TrimSpace(args[0])
+				if !action.IsResizePreset(preset) {
 					return derrors.Newf(
 						derrors.CodeInvalidInput,
 						"unknown preset %q (valid: left-half, right-half, top-half, bottom-half, top-left, top-right, bottom-left, bottom-right, center, fill)",
@@ -245,69 +234,67 @@ Examples:
 				}
 			}
 
-			if width > 0 {
-				cmdArgs = append(cmdArgs, "--width", strconv.Itoa(width))
-			}
+			resizeArgs := resizeWindowArgsFromFlags(cobraCmd, preset)
 
-			if height > 0 {
-				cmdArgs = append(cmdArgs, "--height", strconv.Itoa(height))
-			}
-
-			if widthPct > 0 {
-				cmdArgs = append(
-					cmdArgs,
-					"--width-percent",
-					strconv.FormatFloat(widthPct, 'f', -1, 64),
-				)
-			}
-
-			if heightPct > 0 {
-				cmdArgs = append(
-					cmdArgs,
-					"--height-percent",
-					strconv.FormatFloat(heightPct, 'f', -1, 64),
-				)
-			}
-
-			if cobraCmd.Flags().Changed("x") {
-				cmdArgs = append(cmdArgs, "--x", strconv.Itoa(xCoord))
-			}
-
-			if cobraCmd.Flags().Changed("y") {
-				cmdArgs = append(cmdArgs, "--y", strconv.Itoa(yCoord))
-			}
-
-			if cobraCmd.Flags().Changed("anchor") {
-				cmdArgs = append(cmdArgs, "--anchor", anchor)
-			}
-
-			if useMargin {
-				cmdArgs = append(cmdArgs, "--margin")
-			}
-
-			if noMargin {
-				cmdArgs = append(cmdArgs, "--no-margin")
-			}
-
-			return state.runAction(string(action.NameResizeWindow), cmdArgs)
+			return state.runAction(action.Command{
+				Name:         action.NameResizeWindow,
+				ResizeWindow: resizeArgs,
+			})
 		},
 	}
 
-	cmd.Flags().IntVarP(&width, "width", "w", 0, "Absolute window width in points")
-	cmd.Flags().IntVar(&height, "height", 0, "Absolute window height in points")
-	cmd.Flags().Float64Var(&widthPct, "width-percent", 0, "Width as percentage of screen (0-100)")
+	cmd.Flags().IntP("width", "w", 0, "Absolute window width in points")
+	cmd.Flags().Int("height", 0, "Absolute window height in points")
+	cmd.Flags().Float64("width-percent", 0, "Width as percentage of screen (0-100)")
+	cmd.Flags().Float64("height-percent", 0, "Height as percentage of screen (0-100)")
+	cmd.Flags().Int("x", 0, "Absolute x position in screen coordinates")
+	cmd.Flags().Int("y", 0, "Absolute y position in screen coordinates")
 	cmd.Flags().
-		Float64Var(&heightPct, "height-percent", 0, "Height as percentage of screen (0-100)")
-	cmd.Flags().IntVar(&xCoord, "x", 0, "Absolute x position in screen coordinates")
-	cmd.Flags().IntVar(&yCoord, "y", 0, "Absolute y position in screen coordinates")
-	cmd.Flags().
-		StringVarP(&anchor, "anchor", "a", "", "Anchor point for positioning (tl, tc, tr, cl, cc, cr, bl, bc, br)")
-	cmd.Flags().
-		BoolVar(&useMargin, "margin", false, "Enable tiled window margins (overrides system setting)")
-	cmd.Flags().
-		BoolVar(&noMargin, "no-margin", false, "Disable tiled window margins (overrides system setting)")
+		StringP("anchor", "a", "", "Anchor point for positioning (tl, tc, tr, cl, cc, cr, bl, bc, br)")
+	cmd.Flags().Bool("margin", false, "Enable tiled window margins (overrides system setting)")
+	cmd.Flags().Bool("no-margin", false, "Disable tiled window margins (overrides system setting)")
 
 	return cmd
+}
+
+// resizeWindowArgsFromFlags reads resize_window's typed payload directly off
+// cobraCmd's flags — the one place these values are read, since nothing
+// keeps a bound variable of its own. It uses Flags().Changed(...) — not a
+// flag's value — to tell whether the caller gave it, the rule --x and --y
+// already followed and --width, --height and their -percent counterparts
+// now match, so an explicit zero is forwarded rather than silently dropped.
+func resizeWindowArgsFromFlags(cobraCmd *cobra.Command, preset string) action.ResizeWindowArgs {
+	flags := cobraCmd.Flags()
+
+	width, _ := flags.GetInt("width")
+	height, _ := flags.GetInt("height")
+	widthPct, _ := flags.GetFloat64("width-percent")
+	heightPct, _ := flags.GetFloat64("height-percent")
+	xCoord, _ := flags.GetInt("x")
+	yCoord, _ := flags.GetInt("y")
+	anchor, _ := flags.GetString("anchor")
+	useMargin, _ := flags.GetBool("margin")
+	noMargin, _ := flags.GetBool("no-margin")
+
+	return action.ResizeWindowArgs{
+		Preset:           preset,
+		Width:            width,
+		WidthSet:         flags.Changed("width"),
+		Height:           height,
+		HeightSet:        flags.Changed("height"),
+		WidthPercent:     widthPct,
+		WidthPercentSet:  flags.Changed("width-percent"),
+		HeightPercent:    heightPct,
+		HeightPercentSet: flags.Changed("height-percent"),
+		X:                xCoord,
+		XSet:             flags.Changed("x"),
+		Y:                yCoord,
+		YSet:             flags.Changed("y"),
+		Anchor:           anchor,
+		AnchorSet:        flags.Changed("anchor"),
+		UseMargin:        useMargin,
+		NoMargin:         noMargin,
+	}
 }
 
 func validateActionSpaceArgs(_ *cobra.Command, args []string) error {

--- a/cmd/mimi/cmd/action_runner.go
+++ b/cmd/mimi/cmd/action_runner.go
@@ -6,18 +6,21 @@ import (
 	"github.com/y3owk1n/mimi/internal/ipc"
 )
 
-// runAction sends an action to the daemon, falling back to executing it
-// directly when no daemon is listening.
-func (s *cliState) runAction(name string, args []string) error {
+// runAction sends a typed command to the daemon, falling back to running it
+// directly when no daemon is listening. The command is built once, so
+// neither path re-parses a string the other already held typed: the daemon
+// path has ipc marshal it to the wire's strings, and the direct path runs it
+// as-is.
+func (s *cliState) runAction(cmd action.Command) error {
 	socketPath := ipc.ResolveSocketPath(s.configPath)
 
-	err := ipc.TryExecute(socketPath, name, args)
+	err := ipc.TryExecute(socketPath, cmd)
 	if err == nil {
 		return nil
 	}
 
 	if derrors.IsCode(err, derrors.CodeDaemonUnavailable) {
-		return action.Execute(name, args)
+		return action.ExecuteCommand(cmd)
 	}
 
 	return err

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -1,0 +1,143 @@
+//nolint:testpackage
+package cmd
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+)
+
+// resizeFlags parses args against a fresh resize_window flag set and returns
+// the typed payload resizeWindowArgsFromFlags builds from it, without
+// running the command (which would reach for the real desktop).
+func resizeFlags(t *testing.T, preset string, args ...string) action.ResizeWindowArgs {
+	t.Helper()
+
+	cmd := buildResizeWindowCommand(&cliState{})
+
+	err := cmd.Flags().Parse(args)
+	if err != nil {
+		t.Fatalf("parsing flags %v: %v", args, err)
+	}
+
+	return resizeWindowArgsFromFlags(cmd, preset)
+}
+
+// TestResizeWindowArgsFromFlags_UsesChangedForEveryDimensionFlag pins the
+// consistency fix mimi#95 asks for: --width, --height, --width-percent and
+// --height-percent now all use Flags().Changed(...), the same idiom --x and
+// --y already followed, so an explicitly-zero flag is forwarded rather than
+// silently dropped for being "not > 0".
+func TestResizeWindowArgsFromFlags_UsesChangedForEveryDimensionFlag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("width 0 is forwarded when given", func(t *testing.T) {
+		t.Parallel()
+
+		got := resizeFlags(t, "", "--width", "0")
+
+		if !got.WidthSet {
+			t.Fatal("WidthSet = false, want true for an explicit --width 0")
+		}
+
+		if got.Width != 0 {
+			t.Fatalf("Width = %d, want 0", got.Width)
+		}
+	})
+
+	t.Run("height 0 is forwarded when given", func(t *testing.T) {
+		t.Parallel()
+
+		got := resizeFlags(t, "", "--height", "0")
+
+		if !got.HeightSet {
+			t.Fatal("HeightSet = false, want true for an explicit --height 0")
+		}
+	})
+
+	t.Run("width-percent 0 is forwarded when given", func(t *testing.T) {
+		t.Parallel()
+
+		got := resizeFlags(t, "", "--width-percent", "0")
+
+		if !got.WidthPercentSet {
+			t.Fatal("WidthPercentSet = false, want true for an explicit --width-percent 0")
+		}
+	})
+
+	t.Run("height-percent 0 is forwarded when given", func(t *testing.T) {
+		t.Parallel()
+
+		got := resizeFlags(t, "", "--height-percent", "0")
+
+		if !got.HeightPercentSet {
+			t.Fatal("HeightPercentSet = false, want true for an explicit --height-percent 0")
+		}
+	})
+
+	t.Run("none of the four are set when never given", func(t *testing.T) {
+		t.Parallel()
+
+		got := resizeFlags(t, "")
+
+		if got.WidthSet || got.HeightSet || got.WidthPercentSet || got.HeightPercentSet {
+			t.Fatalf("expected no Set flags, got %+v", got)
+		}
+	})
+
+	t.Run("a positive width is still forwarded, as before", func(t *testing.T) {
+		t.Parallel()
+
+		got := resizeFlags(t, "", "--width", "800")
+
+		if !got.WidthSet || got.Width != 800 {
+			t.Fatalf("got %+v, want WidthSet=true Width=800", got)
+		}
+	})
+}
+
+func TestResizeWindowArgsFromFlags_CarriesThePresetAndTheOtherFlags(t *testing.T) {
+	t.Parallel()
+
+	got := resizeFlags(t, "left-half", "--x", "10", "--y", "20", "--anchor", "cc", "--margin")
+
+	want := action.ResizeWindowArgs{
+		Preset:    "left-half",
+		X:         10,
+		XSet:      true,
+		Y:         20,
+		YSet:      true,
+		Anchor:    "cc",
+		AnchorSet: true,
+		UseMargin: true,
+	}
+
+	if got != want {
+		t.Fatalf("resizeWindowArgsFromFlags() = %+v, want %+v", got, want)
+	}
+}
+
+// TestFocusWindowCommand_RejectsBackwardWithDirection checks the CLI surfaces
+// action.NewFocusWindowArgs' validation before ever reaching the desktop —
+// this fails during flag validation, not execution, so it is safe to run
+// through the real command tree.
+func TestFocusWindowCommand_RejectsBackwardWithDirection(t *testing.T) {
+	t.Parallel()
+
+	_, err := runCommand(t, "action", "focus_window", "--backward", "--up")
+	if err == nil {
+		t.Fatal("expected an error combining --backward with a direction flag")
+	}
+}
+
+// TestSpaceCommand_RejectsZero checks the space subcommand's positional-arg
+// validation still runs before state.runAction, the same guarantee it made
+// before the CLI started building a typed action.Command.
+func TestSpaceCommand_RejectsZero(t *testing.T) {
+	t.Parallel()
+
+	_, err := runCommand(t, "action", "space", "0")
+	if err == nil {
+		t.Fatal("expected an error for space 0")
+	}
+}

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -32,27 +32,22 @@ func IsKnownName(name string) bool {
 	}
 }
 
-type parsedFocusWindowArgs struct {
-	useBackward bool
-	direction   string // "up", "down", "left", "right", or ""
-}
-
-func parseFocusWindowArgs(rawArgs []string) (parsedFocusWindowArgs, error) {
-	var parsed parsedFocusWindowArgs
+func parseFocusWindowArgs(rawArgs []string) (FocusWindowArgs, error) {
+	var parsed FocusWindowArgs
 
 	for _, arg := range rawArgs {
 		switch arg {
 		case "--backward":
-			parsed.useBackward = true
+			parsed.Backward = true
 		case "--up", "--down", "--left", "--right":
-			if parsed.direction != "" {
+			if parsed.Direction != "" {
 				return parsed, derrors.New(
 					derrors.CodeInvalidInput,
 					"only one direction flag allowed (--up, --down, --left, --right)",
 				)
 			}
 
-			parsed.direction = arg[2:]
+			parsed.Direction = arg[2:]
 		default:
 			if strings.HasPrefix(arg, "--") {
 				return parsed, derrors.New(
@@ -63,24 +58,26 @@ func parseFocusWindowArgs(rawArgs []string) (parsedFocusWindowArgs, error) {
 		}
 	}
 
-	if parsed.direction != "" && parsed.useBackward {
-		return parsed, derrors.New(
-			derrors.CodeInvalidInput,
-			"--backward cannot be combined with a direction flag",
-		)
+	err := validateFocusWindowCombo(parsed.Direction, parsed.Backward)
+	if err != nil {
+		return parsed, err
 	}
 
 	return parsed, nil
 }
 
-type spaceArg struct {
-	index     int
-	direction int // +1 for next, -1 for prev; 0 means absolute index
+// SpaceArg is the parsed form of the one argument space and
+// move_window_to_space take: either an absolute 1-based Index, or a relative
+// Direction (+1 for next, -1 for prev), never both.
+type SpaceArg struct {
+	Index     int
+	Direction int // +1 for next, -1 for prev; 0 means absolute index
 }
 
-func parseSpaceArg(args []string) (spaceArg, error) {
+// ParseSpaceArg parses the one argument the space actions take.
+func ParseSpaceArg(args []string) (SpaceArg, error) {
 	if len(args) != 1 {
-		return spaceArg{}, derrors.Newf(
+		return SpaceArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
 			"space requires exactly one argument: a 1-based number, \"next\", or \"prev\"",
 		)
@@ -88,47 +85,53 @@ func parseSpaceArg(args []string) (spaceArg, error) {
 
 	raw := strings.TrimSpace(args[0])
 	if raw == "" {
-		return spaceArg{}, derrors.New(derrors.CodeInvalidInput, "space argument cannot be empty")
+		return SpaceArg{}, derrors.New(derrors.CodeInvalidInput, "space argument cannot be empty")
 	}
 
 	switch raw {
 	case "next":
-		return spaceArg{direction: 1}, nil
+		return SpaceArg{Direction: 1}, nil
 	case "prev", "previous":
-		return spaceArg{direction: -1}, nil
+		return SpaceArg{Direction: -1}, nil
 	}
 
 	index, parseErr := strconv.Atoi(raw)
 	if parseErr != nil || index < 1 {
-		return spaceArg{}, derrors.Newf(
+		return SpaceArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
 			"space must be a positive integer, \"next\", or \"prev\", got %q",
 			raw,
 		)
 	}
 
-	return spaceArg{index: index}, nil
+	return SpaceArg{Index: index}, nil
 }
 
 // resolveSpaceArg parses the one argument the space actions take and turns it
 // into the 1-based space number it names.
-//
-// Only "next" and "prev" need the desktop: they are relative to whichever space
-// is in front, and they wrap around at both ends.
 func (e *Executor) resolveSpaceArg(args []string) (int, error) {
-	parsed, err := parseSpaceArg(args)
+	parsed, err := ParseSpaceArg(args)
 	if err != nil {
 		return 0, err
 	}
 
-	if parsed.direction == 0 {
-		return parsed.index, nil
+	return e.resolveSpaceArgTyped(parsed)
+}
+
+// resolveSpaceArgTyped turns an already-parsed SpaceArg into the 1-based
+// space number it names.
+//
+// Only "next" and "prev" need the desktop: they are relative to whichever space
+// is in front, and they wrap around at both ends.
+func (e *Executor) resolveSpaceArgTyped(parsed SpaceArg) (int, error) {
+	if parsed.Direction == 0 {
+		return parsed.Index, nil
 	}
 
 	// Reading where the desktop is before acting on it is still driving it, so
 	// the permission comes first here too — the action this feeds checks it
 	// again, and a revoked permission has to be the error either way round.
-	err = e.desktop.EnsureAccessible()
+	err := e.desktop.EnsureAccessible()
 	if err != nil {
 		return 0, err
 	}
@@ -143,7 +146,7 @@ func (e *Executor) resolveSpaceArg(args []string) (int, error) {
 		return 0, derrors.New(derrors.CodeActionFailed, "no Mission Control spaces found")
 	}
 
-	return ((current - 1 + parsed.direction + count) % count) + 1, nil
+	return ((current - 1 + parsed.Direction + count) % count) + 1, nil
 }
 
 // IsResizePreset reports whether s is a known resize window preset.
@@ -358,7 +361,7 @@ func (e *Executor) Execute(name string, args []string) error {
 			return err
 		}
 
-		return e.FocusWindow(parsed.useBackward, parsed.direction)
+		return e.FocusWindow(parsed.Backward, parsed.Direction)
 	case NameSpace:
 		index, err := e.resolveSpaceArg(args)
 		if err != nil {

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -1,0 +1,263 @@
+package action
+
+import (
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// Command is a fully-typed action instruction, built once by the caller
+// instead of round-tripped through the string arguments the IPC wire format
+// carries. Only the field matching Name is read; the others sit at their
+// zero value.
+//
+// ExecuteCommand is the direct-execution counterpart to Execute: Execute
+// exists because the IPC wire format is strings, and ExecuteCommand exists
+// because the direct-execution path never needed to be.
+type Command struct {
+	Name Name
+
+	FocusWindow       FocusWindowArgs
+	Space             SpaceArg
+	MoveWindowToSpace SpaceArg
+	ResizeWindow      ResizeWindowArgs
+}
+
+// FocusWindowArgs is focus_window's typed payload.
+type FocusWindowArgs struct {
+	Backward bool
+	// Direction is "", "up", "down", "left", or "right".
+	Direction string
+}
+
+// NewFocusWindowArgs builds focus_window's typed payload directly from the
+// CLI's already-typed flags, without a string round trip. It applies the
+// same rule parseFocusWindowArgs enforces on the string path: at most one
+// direction, and never alongside --backward.
+func NewFocusWindowArgs(
+	backward, focusUp, focusDown, focusLeft, focusRight bool,
+) (FocusWindowArgs, error) {
+	direction, err := focusDirectionOf(focusUp, focusDown, focusLeft, focusRight)
+	if err != nil {
+		return FocusWindowArgs{}, err
+	}
+
+	err = validateFocusWindowCombo(direction, backward)
+	if err != nil {
+		return FocusWindowArgs{}, err
+	}
+
+	return FocusWindowArgs{Backward: backward, Direction: direction}, nil
+}
+
+// focusDirectionOf turns the four direction flags into the one direction
+// they name, rejecting more than one set at once.
+func focusDirectionOf(focusUp, focusDown, focusLeft, focusRight bool) (string, error) {
+	direction := ""
+
+	for _, candidate := range []struct {
+		set  bool
+		name string
+	}{{focusUp, "up"}, {focusDown, "down"}, {focusLeft, "left"}, {focusRight, "right"}} {
+		if !candidate.set {
+			continue
+		}
+
+		if direction != "" {
+			return "", derrors.New(
+				derrors.CodeInvalidInput,
+				"only one direction flag allowed (--up, --down, --left, --right)",
+			)
+		}
+
+		direction = candidate.name
+	}
+
+	return direction, nil
+}
+
+// validateFocusWindowCombo rejects a direction combined with --backward — the
+// one rule both the typed and the string-parsed paths enforce.
+func validateFocusWindowCombo(direction string, backward bool) error {
+	if direction != "" && backward {
+		return derrors.New(
+			derrors.CodeInvalidInput,
+			"--backward cannot be combined with a direction flag",
+		)
+	}
+
+	return nil
+}
+
+// ResizeWindowArgs is resize_window's typed payload: the CLI's raw flags,
+// each paired with a Set bit so a flag the user never gave can be told apart
+// from one given as its zero value — the same distinction
+// cobraCmd.Flags().Changed(...) makes at the CLI layer.
+type ResizeWindowArgs struct {
+	// Preset is a named tiling shortcut, or "" for none.
+	Preset string
+
+	Width    int
+	WidthSet bool
+
+	Height    int
+	HeightSet bool
+
+	WidthPercent    float64
+	WidthPercentSet bool
+
+	HeightPercent    float64
+	HeightPercentSet bool
+
+	X    int
+	XSet bool
+
+	Y    int
+	YSet bool
+
+	// Anchor is a two-letter anchor name (tl, cc, br, ...).
+	Anchor    string
+	AnchorSet bool
+
+	UseMargin bool
+	NoMargin  bool
+}
+
+// ResizeRequestFromArgs turns resize_window's already-typed CLI flags into
+// the geometry request they describe. It is ParseResizeRequest's
+// direct-execution counterpart: the same range checks and the same
+// zero-collapses-to-keep convention (see ParseResizeRequest's doc comment),
+// without the string flags that convention was written against.
+func ResizeRequestFromArgs(args ResizeWindowArgs) (geometry.Request, error) {
+	if args.WidthSet && args.Width < 0 {
+		return geometry.Request{}, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"invalid width: %d",
+			args.Width,
+		)
+	}
+
+	if args.HeightSet && args.Height < 0 {
+		return geometry.Request{}, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"invalid height: %d",
+			args.Height,
+		)
+	}
+
+	if args.WidthPercentSet && (args.WidthPercent < 0 || args.WidthPercent > percentageWhole) {
+		return geometry.Request{}, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"invalid width-percent: %v (0-100)",
+			args.WidthPercent,
+		)
+	}
+
+	if args.HeightPercentSet && (args.HeightPercent < 0 || args.HeightPercent > percentageWhole) {
+		return geometry.Request{}, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"invalid height-percent: %v (0-100)",
+			args.HeightPercent,
+		)
+	}
+
+	req := geometry.Request{Preset: args.Preset}
+
+	width, widthPercent := 0.0, 0.0
+	if args.WidthSet {
+		width = float64(args.Width)
+	}
+
+	if args.WidthPercentSet {
+		widthPercent = args.WidthPercent
+	}
+
+	req.Width = dimensionOf(width, widthPercent)
+
+	height, heightPercent := 0.0, 0.0
+	if args.HeightSet {
+		height = float64(args.Height)
+	}
+
+	if args.HeightPercentSet {
+		heightPercent = args.HeightPercent
+	}
+
+	req.Height = dimensionOf(height, heightPercent)
+
+	if args.XSet {
+		x := float64(args.X)
+		req.X = &x
+	}
+
+	if args.YSet {
+		y := float64(args.Y)
+		req.Y = &y
+	}
+
+	if args.AnchorSet {
+		anchor, ok := geometry.ParseAnchor(args.Anchor)
+		if !ok {
+			return geometry.Request{}, derrors.Newf(
+				derrors.CodeInvalidInput,
+				"invalid anchor: %q (use tl, tc, tr, cl, cc, cr, bl, bc, br)",
+				args.Anchor,
+			)
+		}
+
+		req.Anchor = &anchor
+	}
+
+	if args.UseMargin {
+		useMargins := true
+		req.UseMargins = &useMargins
+	}
+
+	if args.NoMargin {
+		useMargins := false
+		req.UseMargins = &useMargins
+	}
+
+	return req, nil
+}
+
+// ExecuteCommand runs cmd against the desktop mimi is running on.
+func ExecuteCommand(cmd Command) error {
+	return defaultExecutor.ExecuteCommand(cmd)
+}
+
+// ExecuteCommand runs a fully-typed command. It is Execute's
+// direct-execution counterpart: no string carries the arguments here, so
+// nothing has to re-parse one.
+func (e *Executor) ExecuteCommand(cmd Command) error {
+	switch cmd.Name {
+	case NameFocusWindow:
+		return e.FocusWindow(cmd.FocusWindow.Backward, cmd.FocusWindow.Direction)
+	case NameSpace:
+		index, err := e.resolveSpaceArgTyped(cmd.Space)
+		if err != nil {
+			return err
+		}
+
+		return e.FocusSpace(index)
+	case NameMoveWindowToSpace:
+		index, err := e.resolveSpaceArgTyped(cmd.MoveWindowToSpace)
+		if err != nil {
+			return err
+		}
+
+		return e.MoveWindowToSpace(index)
+	case NameResizeWindow:
+		req, err := ResizeRequestFromArgs(cmd.ResizeWindow)
+		if err != nil {
+			return err
+		}
+
+		return e.ResizeWindow(req)
+	default:
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"unknown action %q (supported: focus_window, space, move_window_to_space, resize_window)",
+			cmd.Name,
+		)
+	}
+}

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -1,0 +1,297 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// TestNewFocusWindowArgs_BuildsTheTypedPayload pins the mapping from the
+// CLI's already-typed bools onto FocusWindowArgs, without a string round
+// trip.
+func TestNewFocusWindowArgs_BuildsTheTypedPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		backward              bool
+		up, down, left, right bool
+		want                  action.FocusWindowArgs
+	}{
+		{name: "nothing set", want: action.FocusWindowArgs{}},
+		{name: "backward only", backward: true, want: action.FocusWindowArgs{Backward: true}},
+		{name: "up", up: true, want: action.FocusWindowArgs{Direction: "up"}},
+		{name: "down", down: true, want: action.FocusWindowArgs{Direction: "down"}},
+		{name: "left", left: true, want: action.FocusWindowArgs{Direction: "left"}},
+		{name: "right", right: true, want: action.FocusWindowArgs{Direction: "right"}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := action.NewFocusWindowArgs(
+				testCase.backward,
+				testCase.up,
+				testCase.down,
+				testCase.left,
+				testCase.right,
+			)
+			if err != nil {
+				t.Fatalf("NewFocusWindowArgs() error = %v, want nil", err)
+			}
+
+			if got != testCase.want {
+				t.Fatalf("NewFocusWindowArgs() = %+v, want %+v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestNewFocusWindowArgs_RejectsMoreThanOneDirection(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.NewFocusWindowArgs(false, true, true, false, false)
+	if err == nil {
+		t.Fatal("NewFocusWindowArgs(up, down) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+func TestNewFocusWindowArgs_RejectsBackwardWithDirection(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.NewFocusWindowArgs(true, true, false, false, false)
+	if err == nil {
+		t.Fatal("NewFocusWindowArgs(backward, up) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+// TestResizeRequestFromArgs_MatchesParseResizeRequest pins that the typed
+// direct-execution path resolves every ResizeWindowArgs case exactly the way
+// ParseResizeRequest resolves the equivalent string flags, so the two paths
+// can never quietly diverge.
+func TestResizeRequestFromArgs_MatchesParseResizeRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args action.ResizeWindowArgs
+		want geometry.Request
+	}{
+		{
+			name: "nothing set asks for nothing",
+			args: action.ResizeWindowArgs{},
+			want: geometry.Request{},
+		},
+		{
+			name: "absolute sizes",
+			args: action.ResizeWindowArgs{Width: 800, WidthSet: true, Height: 600, HeightSet: true},
+			want: geometry.Request{Width: geometry.Absolute(800), Height: geometry.Absolute(600)},
+		},
+		{
+			name: "percentage sizes",
+			args: action.ResizeWindowArgs{
+				WidthPercent: 45, WidthPercentSet: true,
+				HeightPercent: 55, HeightPercentSet: true,
+			},
+			want: geometry.Request{Width: geometry.Percent(45), Height: geometry.Percent(55)},
+		},
+		{
+			name: "an absolute size wins over a percentage one",
+			args: action.ResizeWindowArgs{
+				Width: 800, WidthSet: true,
+				WidthPercent: 45, WidthPercentSet: true,
+			},
+			want: geometry.Request{Width: geometry.Absolute(800)},
+		},
+		{
+			name: "a zero width, explicitly set, still keeps the current width",
+			args: action.ResizeWindowArgs{Width: 0, WidthSet: true},
+			want: geometry.Request{Width: geometry.Keep()},
+		},
+		{
+			name: "an explicit position",
+			args: action.ResizeWindowArgs{X: 100, XSet: true, Y: 230, YSet: true},
+			want: geometry.Request{X: new(100.0), Y: new(230.0)},
+		},
+		{
+			name: "an anchor",
+			args: action.ResizeWindowArgs{Anchor: "br", AnchorSet: true},
+			want: geometry.Request{Anchor: new(geometry.BottomRight)},
+		},
+		{
+			name: "margins forced on",
+			args: action.ResizeWindowArgs{UseMargin: true},
+			want: geometry.Request{UseMargins: new(true)},
+		},
+		{
+			name: "margins forced off",
+			args: action.ResizeWindowArgs{NoMargin: true},
+			want: geometry.Request{UseMargins: new(false)},
+		},
+		{
+			name: "a preset carries through",
+			args: action.ResizeWindowArgs{Preset: presetLeftHalf},
+			want: geometry.Request{Preset: presetLeftHalf},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := action.ResizeRequestFromArgs(testCase.args)
+			if err != nil {
+				t.Fatalf("ResizeRequestFromArgs(%+v) error = %v", testCase.args, err)
+			}
+
+			assertRequest(t, got, testCase.want)
+		})
+	}
+}
+
+func TestResizeRequestFromArgs_InvalidWidth(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.ResizeRequestFromArgs(action.ResizeWindowArgs{Width: -100, WidthSet: true})
+	if err == nil {
+		t.Fatal("ResizeRequestFromArgs(width -100) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+func TestResizeRequestFromArgs_InvalidWidthPercent(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.ResizeRequestFromArgs(
+		action.ResizeWindowArgs{WidthPercent: 150, WidthPercentSet: true},
+	)
+	if err == nil {
+		t.Fatal("ResizeRequestFromArgs(width-percent 150) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+func TestResizeRequestFromArgs_InvalidAnchor(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.ResizeRequestFromArgs(action.ResizeWindowArgs{Anchor: "xx", AnchorSet: true})
+	if err == nil {
+		t.Fatal("ResizeRequestFromArgs(anchor xx) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+// TestExecuteCommand_MirrorsExecute checks ExecuteCommand reaches the same
+// executor methods Execute's string parsing does, for every action, using
+// the same fake desktop tests already exercise Execute against.
+func TestExecuteCommand_MirrorsExecute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("focus_window", func(t *testing.T) {
+		t.Parallel()
+
+		desktop := desktopWithWindows(3, 2)
+
+		err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
+			Name:        action.NameFocusWindow,
+			FocusWindow: action.FocusWindowArgs{},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteCommand(focus_window) error = %v, want nil", err)
+		}
+
+		wantFocused(t, desktop, 1)
+	})
+
+	t.Run("space", func(t *testing.T) {
+		t.Parallel()
+
+		desktop := desktopWithSpaces(1)
+
+		err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
+			Name:  action.NameSpace,
+			Space: action.SpaceArg{Index: 2},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteCommand(space) error = %v, want nil", err)
+		}
+
+		if desktop.activeSpace != 2 {
+			t.Fatalf("active space = %d, want 2", desktop.activeSpace)
+		}
+
+		wantRefreshCalls(t, desktop, 1)
+	})
+
+	t.Run("move_window_to_space", func(t *testing.T) {
+		t.Parallel()
+
+		desktop := desktopWithSpaces(1)
+
+		err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
+			Name:              action.NameMoveWindowToSpace,
+			MoveWindowToSpace: action.SpaceArg{Direction: 1},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteCommand(move_window_to_space) error = %v, want nil", err)
+		}
+
+		if desktop.windowSpace != 2 {
+			t.Fatalf("window space = %d, want 2", desktop.windowSpace)
+		}
+
+		wantRefreshCalls(t, desktop, 1)
+	})
+
+	t.Run("resize_window", func(t *testing.T) {
+		t.Parallel()
+
+		desktop := desktopWithOneWindow()
+
+		err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
+			Name: action.NameResizeWindow,
+			ResizeWindow: action.ResizeWindowArgs{
+				Width: 800, WidthSet: true,
+				Height: 600, HeightSet: true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteCommand(resize_window) error = %v, want nil", err)
+		}
+	})
+}
+
+func TestExecuteCommand_UnknownName(t *testing.T) {
+	t.Parallel()
+
+	err := action.NewExecutor(desktopWithWindows(0, -1)).ExecuteCommand(action.Command{
+		Name: "left_click",
+	})
+	if err == nil {
+		t.Fatal("ExecuteCommand(left_click) expected error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/y3owk1n/mimi/internal/action"
 	"github.com/y3owk1n/mimi/internal/config"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/paths"
@@ -15,10 +16,11 @@ import (
 
 const dialTimeout = 100 * time.Millisecond
 
-// TryExecute sends an action to the daemon over the Unix socket when available.
-// Returns CodeDaemonUnavailable when the daemon is not reachable so callers can
-// fall back to direct execution.
-func TryExecute(socketPath, action string, args []string) error {
+// TryExecute sends a typed command to the daemon over the Unix socket when
+// available, marshaling it to the wire's string args itself. Returns
+// CodeDaemonUnavailable when the daemon is not reachable so callers can fall
+// back to direct execution against the same typed cmd.
+func TryExecute(socketPath string, cmd action.Command) error {
 	socketPath = paths.ExpandHome(socketPath)
 
 	_, err := os.Stat(socketPath)
@@ -46,7 +48,9 @@ func TryExecute(socketPath, action string, args []string) error {
 
 	reader := bufio.NewReader(conn)
 
-	err = writeRequest(conn, Request{Action: action, Args: args})
+	name, args := marshalCommand(cmd)
+
+	err = writeRequest(conn, Request{Action: name, Args: args})
 	if err != nil {
 		return err
 	}

--- a/internal/ipc/marshal.go
+++ b/internal/ipc/marshal.go
@@ -1,0 +1,114 @@
+package ipc
+
+import (
+	"strconv"
+
+	"github.com/y3owk1n/mimi/internal/action"
+)
+
+// Keywords the wire's single positional space argument accepts instead of a
+// number — the same two ParseSpaceArg and marshalSpaceArg agree on.
+const (
+	spaceKeywordNext = "next"
+	spaceKeywordPrev = "prev"
+)
+
+// marshalCommand flattens a typed action.Command into the (action name,
+// string args) pair the wire protocol carries. This is where the CLI's
+// typed values are turned into strings — the direct-execution path never
+// pays for it, since it runs cmd through action.ExecuteCommand instead.
+func marshalCommand(cmd action.Command) (string, []string) {
+	switch cmd.Name {
+	case action.NameFocusWindow:
+		return string(cmd.Name), marshalFocusWindow(cmd.FocusWindow)
+	case action.NameSpace:
+		return string(cmd.Name), marshalSpaceArg(cmd.Space)
+	case action.NameMoveWindowToSpace:
+		return string(cmd.Name), marshalSpaceArg(cmd.MoveWindowToSpace)
+	case action.NameResizeWindow:
+		return string(cmd.Name), marshalResizeWindow(cmd.ResizeWindow)
+	default:
+		return string(cmd.Name), nil
+	}
+}
+
+func marshalFocusWindow(focusArgs action.FocusWindowArgs) []string {
+	args := []string{}
+
+	if focusArgs.Backward {
+		args = append(args, "--backward")
+	}
+
+	// Direction is always "", "up", "down", "left", or "right" — the flag
+	// spelling is the direction with "--" in front of it.
+	if focusArgs.Direction != "" {
+		args = append(args, "--"+focusArgs.Direction)
+	}
+
+	return args
+}
+
+func marshalSpaceArg(spaceArg action.SpaceArg) []string {
+	switch spaceArg.Direction {
+	case 1:
+		return []string{spaceKeywordNext}
+	case -1:
+		return []string{spaceKeywordPrev}
+	default:
+		return []string{strconv.Itoa(spaceArg.Index)}
+	}
+}
+
+func marshalResizeWindow(resizeArgs action.ResizeWindowArgs) []string {
+	args := []string{}
+
+	if resizeArgs.Preset != "" {
+		args = append(args, resizeArgs.Preset)
+	}
+
+	if resizeArgs.WidthSet {
+		args = append(args, "--width", strconv.Itoa(resizeArgs.Width))
+	}
+
+	if resizeArgs.HeightSet {
+		args = append(args, "--height", strconv.Itoa(resizeArgs.Height))
+	}
+
+	if resizeArgs.WidthPercentSet {
+		args = append(
+			args,
+			"--width-percent",
+			strconv.FormatFloat(resizeArgs.WidthPercent, 'f', -1, 64),
+		)
+	}
+
+	if resizeArgs.HeightPercentSet {
+		args = append(
+			args,
+			"--height-percent",
+			strconv.FormatFloat(resizeArgs.HeightPercent, 'f', -1, 64),
+		)
+	}
+
+	if resizeArgs.XSet {
+		args = append(args, "--x", strconv.Itoa(resizeArgs.X))
+	}
+
+	if resizeArgs.YSet {
+		args = append(args, "--y", strconv.Itoa(resizeArgs.Y))
+	}
+
+	if resizeArgs.AnchorSet {
+		args = append(args, "--anchor", resizeArgs.Anchor)
+	}
+
+	if resizeArgs.UseMargin {
+		args = append(args, "--margin")
+	}
+
+	if resizeArgs.NoMargin {
+		args = append(args, "--no-margin")
+	}
+
+	return args
+}

--- a/internal/ipc/marshal_test.go
+++ b/internal/ipc/marshal_test.go
@@ -1,0 +1,181 @@
+//nolint:testpackage // exercises marshalCommand, which is unexported by design
+package ipc
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+)
+
+// TestMarshalCommand_FocusWindow pins the flag spellings action.Execute's
+// string parser expects, since this is the only place that builds them now
+// that the CLI hands over a typed action.Command instead.
+func TestMarshalCommand_FocusWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args action.FocusWindowArgs
+		want []string
+	}{
+		{name: "nothing set", args: action.FocusWindowArgs{}, want: []string{}},
+		{
+			name: "backward",
+			args: action.FocusWindowArgs{Backward: true},
+			want: []string{"--backward"},
+		},
+		{name: "up", args: action.FocusWindowArgs{Direction: "up"}, want: []string{"--up"}},
+		{name: "down", args: action.FocusWindowArgs{Direction: "down"}, want: []string{"--down"}},
+		{name: "left", args: action.FocusWindowArgs{Direction: "left"}, want: []string{"--left"}},
+		{
+			name: "right",
+			args: action.FocusWindowArgs{Direction: "right"},
+			want: []string{"--right"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			name, args := marshalCommand(action.Command{
+				Name:        action.NameFocusWindow,
+				FocusWindow: testCase.args,
+			})
+
+			if name != string(action.NameFocusWindow) {
+				t.Errorf("name = %q, want %q", name, action.NameFocusWindow)
+			}
+
+			if !reflect.DeepEqual(args, testCase.want) {
+				t.Errorf("args = %v, want %v", args, testCase.want)
+			}
+		})
+	}
+}
+
+func TestMarshalCommand_SpaceArg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  action.SpaceArg
+		want []string
+	}{
+		{name: "absolute index", arg: action.SpaceArg{Index: 3}, want: []string{"3"}},
+		{name: "next", arg: action.SpaceArg{Direction: 1}, want: []string{"next"}},
+		{name: "prev", arg: action.SpaceArg{Direction: -1}, want: []string{"prev"}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, args := marshalCommand(action.Command{Name: action.NameSpace, Space: testCase.arg})
+
+			if !reflect.DeepEqual(args, testCase.want) {
+				t.Errorf("args = %v, want %v", args, testCase.want)
+			}
+		})
+	}
+}
+
+func TestMarshalCommand_MoveWindowToSpaceUsesItsOwnField(t *testing.T) {
+	t.Parallel()
+
+	_, args := marshalCommand(action.Command{
+		Name:              action.NameMoveWindowToSpace,
+		MoveWindowToSpace: action.SpaceArg{Index: 5},
+	})
+
+	want := []string{"5"}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+}
+
+// TestMarshalCommand_ResizeWindow pins the Changed()-style behavior: a flag
+// the CLI never set is omitted from the wire args entirely, including a
+// width or height explicitly given as zero — mirroring what
+// cobraCmd.Flags().Changed(...) reports, not whether the value is > 0.
+func TestMarshalCommand_ResizeWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args action.ResizeWindowArgs
+		want []string
+	}{
+		{name: "nothing set", args: action.ResizeWindowArgs{}, want: []string{}},
+		{
+			name: "a preset",
+			args: action.ResizeWindowArgs{Preset: "left-half"},
+			want: []string{"left-half"},
+		},
+		{
+			name: "width explicitly zero is still forwarded",
+			args: action.ResizeWindowArgs{Width: 0, WidthSet: true},
+			want: []string{"--width", "0"},
+		},
+		{
+			name: "height explicitly zero is still forwarded",
+			args: action.ResizeWindowArgs{Height: 0, HeightSet: true},
+			want: []string{"--height", "0"},
+		},
+		{
+			name: "width-percent explicitly zero is still forwarded",
+			args: action.ResizeWindowArgs{WidthPercent: 0, WidthPercentSet: true},
+			want: []string{"--width-percent", "0"},
+		},
+		{
+			name: "height-percent explicitly zero is still forwarded",
+			args: action.ResizeWindowArgs{HeightPercent: 0, HeightPercentSet: true},
+			want: []string{"--height-percent", "0"},
+		},
+		{
+			name: "width not set is omitted",
+			args: action.ResizeWindowArgs{Width: 0, WidthSet: false},
+			want: []string{},
+		},
+		{
+			name: "everything set",
+			args: action.ResizeWindowArgs{
+				Width: 800, WidthSet: true,
+				Height: 600, HeightSet: true,
+				X: 10, XSet: true,
+				Y: 20, YSet: true,
+				Anchor: "cc", AnchorSet: true,
+				UseMargin: true,
+			},
+			want: []string{
+				"--width", "800",
+				"--height", "600",
+				"--x", "10",
+				"--y", "20",
+				"--anchor", "cc",
+				"--margin",
+			},
+		},
+		{
+			name: "no-margin",
+			args: action.ResizeWindowArgs{NoMargin: true},
+			want: []string{"--no-margin"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, args := marshalCommand(action.Command{
+				Name:         action.NameResizeWindow,
+				ResizeWindow: testCase.args,
+			})
+
+			if !reflect.DeepEqual(args, testCase.want) {
+				t.Errorf("args = %v, want %v", args, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/ipc"
 )
@@ -14,7 +15,9 @@ import (
 func TestTryExecuteDaemonUnavailable(t *testing.T) {
 	t.Parallel()
 
-	err := ipc.TryExecute(filepath.Join(t.TempDir(), "missing.sock"), "space", []string{"1"})
+	cmd := action.Command{Name: action.NameSpace, Space: action.SpaceArg{Index: 1}}
+
+	err := ipc.TryExecute(filepath.Join(t.TempDir(), "missing.sock"), cmd)
 	if err == nil {
 		t.Fatal("expected error for missing socket")
 	}
@@ -48,7 +51,7 @@ func TestServerClientRoundTrip(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	err := ipc.TryExecute(socketPath, "unknown_action", nil)
+	err := ipc.TryExecute(socketPath, action.Command{Name: "unknown_action"})
 	if err == nil {
 		t.Fatal("expected error for unknown action")
 	}


### PR DESCRIPTION
## Description

This PR reworks how `mimi action` carries its arguments into execution on the direct (no-daemon) path. The CLI used to build typed values with Cobra, flatten them into strings, and hand them to the action layer to parse right back into the same types — work that was paid even though nothing was ever serialized. The direct-execution path now carries the CLI's typed values straight through to execution instead.

The daemon path is unaffected in shape: the IPC wire format still carries string arguments, and turning the CLI's typed value into those strings is now the IPC client's job rather than something the CLI does up front for both paths alike.

This PR also folds in a small consistency fix: `--width`, `--height`, `--width-percent` and `--height-percent` now use the same "was this flag given" check `--x` and `--y` already used, instead of only forwarding the flag when its value was greater than zero. This is a consistency fix rather than a bug fix — an explicit `--width 0` and an omitted `--width` already resolved identically downstream (the window keeps its current width either way), so no observable behavior changes.

## Related Issues

Closes #95

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing CLI/config surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Deliberately out of scope, per the issue's own "Alternatives considered": the ~170-line hand parser (`ParseResizeRequest`) that decodes the wire's string arguments is untouched and keeps serving the daemon path, the IPC wire format (`Request.Args []string`) is unchanged, and the three separate space-argument validators are left as they were (consolidating them is a separate, larger job).

`internal/action`'s space-argument parser was renamed and exported (unchanged behavior) so the CLI can build its typed value from the same logic rather than duplicating it — that's plumbing, not the validator consolidation called out above.

Preserved exactly: the systray's workspace title still refreshes after a successful `space` or `move_window_to_space` action on both the daemon and direct-execution paths (fixed separately in #100); new tests pin this through the typed path too.
