### PR TITLE
fix(paths): return path unchanged when home directory is unresolvable

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -7,10 +7,17 @@ import (
 )
 
 // ExpandHome expands a leading ~ to the current user's home directory.
-// If path does not start with ~, it is returned unchanged.
+// If path does not start with ~, it is returned unchanged. If the home
+// directory cannot be resolved, path is also returned unchanged (still
+// containing the literal ~) rather than being joined onto an empty
+// string, which would silently produce a path relative to the current
+// working directory.
 func ExpandHome(path string) string {
 	if strings.HasPrefix(path, "~") {
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
 
 		return filepath.Join(home, path[1:])
 	}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,56 @@
+package paths_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/paths"
+)
+
+func TestExpandHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := paths.ExpandHome("~/.config/mimi/config.toml")
+	want := filepath.Join(home, ".config", "mimi", "config.toml")
+
+	if got != want {
+		t.Errorf("ExpandHome() = %q, want %q", got, want)
+	}
+}
+
+func TestExpandHome_NoTilde(t *testing.T) {
+	got := paths.ExpandHome("/etc/mimi/config.toml")
+	want := "/etc/mimi/config.toml"
+
+	if got != want {
+		t.Errorf("ExpandHome() = %q, want %q", got, want)
+	}
+}
+
+// TestExpandHome_HomeUnresolvable exercises the failure branch of
+// os.UserHomeDir(), which reads $HOME on Unix. Clearing it forces the
+// lookup to fail. Per the ticket's ruling, ExpandHome must return the
+// path unchanged (still containing the literal "~") rather than joining
+// onto an empty string, which would silently produce a path relative to
+// the current working directory.
+func TestExpandHome_HomeUnresolvable(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	const input = "~/.config/mimi/config.toml"
+
+	got := paths.ExpandHome(input)
+
+	if got != input {
+		t.Errorf("ExpandHome() = %q, want unchanged %q", got, input)
+	}
+
+	if !strings.Contains(got, "~") {
+		t.Errorf("ExpandHome() = %q, want it to retain the literal ~", got)
+	}
+
+	if filepath.IsAbs(got) {
+		t.Errorf("ExpandHome() = %q, want it not to become an absolute/CWD-relative path", got)
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes `ExpandHome` silently returning a path relative to the current working directory when the user's home directory cannot be resolved. It now returns the input path unchanged (tilde and all) in that failure case, so a later file operation fails with a path the user recognises instead of one that points nowhere near the cause. Deliberate limitation: the function still does not surface an error to callers — per the maintainer's ruling on the issue, changing the signature would touch all 23 call sites and was explicitly rejected.

## Related Issues

Closes #105

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented public contract change (signature and doc comment intent unchanged; only the failure-branch behavior, which was previously undocumented, is now specified in the doc comment itself)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

This is a latent-robustness fix, not a reproduced bug — the issue notes macOS normally provides `HOME` to Aqua session agents. The failure branch is exercised in tests by clearing `$HOME`, which is what `os.UserHomeDir()` reads on Unix.

Only `internal/paths/paths.go` and `internal/paths/paths_test.go` changed. None of the 23 call sites listed in the issue were touched.
