### PR TITLE
fix(config,observe,hooks,systray): tolerate a nil logger in every constructor that accepts one

### DIFF
--- a/internal/config/nil_logger_test.go
+++ b/internal/config/nil_logger_test.go
@@ -1,0 +1,47 @@
+//nolint:testpackage // exercises reload, an unexported method, to reach the logger call
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestNewWatcher_NilLogger pins the contract stated in AGENTS.md and
+// docs/CODING_STANDARDS.md: a constructor that accepts a *zap.SugaredLogger
+// tolerates nil by falling back to zap.NewNop(). Before this guard existed,
+// passing nil stored the nil pointer and the first log call panicked.
+//
+// The test passes by not panicking; there is no value to assert, because the
+// contract promises a logger that deliberately records nothing.
+func TestNewWatcher_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// construct builds the value under test with a nil logger and then
+		// drives it through a code path that logs. It must not panic.
+		construct func(t *testing.T)
+	}{
+		{
+			name: "NewWatcher",
+			construct: func(t *testing.T) {
+				t.Helper()
+
+				// A path that cannot be loaded drives reload down its
+				// Warnw branch, which is the cheapest route to a log call.
+				missing := filepath.Join(t.TempDir(), "does-not-exist.toml")
+
+				w := NewWatcher(missing, func(*Config) {}, nil)
+				w.reload()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.construct(t)
+		})
+	}
+}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -22,6 +22,10 @@ type Watcher struct {
 
 // NewWatcher creates a new config file watcher.
 func NewWatcher(path string, onChange func(*Config), logger *zap.SugaredLogger) *Watcher {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
 	return &Watcher{path: paths.ExpandHome(path), onChange: onChange, logger: logger}
 }
 

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -71,6 +71,10 @@ type Executor struct {
 
 // NewExecutor creates an executor with the given registry and settings.
 func NewExecutor(reg *Registry, cfg *config.SettingsConfig, logger *zap.SugaredLogger) *Executor {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
 	return &Executor{
 		registry: reg,
 		cfg:      cfg,

--- a/internal/hooks/nil_logger_test.go
+++ b/internal/hooks/nil_logger_test.go
@@ -1,0 +1,49 @@
+package hooks_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/events"
+	"github.com/y3owk1n/mimi/internal/hooks"
+)
+
+// TestNewExecutor_NilLogger pins the contract stated in AGENTS.md and
+// docs/CODING_STANDARDS.md: a constructor that accepts a *zap.SugaredLogger
+// tolerates nil by falling back to zap.NewNop(). Before this guard existed,
+// passing nil stored the nil pointer and the first log call panicked.
+//
+// The test passes by not panicking; there is no value to assert, because the
+// contract promises a logger that deliberately records nothing.
+func TestNewExecutor_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// construct builds the value under test with a nil logger and then
+		// drives it through a code path that logs. It must not panic.
+		construct func(t *testing.T)
+	}{
+		{
+			name: "NewExecutor",
+			construct: func(t *testing.T) {
+				t.Helper()
+
+				// An empty registry means Handle logs its "processing
+				// event" line and matches nothing, so no hook shells out.
+				cfg := &config.SettingsConfig{MaxHookWorkers: 1}
+
+				ex := hooks.NewExecutor(hooks.NewRegistry(), cfg, nil)
+				ex.Handle(events.Event{Kind: events.WorkspaceChanged})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.construct(t)
+		})
+	}
+}

--- a/internal/observe/nil_logger_test.go
+++ b/internal/observe/nil_logger_test.go
@@ -1,0 +1,57 @@
+//nolint:testpackage // exercises handle, an unexported method, to reach the logger call
+package observe
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+// TestNewRouter_NilLogger pins the contract stated in AGENTS.md and
+// docs/CODING_STANDARDS.md: a constructor that accepts a *zap.SugaredLogger
+// tolerates nil by falling back to zap.NewNop(). Before this guard existed,
+// passing nil stored the nil pointer and the first log call panicked.
+//
+// Both of the package's logger-accepting constructors are covered:
+// NewRouterWithDebounce holds the guard and NewRouter delegates to it, so the
+// NewRouter row would still fail if that delegation were ever replaced by an
+// independent struct literal.
+func TestNewRouter_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	// A default-kind event falls straight through handle's switch to the
+	// unconditional Debugw, which is the cheapest route to a log call.
+	evt := events.Event{Kind: events.WorkspaceChanged}
+
+	tests := []struct {
+		name string
+		// newRouter builds a Router with a nil logger.
+		newRouter func() *Router
+	}{
+		{
+			name: "NewRouter",
+			newRouter: func() *Router {
+				return NewRouter(events.NewBus(), NewAXTracker(false), nil)
+			},
+		},
+		{
+			name: "NewRouterWithDebounce",
+			newRouter: func() *Router {
+				return NewRouterWithDebounce(
+					events.NewBus(),
+					NewAXTracker(false),
+					nil,
+					testDebounceWindow,
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.newRouter().handle(evt)
+		})
+	}
+}

--- a/internal/observe/router.go
+++ b/internal/observe/router.go
@@ -33,7 +33,8 @@ type resizeState struct {
 }
 
 // NewRouter creates an event router for the hook daemon with the default
-// resize debounce window (250ms).
+// resize debounce window (250ms). A nil logger is tolerated; the fallback to
+// zap.NewNop() lives in NewRouterWithDebounce, which this delegates to.
 func NewRouter(bus *events.Bus, tracker *AXTracker, logger *zap.SugaredLogger) *Router {
 	return NewRouterWithDebounce(bus, tracker, logger, defaultResizeDebounceDuration)
 }
@@ -46,6 +47,10 @@ func NewRouterWithDebounce(
 	logger *zap.SugaredLogger,
 	debounceWindow time.Duration,
 ) *Router {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
 	if debounceWindow <= 0 {
 		debounceWindow = defaultResizeDebounceDuration
 	}

--- a/internal/systray/component.go
+++ b/internal/systray/component.go
@@ -38,6 +38,10 @@ func NewComponent(
 	showWorkspaceNumber bool,
 	logger *zap.SugaredLogger,
 ) *Component {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Component{

--- a/internal/systray/nil_logger_test.go
+++ b/internal/systray/nil_logger_test.go
@@ -1,0 +1,57 @@
+//nolint:testpackage // exercises handleReloadConfig, an unexported method, to reach the logger call
+package systray
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// errReloadFailed drives handleReloadConfig down its Warnw branch.
+var errReloadFailed = errors.New("reload failed")
+
+// TestNewComponent_NilLogger pins the contract stated in AGENTS.md and
+// docs/CODING_STANDARDS.md: a constructor that accepts a *zap.SugaredLogger
+// tolerates nil by falling back to zap.NewNop(). Before this guard existed,
+// passing nil stored the nil pointer and the first log call panicked.
+//
+// NewComponent is easy to miss when auditing this contract — its signature is
+// multi-line, so the logger parameter does not sit on the `func` line where a
+// grep for it would land.
+//
+// The test passes by not panicking; there is no value to assert, because the
+// contract promises a logger that deliberately records nothing.
+func TestNewComponent_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// construct builds the value under test with a nil logger and then
+		// drives it through a code path that logs. It must not panic.
+		construct func(t *testing.T)
+	}{
+		{
+			name: "NewComponent",
+			construct: func(t *testing.T) {
+				t.Helper()
+
+				// A failing reload is the cheapest route to a log call that
+				// does not touch Cocoa.
+				reload := func(context.Context, string) error { return errReloadFailed }
+
+				c := NewComponent("v0", "config.toml", reload, func() {}, false, nil)
+				defer c.Close()
+
+				c.handleReloadConfig()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.construct(t)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a documented safety guarantee that was never actually implemented. Both `AGENTS.md` and `docs/CODING_STANDARDS.md` promise that anything constructed with an optional logger tolerates being given none, quietly discarding its output. Nothing honoured that promise — passing no logger stored nothing and crashed at the first line either component tried to log.

Every affected construction path now falls back to a no-op logger, so the documented behaviour and the real behaviour agree. There is no user-visible change: the daemon and CLI have always supplied a real logger, so no shipped path could reach the crash. The value is that the promise is now true for anyone writing against it, and tests no longer have to thread a throwaway logger through every construction just to avoid a panic.

The deliberate limitation is that the fallback covers constructors only, which is the boundary the two documents describe. The daemon's own entry point and its internal helpers also accept a logger but are not constructors, always receive a real one, and are left unchanged rather than given guards nobody would use.

## Related Issues

Closes #108

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, the documents already describe this behaviour and are deliberately left untouched; this PR makes the code match them.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

`just vet` and `just fmt-check` were also run and pass; `fmt-check` matters here because the change touches `internal/systray/`, whose Objective-C formatting CI gates separately.

The issue's scope named four constructors. A sweep for every function in the repo that accepts a logger found a fifth the issue missed — the system tray menu component. Its signature spans several lines, so the logger parameter does not sit on the `func` line where a grep for it would land. It is guarded here too, and its test comment records why it is easy to overlook.

Two constructors in the event-routing package share one guard: the convenience one delegates to the one taking an explicit debounce window, so duplicating the check there would be dead code. Both are still covered by tests, so the guard would fail loudly if that delegation were ever replaced.

Each affected package gains a table test that constructs with no logger and then drives the value through a path that logs. These are behavioural tests, so they pin the five constructors that exist today; they would not catch a *new* constructor added later without a guard. A static sweep asserting the guard across the repo would close that gap and is worth considering separately — it is the same shape as the doc/code drift test added in #115.
