### PR TITLE
feat(events,daemon): count event-bus drops and log them on shutdown

### DIFF
--- a/cmd/mimi/cmd/status.go
+++ b/cmd/mimi/cmd/status.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/y3owk1n/mimi/internal/native"
 	"github.com/y3owk1n/mimi/internal/paths"
 	"github.com/y3owk1n/mimi/internal/permissions"
 )
@@ -44,13 +43,6 @@ func newStatusCmd(state *cliState) *cobra.Command {
 				cmd.Printf("ipc: socket available at %s\n", paths.ExpandHome(socketPath))
 			} else {
 				cmd.Println("ipc: socket not available (actions run directly until daemon starts)")
-			}
-
-			if dropped := native.EventDropCount(); dropped > 0 {
-				cmd.Printf(
-					"events dropped: %d (channel backpressure; check hook latency and log throttling)\n",
-					dropped,
-				)
 			}
 
 			return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -294,7 +294,7 @@ func runSignalLoop(
 		select {
 		case <-quitCh:
 			logger.Info("shutting down from systray")
-			shutdown(cancel, pipeline)
+			shutdown(cancel, pipeline, logger)
 
 			return
 		case sig := <-sigCh:
@@ -305,7 +305,7 @@ func runSignalLoop(
 			}
 
 			logger.Infow("shutting down", "signal", sig)
-			shutdown(cancel, pipeline)
+			shutdown(cancel, pipeline, logger)
 
 			return
 		}
@@ -323,11 +323,25 @@ func reloadConfig(configPath string, cfgReloader *reloader, logger *zap.SugaredL
 	applyReload(cfgReloader, newCfg, reloadTriggerSighup, logger)
 }
 
-func shutdown(cancel context.CancelFunc, pipeline *eventPipeline) {
+func shutdown(cancel context.CancelFunc, pipeline *eventPipeline, logger *zap.SugaredLogger) {
 	cancel()
 	native.StopObservers()
+	logEventDropCounts(native.EventDropCount(), pipeline.bus.DropCount(), logger)
 	pipeline.bus.Unsubscribe(pipeline.logSub)
 	pipeline.bus.Unsubscribe(pipeline.hookSub)
+}
+
+// logEventDropCounts logs the native observer's and the event bus's drop
+// counters as distinct fields. Shutdown is the first — and, per #94, the
+// only — place either count becomes observable: the native counter lives in
+// the daemon process's own address space (mimi status runs in the CLI
+// process and can never see it), and the bus has no other reader.
+func logEventDropCounts(nativeDropped, busDropped int64, logger *zap.SugaredLogger) {
+	logger.Infow(
+		"event drop counts",
+		"native_dropped", nativeDropped,
+		"bus_dropped", busDropped,
+	)
 }
 
 func writePID(path string) error {

--- a/internal/daemon/shutdown_test.go
+++ b/internal/daemon/shutdown_test.go
@@ -1,0 +1,53 @@
+//nolint:testpackage // tests logEventDropCounts, an unexported function
+package daemon
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestLogEventDropCounts_LogsBothCountersAsDistinctFields pins the contract
+// that the daemon's only observability point for these two counters logs
+// both the native-side and bus-side drop totals as separate fields, so a
+// maintainer can tell which layer is under backpressure.
+func TestLogEventDropCounts_LogsBothCountersAsDistinctFields(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core).Sugar()
+
+	const (
+		nativeDropped = int64(3)
+		busDropped    = int64(7)
+	)
+
+	logEventDropCounts(nativeDropped, busDropped, logger)
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("got %d log entries, want 1", len(entries))
+	}
+
+	entry := entries[0]
+
+	gotNative, hasNative := entry.ContextMap()["native_dropped"]
+	if !hasNative {
+		t.Fatalf("log entry missing native_dropped field: %+v", entry.ContextMap())
+	}
+
+	if gotNative != nativeDropped {
+		t.Errorf("native_dropped = %v, want %d", gotNative, nativeDropped)
+	}
+
+	gotBus, hasBus := entry.ContextMap()["bus_dropped"]
+	if !hasBus {
+		t.Fatalf("log entry missing bus_dropped field: %+v", entry.ContextMap())
+	}
+
+	if gotBus != busDropped {
+		t.Errorf("bus_dropped = %v, want %d", gotBus, busDropped)
+	}
+}

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -1,6 +1,9 @@
 package events
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // Subscriber is a channel that receives events.
 type Subscriber chan Event
@@ -12,9 +15,10 @@ type KindFilter func(EventKind) bool
 
 // Bus is a pub-sub event bus that fans out events to subscribers.
 type Bus struct {
-	mu      sync.RWMutex
-	subs    []Subscriber
-	filters []KindFilter
+	mu        sync.RWMutex
+	subs      []Subscriber
+	filters   []KindFilter
+	dropCount atomic.Int64
 }
 
 // NewBus creates a new event bus.
@@ -74,6 +78,14 @@ func (b *Bus) Publish(evt Event) {
 		select {
 		case sub <- evt:
 		default:
+			b.dropCount.Add(1)
 		}
 	}
+}
+
+// DropCount returns the number of events Publish has discarded because a
+// subscriber's buffer was full. It counts every dropped delivery across all
+// subscribers, not per-subscriber.
+func (b *Bus) DropCount() int64 {
+	return b.dropCount.Load()
 }

--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -111,8 +111,35 @@ func TestBus_Publish_DropsWhenSubscriberBufferFull(t *testing.T) {
 	bus := events.NewBus()
 	sub := bus.Subscribe(1)
 
+	if got := bus.DropCount(); got != 0 {
+		t.Fatalf("DropCount() before any drop = %d, want 0", got)
+	}
+
 	bus.Publish(events.Event{ID: "first", Kind: testKindA})
 	bus.Publish(events.Event{ID: "dropped", Kind: testKindA}) // buffer full; Publish must not block
+
+	if got := bus.DropCount(); got != 1 {
+		t.Errorf("DropCount() after 1 forced drop = %d, want 1", got)
+	}
+
+	// Keep the buffer full (do not drain it yet) so every further publish
+	// is forced to drop too, proving DropCount tallies across drops rather
+	// than latching at 1.
+	const extraDrops = 3
+
+	for range extraDrops {
+		bus.Publish(events.Event{ID: "dropped-again", Kind: testKindA})
+	}
+
+	const wantTotalDrops = 1 + extraDrops
+	if got := bus.DropCount(); got != wantTotalDrops {
+		t.Errorf(
+			"DropCount() after %d forced drops = %d, want %d",
+			wantTotalDrops,
+			got,
+			wantTotalDrops,
+		)
+	}
 
 	got, ok := recv(t, sub)
 	if !ok || got.ID != "first" {


### PR DESCRIPTION
## Description

This PR makes event-bus backpressure countable and gives both drop counters a place to be seen. The bus previously discarded an event silently whenever a subscriber's channel was full, with nothing to point at when a hook "randomly" didn't fire. Separately, the native observer counter was only ever read by `mimi status`, which runs in the CLI process and can never see the daemon process's copy of that counter — the branch printing it could never fire.

The bus now tracks its own drop count. On daemon shutdown — the first and only place either number becomes observable — the daemon logs both the native observer's drop count and the bus's drop count as distinct structured fields. The dead, unreachable branch in `mimi status` is removed along with its now-unused import.

Deliberate limitation: neither count is surfaced in `mimi status`. Doing that needs a stats query added to the IPC protocol, which is a separate design change and out of scope here (also avoids colliding with the concurrent `internal/ipc` work in #95).

## Related Issues

Closes #94

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing config/CLI/hook surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Per the issue's "Explicitly NOT in scope" section, this intentionally does not extend the IPC protocol with a stats request, and does not otherwise make `mimi status` report either count. A single bus-wide counter is used rather than per-subscriber counters, matching the issue's rationale (there are exactly two subscribers, and per-subscriber counts would need a handle type or a map lookup under the bus's `RLock`).
