### PR TITLE
fix(config): stop the watcher claiming a reload succeeded before it has

### DIFF
--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -54,18 +54,6 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 	defer stopDebounce()
 
-	reload := func() {
-		cfg, err := Load(w.path)
-		if err != nil {
-			w.logger.Warnw("config reload failed", "err", err)
-
-			return
-		}
-
-		w.logger.Info("config reloaded")
-		w.onChange(cfg)
-	}
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -82,10 +70,10 @@ func (w *Watcher) Run(ctx context.Context) error {
 					if debounce.Stop() {
 						debounce.Reset(debounceDelay)
 					} else {
-						debounce = time.AfterFunc(debounceDelay, reload)
+						debounce = time.AfterFunc(debounceDelay, w.reload)
 					}
 				} else {
-					debounce = time.AfterFunc(debounceDelay, reload)
+					debounce = time.AfterFunc(debounceDelay, w.reload)
 				}
 			}
 		case err, ok := <-fileWatcher.Errors:
@@ -96,4 +84,26 @@ func (w *Watcher) Run(ctx context.Context) error {
 			w.logger.Warnw("config watcher error", "err", err)
 		}
 	}
+}
+
+// reload parses the watched file and, on success, hands it to onChange.
+//
+// It does not log a success line: onChange is where the hook registry
+// actually reloads and where a bad hook (an invalid regex, for example) is
+// caught, so only the caller can know whether the reload as a whole
+// succeeded. The daemon's applyReload is that caller, and it logs the one
+// authoritative "config reloaded" / "config reload failed" line for every
+// trigger. Logging a debug line here — rather than nothing — still records
+// that the file parsed, which is useful when a later onChange failure needs
+// to be told apart from a parse failure.
+func (w *Watcher) reload() {
+	cfg, err := Load(w.path)
+	if err != nil {
+		w.logger.Warnw("config reload failed", "err", err)
+
+		return
+	}
+
+	w.logger.Debug("config file parsed")
+	w.onChange(cfg)
 }

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -1,0 +1,122 @@
+//nolint:testpackage // tests reload, an unexported method exercising Watcher's private log/dispatch ordering
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+const watcherTestMarker = "watcher-test-marker.log"
+
+// newTestWatcher writes contents to a config file in dir and returns a
+// Watcher over it, wired to onChange, plus the log entries reload will
+// produce on it.
+func newTestWatcher(
+	t *testing.T,
+	dir, contents string,
+	onChange func(*Config),
+) (*Watcher, *observer.ObservedLogs) {
+	t.Helper()
+
+	path := filepath.Join(dir, "config.toml")
+
+	err := os.WriteFile(path, []byte(contents), 0o600)
+	if err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core).Sugar()
+
+	return NewWatcher(path, onChange, logger), logs
+}
+
+// TestWatcher_Reload_OnSuccess_DoesNotClaimReloadSucceeded pins the fix for
+// #107: a successful config.Load must not log an Info "config reloaded" line,
+// because that claims more than has happened at that point — onChange (the
+// hook registry reload) hasn't run yet, and it is the one that can still
+// fail. The daemon's applyReload is the sole place that logs the outcome of
+// a reload; the watcher only logs that it parsed the file.
+func TestWatcher_Reload_OnSuccess_DoesNotClaimReloadSucceeded(t *testing.T) {
+	t.Parallel()
+
+	var gotCfg *Config
+
+	onChange := func(cfg *Config) { gotCfg = cfg }
+
+	dir := t.TempDir()
+	watcher, logs := newTestWatcher(
+		t,
+		dir,
+		"[settings]\nlog_file = \""+watcherTestMarker+"\"\n",
+		onChange,
+	)
+	watcher.reload()
+
+	if gotCfg == nil {
+		t.Fatal("onChange was not called")
+	}
+
+	if gotCfg.Settings.LogFile != watcherTestMarker {
+		t.Errorf("onChange got LogFile = %q, want %q", gotCfg.Settings.LogFile, watcherTestMarker)
+	}
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("got %d log entries, want 1: %+v", len(entries), entries)
+	}
+
+	entry := entries[0]
+
+	if entry.Message != "config file parsed" {
+		t.Errorf("log message = %q, want %q", entry.Message, "config file parsed")
+	}
+
+	if entry.Level != zapcore.DebugLevel {
+		t.Errorf(
+			"watcher logged %q at %v, want Debug; the daemon's applyReload owns the Info-level success/failure line",
+			entry.Message,
+			entry.Level,
+		)
+	}
+}
+
+// TestWatcher_Reload_OnFailure_LogsWarnAndSkipsOnChange pins the existing
+// (and unchanged) failure path: a bad config file must not invoke onChange,
+// and must log exactly one Warn line so it isn't followed by anything that
+// looks like a success.
+func TestWatcher_Reload_OnFailure_LogsWarnAndSkipsOnChange(t *testing.T) {
+	t.Parallel()
+
+	called := false
+
+	onChange := func(*Config) { called = true }
+
+	dir := t.TempDir()
+	watcher, logs := newTestWatcher(t, dir, "not valid toml [[[", onChange)
+	watcher.reload()
+
+	if called {
+		t.Error("onChange was called despite a failed Load")
+	}
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("got %d log entries, want 1: %+v", len(entries), entries)
+	}
+
+	entry := entries[0]
+
+	if entry.Level != zapcore.WarnLevel {
+		t.Errorf("log level = %v, want Warn", entry.Level)
+	}
+
+	if entry.Message != "config reload failed" {
+		t.Errorf("log message = %q, want %q", entry.Message, "config reload failed")
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the config watcher reporting a reload as successful before the reload has actually happened. On a failed fsnotify-triggered reload, the daemon log used to read `config reloaded` immediately followed by `config reload failed`, because the watcher logged success as soon as the file parsed — before handing the config off to the step that reloads the hook registry and can still fail (an invalid hook regex, for example).

The watcher now logs at debug level that the file parsed, and no longer claims a reload succeeded. The daemon's own reload-outcome log (added in #104) remains the single authoritative line for whether a reload succeeded or failed, on every trigger.

## Related Issues

Closes #107

## Type of Change

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no docs describe this log line
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The issue offered two fix directions: move the success log after `onChange` runs, or demote and reword it so it stops competing with the daemon's own success/failure line. `onChange` is `func(*Config)` with no return value, so it can't report success or failure without a signature change that would ripple into `internal/daemon` — out of scope here. This PR takes the second option: `config file parsed` at debug, with the daemon's `applyReload` left as the sole place that logs `config reloaded` / `config reload failed`.

`internal/config` had no tests before this change; `watcher_test.go` adds direct unit coverage for the watcher's reload step (extracted from an inline closure into an unexported method so it's testable without driving real fsnotify events) on both the success and failure paths.
