### PR TITLE
test(ipc): pin and document how mimi action resolves the daemon socket

### DIFF
--- a/cmd/mimi/cmd/action_runner_test.go
+++ b/cmd/mimi/cmd/action_runner_test.go
@@ -1,0 +1,117 @@
+//nolint:testpackage
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// shortSocketDir returns a short-lived directory for a Unix socket file.
+// t.TempDir() embeds the full (sub)test name in the path, which for this
+// test's long, descriptive name blows past sockaddr_un's ~104-byte limit and
+// makes the real bind(2) below fail with EINVAL — os.MkdirTemp keeps the
+// prefix short instead.
+//
+//nolint:usetesting // t.TempDir() is too long for a Unix socket path here; see comment above
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "mimi-ipc")
+	if err != nil {
+		t.Fatalf("creating short socket dir: %v", err)
+	}
+
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	return dir
+}
+
+// stateWithSocketConfig writes a minimal config setting socket_file to
+// socketPath and returns a cliState pointed at it — the setup both routing
+// tests below share.
+func stateWithSocketConfig(t *testing.T, socketPath string) *cliState {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	writeConfigFile(t, configPath, fmt.Sprintf("[settings]\nsocket_file = %q\n", socketPath))
+
+	return &cliState{configPath: configPath}
+}
+
+// TestRunAction_RoutesToDaemonWhenListening pins the routing mimi#90 asks to
+// be documented and tested: since PR #88, runAction resolves socket_file
+// from the (now always-resolved) config path and finds a daemon listening on
+// a custom socket where before #88 it always looked on the default one
+// instead. A bare Unix listener stands in for the daemon here — it answers
+// every request with ok:true, which an empty-name action.Command can never
+// produce on its own (ExecuteCommand's default case always errors), so a nil
+// result proves runAction reached the fake daemon rather than falling back.
+func TestRunAction_RoutesToDaemonWhenListening(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(shortSocketDir(t), "mimi.sock")
+	state := stateWithSocketConfig(t, socketPath)
+
+	lc := net.ListenConfig{}
+
+	listener, err := lc.Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("listening on fake daemon socket: %v", err)
+	}
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Drain the request line, then answer ok — the fake daemon never
+		// needs to inspect what was asked of it for this test.
+		_, _ = bufio.NewReader(conn).ReadBytes('\n')
+		_, _ = conn.Write([]byte("{\"ok\":true}\n"))
+	}()
+
+	err = state.runAction(action.Command{})
+	if err != nil {
+		t.Fatalf(
+			"runAction with a daemon listening on the configured socket = %v, want nil (it should have routed there instead of falling back to direct execution, which always errors on an empty action name)",
+			err,
+		)
+	}
+}
+
+// TestRunAction_FallsBackToDirectWhenNoDaemonListening is
+// TestRunAction_RoutesToDaemonWhenListening's mirror: the configured socket
+// exists nowhere on disk, so runAction must fall back to direct execution —
+// observable here because action.ExecuteCommand rejects the empty action
+// name with CodeInvalidInput, the same error direct execution has always
+// returned for an unrecognized action.
+func TestRunAction_FallsBackToDirectWhenNoDaemonListening(t *testing.T) {
+	t.Parallel()
+
+	// never created — nothing listens here
+	socketPath := filepath.Join(shortSocketDir(t), "mimi.sock")
+	state := stateWithSocketConfig(t, socketPath)
+
+	err := state.runAction(action.Command{})
+	if err == nil {
+		t.Fatal(
+			"expected runAction to fall back to direct execution and fail on the empty action name",
+		)
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput from direct execution's fallback, got %v", err)
+	}
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -57,6 +57,27 @@ line with no color. The `log_file` log is always JSON, whatever `log_format`
 says, so anything already piping that file through `jq` keeps working. An
 unrecognized value logs a warning and falls back to `text`.
 
+### socket_file
+
+`socket_file` is the Unix socket the daemon listens on and `mimi action …`
+looks for it on. Every `mimi action` invocation resolves its config path
+first (the default path when `-c`/`--config` is not given) and reads
+`socket_file` from it, then checks that socket:
+
+- **A daemon is listening** — the action is sent over the socket and runs on
+  the daemon's dedicated OS thread.
+- **Nothing is listening** — the CLI falls back to running the action
+  directly, in the CLI's own process.
+
+Both paths produce the same result, but not with the same timing: the daemon
+path is a socket round trip; the direct path runs in-process with no daemon
+involved at all. If you run the daemon with a non-default `socket_file`, that
+value is what routes `mimi action` to it — a mismatch between the two (or a
+daemon that hasn't picked up a changed `socket_file`, since it is
+restart-only) means actions silently execute directly instead of reaching the
+daemon. See [Troubleshooting](TROUBLESHOOTING.md#mimi-action-runs-but-seems-to-ignore-the-running-daemon)
+for how to tell which path an action actually took.
+
 ### Debug logging
 
 `log_level = "debug"` adds two extra lines per routed event: a router

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -7,6 +7,33 @@
 3. **Check space index** — spaces are 1-based in Mission Control order (`mimi action space 1` is the first space)
 4. **Close Mission Control** — actions refuse to run while Mission Control is open
 
+## `mimi action` runs but seems to ignore the running daemon
+
+`mimi action …` routes over the daemon's Unix socket (`settings.socket_file`)
+when something is listening there, and otherwise falls back to running the
+action directly, in the CLI's own process — see
+[Configuration: socket_file](CONFIGURATION.md#socket_file). Both paths run
+the same action and produce the same result, so this normally isn't visible.
+It matters when:
+
+- **The daemon and the CLI disagree on `socket_file`.** `mimi action` always
+  resolves its own config path (the default when no `-c`/`--config` is
+  given) and reads `socket_file` from *that* file. If the daemon was started
+  against a different config, or `socket_file` was edited but the daemon not
+  restarted (it's restart-only — see [Reloading](CONFIGURATION.md#reloading)),
+  the CLI is checking a socket the daemon isn't on, actions fall back to
+  direct execution silently, and nothing errors.
+- **You're timing something.** The daemon path is a socket round trip to an
+  already-running process; the direct path pays process startup cost instead
+  but skips the socket. An action that behaves differently under load, or
+  under a hotkey runner that expects the daemon's turnaround, may be taking
+  the path you didn't expect.
+
+To check which path an action actually took, run `mimi status` to confirm
+the daemon is running and reachable, and compare its socket path against
+`mimi config dump`'s `socketFile` for the same `-c`/`--config` your action
+command uses.
+
 ## Window hooks not firing
 
 1. Run `mimi status` — confirm daemon is running and Accessibility is granted

--- a/internal/ipc/resolve_socket_path_test.go
+++ b/internal/ipc/resolve_socket_path_test.go
@@ -1,0 +1,109 @@
+package ipc_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/ipc"
+)
+
+// TestResolveSocketPath pins mimi#90: PR #88 widened config-path resolution
+// so every `mimi action …` invocation now passes a real (never empty) config
+// path through to ResolveSocketPath, which loads that config and returns its
+// socket_file — including a custom one, where before #88 the CLI always
+// looked on the default socket instead. This test pins the three cases the
+// function itself promises, independent of how the CLI resolves the config
+// path that reaches it.
+func TestResolveSocketPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a config path given returns the configured socket_file", func(t *testing.T) {
+		t.Parallel()
+
+		configPath := filepath.Join(t.TempDir(), "config.toml")
+		wantSocket := filepath.Join(t.TempDir(), "custom.sock")
+
+		writeTOML(t, configPath, "[settings]\nsocket_file = "+quoteTOML(wantSocket)+"\n")
+
+		got := ipc.ResolveSocketPath(configPath)
+		if got != wantSocket {
+			t.Fatalf(
+				"ResolveSocketPath(%q) = %q, want configured socket %q",
+				configPath,
+				got,
+				wantSocket,
+			)
+		}
+	})
+
+	// The remaining cases all promise the same outcome — the default
+	// socket — for different reasons ResolveSocketPath never reaches a
+	// configured socket_file.
+	tests := []struct {
+		name       string
+		configPath func(t *testing.T) string
+	}{
+		{
+			name: "empty config path returns the default socket without touching disk",
+			configPath: func(*testing.T) string {
+				return ""
+			},
+		},
+		{
+			name: "a config path that fails to load returns the default socket",
+			configPath: func(t *testing.T) string {
+				t.Helper()
+
+				// A path with no file behind it: config.Load fails to read
+				// it, so ResolveSocketPath must fall back to the default
+				// socket rather than propagate the load error or return an
+				// empty path.
+				return filepath.Join(t.TempDir(), "does-not-exist.toml")
+			},
+		},
+		{
+			name: "a config path with unparsable content returns the default socket",
+			configPath: func(t *testing.T) string {
+				t.Helper()
+
+				configPath := filepath.Join(t.TempDir(), "broken.toml")
+				writeTOML(t, configPath, "this is not valid = = toml\n")
+
+				return configPath
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ipc.ResolveSocketPath(tt.configPath(t))
+			if got != config.DefaultSocketPath {
+				t.Fatalf(
+					"ResolveSocketPath(...) = %q, want default %q",
+					got,
+					config.DefaultSocketPath,
+				)
+			}
+		})
+	}
+}
+
+// writeTOML writes body to path, failing the test on any I/O error.
+func writeTOML(t *testing.T, path, body string) {
+	t.Helper()
+
+	err := os.WriteFile(path, []byte(body), 0o600)
+	if err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// quoteTOML wraps s in double quotes for use as a TOML string value. Test
+// inputs here never contain a quote or backslash, so no escaping is needed.
+func quoteTOML(s string) string {
+	return `"` + s + `"`
+}


### PR DESCRIPTION
## Description

This PR pins and documents how `mimi action …` decides whether to route through the daemon or run directly.

PR #88 widened config-path resolution so every command now loads a real config file first, which changed how `mimi action` finds the daemon socket: it now honors a custom `settings.socket_file` instead of always checking the default one. That routing shipped untested and undocumented. This adds tests that pin `ipc.ResolveSocketPath`'s three cases (configured socket, default when no config path is given, default when the config fails to load) and a test covering the action path choosing the daemon when one is listening on the configured socket versus falling back to direct execution when nothing is. `docs/CONFIGURATION.md` and `docs/TROUBLESHOOTING.md` now describe the routing and its behavioural and timing implications.

No deliberate limitation beyond scope: this does not touch the systray-refresh divergence mentioned in the original ticket, because #98/#100 already resolved it — both the daemon and direct paths refresh the systray identically today, so there is nothing left to document there.

## Related Issues

Closes #90

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Tests-and-documentation only; no behaviour change. `just vet` also passes on this branch, on top of the checklist above.
