### PR TITLE
fix(errors): correct the IPC error code string and sync the documented list

### DIFF
--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -110,7 +110,7 @@ return derrors.New(derrors.CodeInternal, "something went wrong")
 return derrors.Wrapf(err, derrors.CodeConfigIOFailed, "reading config")
 ```
 
-Available error codes: `CodeAccessibilityDenied`, `CodeAccessibilityFailed`, `CodeInvalidConfig`, `CodeInvalidInput`, `CodeActionFailed`, `CodeContextCanceled`, `CodeTimeout`, `CodeInternal`, `CodeLoggingFailed`, `CodeConfigIOFailed`, `CodeSerializationFailed`, `CodeBridgeFailed`, `CodeNotSupported`.
+Available error codes: `CodeAccessibilityDenied`, `CodeAccessibilityFailed`, `CodeInvalidConfig`, `CodeInvalidInput`, `CodeActionFailed`, `CodeContextCanceled`, `CodeTimeout`, `CodeInternal`, `CodeLoggingFailed`, `CodeConfigIOFailed`, `CodeSerializationFailed`, `CodeBridgeFailed`, `CodeDaemonUnavailable`, `CodeIPCFailed`, `CodeServiceFailed`, `CodeNotSupported`.
 
 ---
 

--- a/internal/errors/coding_standards_test.go
+++ b/internal/errors/coding_standards_test.go
@@ -1,0 +1,137 @@
+package errors_test
+
+// This file pins the one boundary the compiler cannot check: the "Available
+// error codes" list in docs/CODING_STANDARDS.md and the exported Code*
+// constants in errors.go are two independently hand-maintained lists of the
+// same set. If a future edit adds, removes, or renames a Code* constant
+// without updating the doc (or vice versa), this test fails instead of the
+// drift sitting undetected until a contributor reaches for a code the docs
+// promised and the compiler rejects it.
+//
+// It reads both files as plain text fixtures via regexp rather than using
+// go/ast, following the same approach as
+// internal/native/eventkinds_test.go's parsing of eventkinds.h.
+//
+// Unlike that precedent, this file lives in package errors_test (not
+// errors) rather than carrying a //nolint:testpackage: it only needs the
+// exported Code* names as plain text, never an unexported identifier, so
+// there is nothing here that requires internal package access.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// codeConstRe matches an exported Code* constant declaration inside the Code
+// enum block in errors.go, e.g.:
+//
+//	CodeAccessibilityDenied Code = "ACCESSIBILITY_DENIED"
+var codeConstRe = regexp.MustCompile(`(?m)^\t(Code\w+)\s+Code\s*=\s*"[^"]*"\s*$`)
+
+// docCodeRe matches a single backtick-quoted Code* identifier, e.g.
+// "`CodeAccessibilityDenied`".
+var docCodeRe = regexp.MustCompile("`(Code\\w+)`")
+
+// parseErrorCodeConstants extracts every exported Code* constant name
+// declared in errors.go.
+func parseErrorCodeConstants(t *testing.T) map[string]struct{} {
+	t.Helper()
+
+	// go test runs with the package directory as the working directory, so
+	// this relative path is stable regardless of the caller's cwd.
+	data, err := os.ReadFile("errors.go")
+	if err != nil {
+		t.Fatalf("reading errors.go: %v", err)
+	}
+
+	matches := codeConstRe.FindAllStringSubmatch(string(data), -1)
+	if len(matches) == 0 {
+		t.Fatal("errors.go: found no Code* constant declarations; parser regex may be stale")
+	}
+
+	names := make(map[string]struct{}, len(matches))
+
+	for _, m := range matches {
+		name := m[1]
+
+		if _, dup := names[name]; dup {
+			t.Fatalf("errors.go: Code%s is declared more than once", name)
+		}
+
+		names[name] = struct{}{}
+	}
+
+	return names
+}
+
+// parseDocErrorCodes extracts every backtick-quoted Code* identifier from
+// the "Available error codes" line in docs/CODING_STANDARDS.md.
+func parseDocErrorCodes(t *testing.T) map[string]struct{} {
+	t.Helper()
+
+	data, err := os.ReadFile("../../docs/CODING_STANDARDS.md")
+	if err != nil {
+		t.Fatalf("reading docs/CODING_STANDARDS.md: %v", err)
+	}
+
+	const marker = "Available error codes:"
+
+	text := string(data)
+
+	idx := strings.Index(text, marker)
+	if idx == -1 {
+		t.Fatal(
+			"docs/CODING_STANDARDS.md: found no \"Available error codes:\" line; doc may have been reworded",
+		)
+	}
+
+	// The list runs to the end of the line it starts on.
+	line := text[idx:]
+	if nl := strings.IndexByte(line, '\n'); nl != -1 {
+		line = line[:nl]
+	}
+
+	matches := docCodeRe.FindAllStringSubmatch(line, -1)
+	if len(matches) == 0 {
+		t.Fatal(
+			"docs/CODING_STANDARDS.md: \"Available error codes\" line has no backtick-quoted Code* identifiers",
+		)
+	}
+
+	names := make(map[string]struct{}, len(matches))
+
+	for _, m := range matches {
+		name := m[1]
+
+		if _, dup := names[name]; dup {
+			t.Fatalf("docs/CODING_STANDARDS.md: %s is listed more than once", name)
+		}
+
+		names[name] = struct{}{}
+	}
+
+	return names
+}
+
+func TestCodingStandardsErrorCodeListMatchesErrorsGo(t *testing.T) {
+	t.Parallel()
+
+	codeConsts := parseErrorCodeConstants(t)
+	docCodes := parseDocErrorCodes(t)
+
+	for name := range codeConsts {
+		if _, ok := docCodes[name]; !ok {
+			t.Errorf("errors.go declares %s, which docs/CODING_STANDARDS.md's "+
+				"\"Available error codes\" list does not mention", name)
+		}
+	}
+
+	for name := range docCodes {
+		if _, ok := codeConsts[name]; !ok {
+			t.Errorf("docs/CODING_STANDARDS.md's \"Available error codes\" list mentions %s, "+
+				"which errors.go does not declare", name)
+		}
+	}
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -50,7 +50,7 @@ const (
 	CodeDaemonUnavailable Code = "DAEMON_UNAVAILABLE"
 
 	// CodeIPCFailed indicates a failure in IPC communication.
-	CodeIPCFailed Code = "IPCF_FAILED"
+	CodeIPCFailed Code = "IPC_FAILED"
 
 	// CodeServiceFailed indicates a failure managing the launchd service:
 	// rendering or writing its plist, or a launchctl invocation.

--- a/internal/ipc/timeout_test.go
+++ b/internal/ipc/timeout_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestServerHandleConnEnqueueTimeout verifies that handleConn returns
-// an IPCF_FAILED "timed out enqueueing action" error when the action
+// an IPC_FAILED "timed out enqueueing action" error when the action
 // worker isn't consuming from actionCh, instead of blocking forever.
 func TestServerHandleConnEnqueueTimeout(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Description

This PR corrects `CodeIPCFailed`'s wire value, which was `"IPCF_FAILED"` instead of the `NOUN_FAILED` shape every other error code follows. `Code` is serialised into `ipc.Response.Code` and printed in CLI error output, so this is a user-visible string, not a cosmetic rename — mimi is pre-1.0, so this is the cheap moment to fix it.

It also fixes `docs/CODING_STANDARDS.md`'s "Available error codes" list so it once again matches `internal/errors/errors.go`. Three codes existed in code but were missing from the list — `CodeDaemonUnavailable`, `CodeIPCFailed`, `CodeServiceFailed` — so a contributor reaching for a code by that list alone would not have found three real ones.

Finally, it adds a test, `internal/errors/coding_standards_test.go`, that parses the doc's list and the package's exported `Code*` constants and fails whenever the two drift apart again, following the same shape `internal/native/eventkinds_test.go` already uses for the `eventkinds.h` / `events.EventKind` boundary (added in #102).

## Related Issues

Closes #106

## Type of Change

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**The IPC code string change:** `CodeIPCFailed`'s value goes from `"IPCF_FAILED"` to `"IPC_FAILED"` in `internal/errors/errors.go`. The only other reference was a doc comment in `internal/ipc/timeout_test.go`, now updated to match. No test asserted the literal string — the one test that checks this code (`TestServerHandleConnEnqueueTimeout` in `internal/ipc/timeout_test.go`) compares against the `derrors.CodeIPCFailed` symbol, so it picks up the corrected value automatically.

**Potentially breaking:** any script or tool parsing `mimi`'s IPC/CLI error output for the literal string `IPCF_FAILED` will need updating to `IPC_FAILED`. Given the pre-1.0 status this is expected to be low-impact, but noting it per the repo's breaking-change convention (no `!` marker or `BREAKING CHANGE:` footer used — that call belongs to a human).

**The corrected error-code list**, in `errors.go`'s declaration order: `CodeAccessibilityDenied`, `CodeAccessibilityFailed`, `CodeInvalidConfig`, `CodeInvalidInput`, `CodeActionFailed`, `CodeContextCanceled`, `CodeTimeout`, `CodeInternal`, `CodeLoggingFailed`, `CodeConfigIOFailed`, `CodeSerializationFailed`, `CodeBridgeFailed`, `CodeDaemonUnavailable`, `CodeIPCFailed`, `CodeServiceFailed`, `CodeNotSupported`.

**Correction to the ticket's original premise:** the ticket also asked to remove `CodeReviewComments` from the docs, on the basis that it existed in the list but not in code. That constant was never actually present anywhere in the "Available error codes" list — not currently, and not at the commit the ticket originally cited as verified (`81f1b44`). The only nearby text is an unrelated "Further Reading" link to a Go wiki page literally titled "Go Code Review Comments", which is almost certainly what was misread while filing the ticket. That link is untouched by this PR; nothing needed removing.

Ran the full `just fmt && just lint && just test && just build` gate locally after every change in this PR; all green.
