### PR TITLE
fix(hooks): stop logging hook commands and failing hook output at the default log level

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,12 +93,16 @@ log), the `reason` a hook was skipped (a fixed string, e.g.
 non-empty title). They never record the window title itself or a hook's
 `run` command text, even at `debug`.
 
-This does not cover every log line that touches hook data. The `"hook ok"` /
-`"hook timed out"` / `"hook failed"` lines emitted after a hook finishes
-running still include the hook's `run` command as `cmd` — that gap is not
-closed here and remains open against AGENTS.md's "never log ... hook command
-contents" rule. Only the `"event"` and `"hook matched"` / `"hook skipped"`
-lines described above carry the no-payload guarantee.
+The `"hook ok"` / `"hook timed out"` / `"hook failed"` lines emitted after a
+hook finishes running follow the same rule: they identify the hook by the
+same `index`, and none of them records the `run` command text.
+
+One gap remains. The `"hook ok"` line still logs the hook's own captured
+stdout and stderr as `output` (trimmed, and capped at 64 KiB). That is hook
+output, i.e. a user payload, and it is an open exception to AGENTS.md's
+"never log ... other user payloads" rule. It is emitted only at
+`log_level = "debug"`; at `info` and above no hook output reaches the log,
+and the `"hook failed"` line reports the failure through `exit` alone.
 
 ---
 

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -131,9 +131,9 @@ func (ex *Executor) Handle(evt events.Event) {
 		)
 
 		if hook.Entry.Async {
-			go ex.run(hook, evt)
+			go ex.run(hookIndex, hook, evt)
 		} else {
-			ex.run(hook, evt)
+			ex.run(hookIndex, hook, evt)
 		}
 	}
 }
@@ -154,7 +154,12 @@ func (ex *Executor) Run(ctx context.Context, sub events.Subscriber) {
 	}
 }
 
-func (ex *Executor) run(hook Hook, evt events.Event) {
+// run executes a single matched hook. hookIndex is the hook's 0-based
+// position within its kind, passed down from Handle's loop so the log lines
+// below can identify the hook without recording its command text. It is a
+// parameter rather than executor state because Handle may launch several
+// async hooks concurrently.
+func (ex *Executor) run(hookIndex int, hook Hook, evt events.Event) {
 	ex.sem <- struct{}{}
 	defer func() { <-ex.sem }()
 
@@ -189,18 +194,18 @@ func (ex *Executor) run(hook Hook, evt events.Event) {
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			ex.logger.Warnw("hook timed out",
-				"kind", evt.Kind, "cmd", hook.Entry.Run, "timeout", timeout)
+				"kind", evt.Kind, "index", hookIndex, "timeout", timeout)
 		} else {
 			ex.logger.Errorw("hook failed",
-				"kind", evt.Kind, "cmd", hook.Entry.Run,
-				"exit", err, "output", strings.TrimSpace(string(out)))
+				"kind", evt.Kind, "index", hookIndex,
+				"exit", err)
 		}
 	} else {
 		output := strings.TrimSpace(string(out))
 
 		attrs := []any{
 			"kind", evt.Kind,
-			"cmd", hook.Entry.Run,
+			"index", hookIndex,
 			"elapsed", elapsed.Round(time.Millisecond),
 		}
 		if output != "" {

--- a/internal/hooks/executor_test.go
+++ b/internal/hooks/executor_test.go
@@ -383,3 +383,234 @@ func TestHandle_LogsHookIndexNotCommand(t *testing.T) {
 		}
 	}
 }
+
+// assertNoLeak fails the test if any observed log entry carries the hook's
+// command text or the hook's own output in its message or any string field.
+func assertNoLeak(t *testing.T, logs *observer.ObservedLogs, secrets ...string) {
+	t.Helper()
+
+	for _, entry := range logs.All() {
+		for _, secret := range secrets {
+			if strings.Contains(entry.Message, secret) {
+				t.Errorf("log message leaked %q: %q", secret, entry.Message)
+			}
+
+			for key, val := range entry.ContextMap() {
+				s, ok := val.(string)
+				if ok && strings.Contains(s, secret) {
+					t.Errorf("log field %q leaked %q: %q", key, secret, s)
+				}
+			}
+		}
+	}
+}
+
+// TestRun_HookFailedLogsIndexWithoutCommandOrOutput pins the contract that the
+// "hook failed" line — which fires at ERROR, i.e. without the user opting into
+// anything — identifies the hook by its index within its kind and carries
+// neither the command text nor the hook's stdout/stderr. See issue #117.
+func TestRun_HookFailedLogsIndexWithoutCommandOrOutput(t *testing.T) {
+	t.Parallel()
+
+	const (
+		secretCmd    = "printf 'sk-output-should-not-appear\\n'; exit 3"
+		secretOutput = "sk-output-should-not-appear"
+	)
+
+	reg := NewRegistry()
+
+	loadErr := reg.Reload(&config.Config{
+		Hooks: config.HooksConfig{
+			AppActivate: []config.HookEntry{
+				{Run: testHookRun}, // index 0: succeeds
+				{Run: secretCmd},   // index 1: fails, printing a secret
+			},
+		},
+	})
+	if loadErr != nil {
+		t.Fatalf("registry reload: %v", loadErr)
+	}
+
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	cfg := &config.SettingsConfig{
+		HookShell:       defaultShell,
+		HookTimeoutSecs: 5,
+		MaxHookWorkers:  1,
+	}
+	exec := NewExecutor(reg, cfg, zap.New(core).Sugar())
+
+	exec.Handle(events.Event{
+		Kind:    events.AppActivate,
+		ID:      "failed-test",
+		AppName: testAppName,
+	})
+
+	failedEntries := logs.FilterMessage("hook failed").All()
+	if len(failedEntries) != 1 {
+		t.Fatalf("got %d \"hook failed\" entries, want 1", len(failedEntries))
+	}
+
+	fields := failedEntries[0].ContextMap()
+
+	if _, hasCmd := fields["cmd"]; hasCmd {
+		t.Errorf("\"hook failed\" entry logged \"cmd\": %+v", fields)
+	}
+
+	if _, hasOutput := fields["output"]; hasOutput {
+		t.Errorf("\"hook failed\" entry logged \"output\": %+v", fields)
+	}
+
+	gotIndex, hasIndex := fields["index"]
+	if !hasIndex {
+		t.Fatalf("\"hook failed\" entry missing \"index\" field: %+v", fields)
+	}
+
+	if gotIndex != int64(1) {
+		t.Errorf("\"hook failed\" index = %v, want 1", gotIndex)
+	}
+
+	if _, hasExit := fields["exit"]; !hasExit {
+		t.Errorf("\"hook failed\" entry missing \"exit\" field: %+v", fields)
+	}
+
+	assertNoLeak(t, logs, secretCmd, secretOutput)
+}
+
+// TestRun_HookTimedOutLogsIndexNotCommand pins that the "hook timed out" line
+// — emitted at WARN, again without any opt-in — identifies the hook by index
+// and never by its command text. See issue #117.
+func TestRun_HookTimedOutLogsIndexNotCommand(t *testing.T) {
+	t.Parallel()
+
+	const secretCmd = "sleep 30 # sk-timeout-should-not-appear"
+
+	reg := NewRegistry()
+
+	loadErr := reg.Reload(&config.Config{
+		Hooks: config.HooksConfig{
+			AppActivate: []config.HookEntry{
+				{Run: secretCmd, TimeoutSecs: 1},
+			},
+		},
+	})
+	if loadErr != nil {
+		t.Fatalf("registry reload: %v", loadErr)
+	}
+
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	cfg := &config.SettingsConfig{
+		HookShell:       defaultShell,
+		HookTimeoutSecs: 30,
+		MaxHookWorkers:  1,
+	}
+	exec := NewExecutor(reg, cfg, zap.New(core).Sugar())
+
+	exec.Handle(events.Event{
+		Kind:    events.AppActivate,
+		ID:      "timeout-test",
+		AppName: testAppName,
+	})
+
+	timedOutEntries := logs.FilterMessage("hook timed out").All()
+	if len(timedOutEntries) != 1 {
+		t.Fatalf("got %d \"hook timed out\" entries, want 1", len(timedOutEntries))
+	}
+
+	fields := timedOutEntries[0].ContextMap()
+
+	if _, hasCmd := fields["cmd"]; hasCmd {
+		t.Errorf("\"hook timed out\" entry logged \"cmd\": %+v", fields)
+	}
+
+	gotIndex, hasIndex := fields["index"]
+	if !hasIndex {
+		t.Fatalf("\"hook timed out\" entry missing \"index\" field: %+v", fields)
+	}
+
+	if gotIndex != int64(0) {
+		t.Errorf("\"hook timed out\" index = %v, want 0", gotIndex)
+	}
+
+	if _, hasTimeout := fields["timeout"]; !hasTimeout {
+		t.Errorf("\"hook timed out\" entry missing \"timeout\" field: %+v", fields)
+	}
+
+	assertNoLeak(t, logs, secretCmd)
+}
+
+// TestRun_HookOkLogsIndexNotCommandAndKeepsOutput pins both halves of the
+// ruling on the debug path: "hook ok" identifies the hook by index rather
+// than by its command text, but deliberately still carries the hook's own
+// output, which is only ever emitted at debug. See issue #117.
+func TestRun_HookOkLogsIndexNotCommandAndKeepsOutput(t *testing.T) {
+	t.Parallel()
+
+	const (
+		secretCmd  = "printf 'hook-stdout-marker\\n' # sk-ok-should-not-appear"
+		wantOutput = "hook-stdout-marker"
+	)
+
+	reg := NewRegistry()
+
+	loadErr := reg.Reload(&config.Config{
+		Hooks: config.HooksConfig{
+			AppActivate: []config.HookEntry{
+				{Run: testHookRun}, // index 0: succeeds silently
+				{Run: secretCmd},   // index 1: succeeds with output
+			},
+		},
+	})
+	if loadErr != nil {
+		t.Fatalf("registry reload: %v", loadErr)
+	}
+
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	cfg := &config.SettingsConfig{
+		HookShell:       defaultShell,
+		HookTimeoutSecs: 5,
+		MaxHookWorkers:  1,
+	}
+	exec := NewExecutor(reg, cfg, zap.New(core).Sugar())
+
+	exec.Handle(events.Event{
+		Kind:    events.AppActivate,
+		ID:      "ok-test",
+		AppName: testAppName,
+	})
+
+	okEntries := logs.FilterMessage("hook ok").All()
+	if len(okEntries) != 2 {
+		t.Fatalf("got %d \"hook ok\" entries, want 2", len(okEntries))
+	}
+
+	for _, entry := range okEntries {
+		if _, hasCmd := entry.ContextMap()["cmd"]; hasCmd {
+			t.Errorf("\"hook ok\" entry logged \"cmd\": %+v", entry.ContextMap())
+		}
+
+		if _, hasIndex := entry.ContextMap()["index"]; !hasIndex {
+			t.Errorf("\"hook ok\" entry missing \"index\" field: %+v", entry.ContextMap())
+		}
+	}
+
+	fields := okEntries[1].ContextMap()
+
+	if gotIndex := fields["index"]; gotIndex != int64(1) {
+		t.Errorf("\"hook ok\" index = %v, want 1", gotIndex)
+	}
+
+	if _, hasElapsed := fields["elapsed"]; !hasElapsed {
+		t.Errorf("\"hook ok\" entry missing \"elapsed\" field: %+v", fields)
+	}
+
+	// The debug path deliberately keeps the hook's output; only the
+	// command text is removed.
+	if gotOutput := fields["output"]; gotOutput != wantOutput {
+		t.Errorf("\"hook ok\" output = %v, want %q", gotOutput, wantOutput)
+	}
+
+	assertNoLeak(t, logs, secretCmd)
+}


### PR DESCRIPTION
## Description

This PR stops mimi's log from recording the text of a user's hook commands and,
at the default log level, the hook's own output. Until now, every line written
after a hook finished carried the literal shell command it ran, and a failing
hook logged its combined stdout and stderr at error level — so a hook holding a
token, or printing one, leaked it into the log file without the user opting into
anything.

Those lines now identify the hook by its position within its event kind, the
same 0-based index already used by the "hook matched" and "hook skipped" lines,
so a failure can be cross-referenced against the debug lines for the same hook.
A failing hook reports through its exit status alone.

One deliberate limitation: the success line still records the hook's output, and
that line is only ever emitted at `log_level = "debug"`. It is documented as an
open gap in the configuration docs rather than closed here.

## Related Issues

Closes #117

## Type of Change

- [x] `fix` — Bug fix

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Log field surface, for anyone parsing the JSON log: on the `hook timed out`,
`hook failed`, and `hook ok` entries the `cmd` field is gone and an integer
`index` field takes its place; `hook failed` no longer carries `output`. The
`output` field on `hook ok` is unchanged. No config key, command, flag, hook
name, or `mimi_*` variable changes, and existing configs keep working.

`just fmt`, `just lint`, `just vet`, `just test`, and `just build` all pass in
this worktree; the new tests also pass under `-race`.
