### PR TITLE
fix(hooks,observe): stop logging hook commands and window titles at debug level

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -57,6 +57,28 @@ line with no color. The `log_file` log is always JSON, whatever `log_format`
 says, so anything already piping that file through `jq` keeps working. An
 unrecognized value logs a warning and falls back to `text`.
 
+### Debug logging
+
+`log_level = "debug"` adds two extra lines per routed event: a router
+`"event"` line (one per event reaching the bus) and, for each hook
+registered on that event's kind, an executor `"hook matched"` or
+`"hook skipped"` line.
+
+Both record only counts, IDs, kinds, PIDs, and booleans: `kind`, `app`,
+`bundle`, `pid`, `event_id`, the hook's `index` within its kind (0-based,
+scoped to hooks of the same kind — enough to tell two hooks apart in the
+log), the `reason` a hook was skipped (a fixed string, e.g.
+`"app filter mismatch"`), and `title_present` (whether the window has a
+non-empty title). They never record the window title itself or a hook's
+`run` command text, even at `debug`.
+
+This does not cover every log line that touches hook data. The `"hook ok"` /
+`"hook timed out"` / `"hook failed"` lines emitted after a hook finishes
+running still include the hook's `run` command as `cmd` — that gap is not
+closed here and remains open against AGENTS.md's "never log ... hook command
+contents" rule. Only the `"event"` and `"hook matched"` / `"hook skipped"`
+lines described above carry the no-payload guarantee.
+
 ---
 
 ## Systray

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -100,15 +100,15 @@ func (ex *Executor) Handle(evt events.Event) {
 		len(hooks),
 	)
 
-	for _, hook := range hooks {
+	for hookIndex, hook := range hooks {
 		matched, reason := hook.Matches(evt)
 		if !matched {
 			ex.logger.Debugw(
 				"hook skipped",
 				"kind",
 				evt.Kind,
-				"cmd",
-				hook.Entry.Run,
+				"index",
+				hookIndex,
 				"reason",
 				reason,
 			)
@@ -120,8 +120,8 @@ func (ex *Executor) Handle(evt events.Event) {
 			"hook matched",
 			"kind",
 			evt.Kind,
-			"cmd",
-			hook.Entry.Run,
+			"index",
+			hookIndex,
 			"async",
 			hook.Entry.Async,
 		)

--- a/internal/hooks/executor_test.go
+++ b/internal/hooks/executor_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/y3owk1n/mimi/internal/config"
 	"github.com/y3owk1n/mimi/internal/events"
@@ -283,5 +285,101 @@ func TestExecutorMergesBaseAndEventEnv(t *testing.T) {
 
 	if !strings.Contains(got, string(events.WindowCreated)) {
 		t.Errorf("hook output missing event env value %q\noutput: %q", events.WindowCreated, got)
+	}
+}
+
+// TestHandle_LogsHookIndexNotCommand pins the contract that "hook skipped"
+// and "hook matched" log the hook's index within its kind (enough to tell
+// two hooks of the same kind apart), never the literal shell command from
+// hook.Entry.Run. See AGENTS.md's logging contract and issue #112.
+func TestHandle_LogsHookIndexNotCommand(t *testing.T) {
+	t.Parallel()
+
+	const secretCmd = "curl -H 'Authorization: Bearer sk-should-not-appear' https://example.internal"
+
+	reg := NewRegistry()
+
+	loadErr := reg.Reload(&config.Config{
+		Hooks: config.HooksConfig{
+			AppActivate: []config.HookEntry{
+				{Run: "true"}, // index 0: matches
+				{Run: secretCmd, App: "SomeOtherAppThatWontMatch"}, // index 1: skipped
+			},
+		},
+	})
+	if loadErr != nil {
+		t.Fatalf("registry reload: %v", loadErr)
+	}
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core).Sugar()
+
+	cfg := &config.SettingsConfig{
+		HookShell:       defaultShell,
+		HookTimeoutSecs: 5,
+		MaxHookWorkers:  1,
+	}
+	exec := NewExecutor(reg, cfg, logger)
+
+	exec.Handle(events.Event{
+		Kind:    events.AppActivate,
+		ID:      "index-test",
+		AppName: "TestApp",
+	})
+
+	matchedEntries := logs.FilterMessage("hook matched").All()
+	if len(matchedEntries) != 1 {
+		t.Fatalf("got %d \"hook matched\" entries, want 1", len(matchedEntries))
+	}
+
+	matchedFields := matchedEntries[0].ContextMap()
+
+	if _, hasCmd := matchedFields["cmd"]; hasCmd {
+		t.Errorf("\"hook matched\" entry logged \"cmd\": %+v", matchedFields)
+	}
+
+	gotIndex, hasIndex := matchedFields["index"]
+	if !hasIndex {
+		t.Fatalf("\"hook matched\" entry missing \"index\" field: %+v", matchedFields)
+	}
+
+	if gotIndex != int64(0) {
+		t.Errorf("\"hook matched\" index = %v, want 0", gotIndex)
+	}
+
+	skippedEntries := logs.FilterMessage("hook skipped").All()
+	if len(skippedEntries) != 1 {
+		t.Fatalf("got %d \"hook skipped\" entries, want 1", len(skippedEntries))
+	}
+
+	skippedFields := skippedEntries[0].ContextMap()
+
+	if _, hasCmd := skippedFields["cmd"]; hasCmd {
+		t.Errorf("\"hook skipped\" entry logged \"cmd\": %+v", skippedFields)
+	}
+
+	gotSkippedIndex, hasSkippedIndex := skippedFields["index"]
+	if !hasSkippedIndex {
+		t.Fatalf("\"hook skipped\" entry missing \"index\" field: %+v", skippedFields)
+	}
+
+	if gotSkippedIndex != int64(1) {
+		t.Errorf("\"hook skipped\" index = %v, want 1", gotSkippedIndex)
+	}
+
+	if gotReason, ok := skippedFields["reason"]; !ok || gotReason != "app filter mismatch" {
+		t.Errorf("\"hook skipped\" reason = %v, want %q", gotReason, "app filter mismatch")
+	}
+
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, secretCmd) {
+			t.Fatalf("log entry leaked secret command in message: %q", entry.Message)
+		}
+
+		for key, val := range entry.ContextMap() {
+			if s, ok := val.(string); ok && strings.Contains(s, secretCmd) {
+				t.Fatalf("log field %q leaked secret command: %q", key, s)
+			}
+		}
 	}
 }

--- a/internal/observe/router.go
+++ b/internal/observe/router.go
@@ -119,7 +119,7 @@ func (r *Router) handle(evt events.Event) {
 		"app", evt.AppName,
 		"bundle", evt.BundleID,
 		"pid", evt.PID,
-		"title", evt.WindowTitle,
+		"title_present", evt.WindowTitle != "",
 	)
 	r.bus.Publish(evt)
 }
@@ -186,7 +186,7 @@ func (r *Router) newDebounceEntry(key string, evt events.Event) *resizeState {
 			"app", resizeEvt.AppName,
 			"bundle", resizeEvt.BundleID,
 			"pid", resizeEvt.PID,
-			"title", resizeEvt.WindowTitle,
+			"title_present", resizeEvt.WindowTitle != "",
 		)
 		r.bus.Publish(resizeEvt)
 	})

--- a/internal/observe/router_test.go
+++ b/internal/observe/router_test.go
@@ -3,10 +3,13 @@ package observe
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/y3owk1n/mimi/internal/events"
 )
@@ -127,6 +130,77 @@ func TestDebounceResize_SingleEvent(t *testing.T) {
 	if remaining != 0 {
 		t.Errorf("expected 0 remaining timers, got %d", remaining)
 	}
+}
+
+// assertNoFieldLeak fails the test if any string-valued log field contains
+// secret. Shared by the title_present tests below so a leak check on one
+// entry's ContextMap isn't duplicated per test.
+func assertNoFieldLeak(t *testing.T, fields map[string]any, secret string) {
+	t.Helper()
+
+	for key, val := range fields {
+		if s, ok := val.(string); ok && strings.Contains(s, secret) {
+			t.Fatalf("log field %q leaked secret: %q", key, s)
+		}
+	}
+}
+
+// TestDebounceResize_FireLogsTitlePresenceNotRawTitle pins the same
+// title_present contract for the debounced-resize publish path (the second
+// "event" log call site in router.go, distinct from handle's). See issue
+// #112.
+func TestDebounceResize_FireLogsTitlePresenceNotRawTitle(t *testing.T) {
+	t.Parallel()
+
+	const secretTitle = "Q4 Financials - confidential.xlsx"
+
+	bus := events.NewBus()
+	sub := bus.Subscribe(16)
+	ax := NewAXTracker(false)
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core).Sugar()
+
+	router := NewRouterWithDebounce(bus, ax, logger, testDebounceWindow)
+
+	evt := events.Event{
+		Kind:        events.WindowResizing,
+		AppName:     testAppName,
+		BundleID:    testBundleID,
+		PID:         42,
+		WindowTitle: secretTitle,
+		At:          time.Now(),
+	}
+
+	router.debounceResize(evt)
+
+	select {
+	case <-sub:
+	case <-time.After(testFireTimeout):
+		t.Fatal("timed out waiting for debounced resize event")
+	}
+
+	entries := logs.FilterMessage("event").All()
+	if len(entries) != 1 {
+		t.Fatalf("got %d \"event\" entries, want 1", len(entries))
+	}
+
+	fields := entries[0].ContextMap()
+
+	if _, hasTitle := fields["title"]; hasTitle {
+		t.Errorf("\"event\" entry logged raw \"title\": %+v", fields)
+	}
+
+	gotPresent, hasPresent := fields["title_present"]
+	if !hasPresent {
+		t.Fatalf("\"event\" entry missing \"title_present\" field: %+v", fields)
+	}
+
+	if b, ok := gotPresent.(bool); !ok || !b {
+		t.Errorf("title_present = %v, want true", gotPresent)
+	}
+
+	assertNoFieldLeak(t, fields, secretTitle)
 }
 
 func TestDebounceResize_MultipleEventsCoalesce(t *testing.T) {
@@ -433,6 +507,71 @@ func TestHandle_DefaultCase_LogsAndPublishesVerbatim(t *testing.T) {
 		}
 	case <-time.After(testFireTimeout):
 		t.Fatal("timed out waiting for the default-case publish")
+	}
+}
+
+// TestHandle_LogsTitlePresenceNotRawTitle pins the contract that the
+// "event" log line never carries evt.WindowTitle verbatim. handle() has no
+// visibility into whether a hook's title filter matched (that lives in
+// internal/hooks), so it logs whether a title is present instead — a
+// payload-free signal computable locally. See AGENTS.md's logging contract
+// and issue #112.
+func TestHandle_LogsTitlePresenceNotRawTitle(t *testing.T) {
+	t.Parallel()
+
+	const secretTitle = "Q4 Financials - confidential.xlsx"
+
+	tests := []struct {
+		name        string
+		windowTitle string
+		wantPresent bool
+	}{
+		{name: "title present", windowTitle: secretTitle, wantPresent: true},
+		{name: "title empty", windowTitle: "", wantPresent: false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			bus := events.NewBus()
+			ax := NewAXTracker(false)
+
+			core, logs := observer.New(zapcore.DebugLevel)
+			logger := zap.New(core).Sugar()
+
+			router := NewRouterWithDebounce(bus, ax, logger, testDebounceWindow)
+
+			router.handle(events.Event{
+				Kind:        events.WindowFocus,
+				AppName:     testAppName,
+				BundleID:    testBundleID,
+				PID:         3,
+				WindowTitle: testCase.windowTitle,
+			})
+
+			entries := logs.FilterMessage("event").All()
+			if len(entries) != 1 {
+				t.Fatalf("got %d \"event\" entries, want 1", len(entries))
+			}
+
+			fields := entries[0].ContextMap()
+
+			if _, hasTitle := fields["title"]; hasTitle {
+				t.Errorf("\"event\" entry logged raw \"title\": %+v", fields)
+			}
+
+			gotPresent, hasPresent := fields["title_present"]
+			if !hasPresent {
+				t.Fatalf("\"event\" entry missing \"title_present\" field: %+v", fields)
+			}
+
+			if gotPresent != testCase.wantPresent {
+				t.Errorf("title_present = %v, want %v", gotPresent, testCase.wantPresent)
+			}
+
+			assertNoFieldLeak(t, fields, secretTitle)
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

This PR stops mimi from writing hook commands and window titles into the
log at `log_level = "debug"`. The executor previously logged a hook's
literal shell command on every match/skip decision, and the router
previously logged the raw window title on every routed event — both are
user payloads that can carry API tokens, internal hostnames, and document
or message previews, and both are named explicitly by the "never log
window titles, hook command contents, or other user payloads" rule.

The executor now logs the hook's index within its kind instead of the
command, which is still enough to tell two hooks of the same kind apart in
the log. The router now logs whether a window title is present (a boolean)
instead of the title text itself — a true "did the title filter match"
signal isn't available at the router's log call site without pulling a
hook-registry dependency into the router, so title presence is the closest
payload-free equivalent computable there.

`docs/CONFIGURATION.md` gains a new section spelling out exactly what
these debug-level log lines record now, and flags — rather than hides —
that the hook outcome lines (`hook ok` / `hook timed out` / `hook failed`)
still include the raw command; that gap is not touched by this PR.

## Related Issues

Closes #112

## Type of Change

- [x] `fix` — Bug fix

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The issue's own "Decision" block asks for a "did the title filter match"
boolean in the router. `Router.handle` has no visibility into hook title
filters — that logic lives in `internal/hooks`, a different package — and
the router deliberately doesn't import it or take a registry dependency.
So this PR logs `title_present` (whether `WindowTitle` is non-empty)
instead, which is available locally and still payload-free; it answers "is
there a title to filter on" rather than "did a specific hook's filter
match". This is a scoped, disclosed substitution, not the literal wording
of the ruling.

Separately: the issue's own scope note ("exactly four call sites") is
inaccurate — `internal/hooks/executor.go`'s `run()` has three more call
sites (`hook ok`, `hook timed out`, `hook failed`) that also log the raw
`run` command, at `debug`/`warn`/`error` levels respectively. These are
untouched here because they sit outside the issue's stated scope, not
because they're considered acceptable; `docs/CONFIGURATION.md` says so
explicitly rather than presenting it as a closed gap.
