### PR TITLE
fix(service,cli): write the installed service's console log beside log_file

### DIFF
--- a/cmd/mimi/cmd/runtime_paths.go
+++ b/cmd/mimi/cmd/runtime_paths.go
@@ -14,3 +14,16 @@ func (s *cliState) runtimePaths() (string, string) {
 
 	return config.DefaultPIDPath, config.DefaultSocketPath
 }
+
+// logFilePath returns the configured settings.log_file, already expanded by
+// the loader. It returns "" both when the setting is unset — it is optional —
+// and when the config cannot be read, which callers must treat the same way:
+// there is no log file to place anything beside.
+func (s *cliState) logFilePath() string {
+	cfg, err := config.Load(s.configPath)
+	if err != nil {
+		return ""
+	}
+
+	return cfg.Settings.LogFile
+}

--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -48,9 +48,9 @@ func newServicesInstallCmd(state *cliState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "install",
 		Short: "Install and load the system service",
-		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.",
+		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.\n\nThe daemon's stdout and stderr are captured beside settings.log_file, as <name>.out.log and <name>.err.log, and that directory is created if missing. When log_file is unset — or is not an absolute path, which launchd cannot open — they fall back to /tmp/mimi.log and /tmp/mimi.err.log.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := defaultService.Install(state.configPath)
+			err := defaultService.Install(state.configPath, state.logFilePath())
 			if err != nil {
 				return err
 			}

--- a/cmd/mimi/cmd/services_test.go
+++ b/cmd/mimi/cmd/services_test.go
@@ -2,10 +2,59 @@
 package cmd
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/service"
 )
+
+// TestCLIState_LogFilePath covers what `mimi services install` hands the plist
+// renderer: the configured settings.log_file, and "" whenever there is none to
+// hand over — which decides whether the installed service captures stdout
+// beside the log file or in /tmp. See issue #99.
+func TestCLIState_LogFilePath(t *testing.T) {
+	tests := []struct {
+		name string
+		// body is the config to write; an empty body means write no config
+		// file at all, so config.Load fails.
+		body string
+		want string
+	}{
+		{
+			name: "log_file set",
+			body: fmt.Sprintf(
+				"[settings]\nlog_file = %q\n",
+				"/Users/test/.local/state/mimi/mimi.log",
+			),
+			want: "/Users/test/.local/state/mimi/mimi.log",
+		},
+		{
+			name: "log_file unset",
+			body: "[settings]\nlog_level = \"debug\"\n",
+			want: "",
+		},
+		{
+			name: "config unreadable",
+			body: "",
+			want: "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.toml")
+			if testCase.body != "" {
+				writeConfigFile(t, configPath, testCase.body)
+			}
+
+			state := &cliState{configPath: configPath}
+			if got := state.logFilePath(); got != testCase.want {
+				t.Errorf("logFilePath() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
 
 func TestFormatStatus(t *testing.T) {
 	tests := []struct {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -185,6 +185,11 @@ Install mimi as a launchd user agent for automatic startup at login.
 mimi services install
 ```
 
+The generated plist captures the daemon's stdout and stderr beside
+`settings.log_file`, creating that directory if missing, or in `/tmp` when
+`log_file` is unset. See
+[Troubleshooting](TROUBLESHOOTING.md#where-a-service-installed-daemons-console-output-lands).
+
 ### `mimi services uninstall`
 
 Remove the launchd agent.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -55,8 +55,61 @@ mimi start
 ```bash
 mimi services status
 launchctl list | grep mimi
-cat /tmp/mimi.err.log    # if using Nix module
+cat /tmp/mimi.err.log    # Nix module, or mimi services install with log_file unset
 ```
+
+### Where a service-installed daemon's console output lands
+
+`mimi services install` writes a launchd plist that captures the daemon's
+stdout and stderr to two files. They are **not** the structured log — that is
+`settings.log_file`, written independently by mimi itself. The captured
+streams are the plain console output, and they are the only place a crash
+early in startup, before the logger exists, can surface.
+
+`mimi services install` places them beside `settings.log_file`, in the same
+directory and under the same name, with distinct suffixes. `~` is expanded
+before it reaches the plist, which always stores absolute paths:
+
+| `settings.log_file`            | stdout                             | stderr                             |
+| ------------------------------ | ---------------------------------- | ---------------------------------- |
+| `~/.local/state/mimi/mimi.log` | `~/.local/state/mimi/mimi.out.log` | `~/.local/state/mimi/mimi.err.log` |
+| `/var/log/mimi/daemon.jsonl`   | `/var/log/mimi/daemon.out.log`     | `/var/log/mimi/daemon.err.log`     |
+| unset, or not an absolute path | `/tmp/mimi.log`                    | `/tmp/mimi.err.log`                |
+
+Notes on this:
+
+- They never point at `settings.log_file` itself. That file belongs to the
+  rotating file-log writer; a second process appending raw console output to
+  it would corrupt the rotation.
+- `settings.log_file` is optional. With it unset, there is no directory to
+  derive from, so the streams keep the `/tmp/mimi.log` and `/tmp/mimi.err.log`
+  the plist has always used — the same pair the Nix modules install. A
+  `log_file` that is not an absolute path — a relative path, or a `~` that
+  could not be expanded because the home directory was unresolvable — falls
+  back the same way, since launchd expands neither and runs the job from `/`.
+- **The captured streams are not rotated.** `settings.log_file` gets size,
+  age, and backup limits; these two get none, while the same plist sets
+  `KeepAlive = true`, so the daemon is restarted for as long as you are
+  logged in. At `log_level = "debug"` mimi emits a console line per window
+  event, so these files grow without bound. Truncate them yourself if they
+  get large:
+
+  ```bash
+  : > ~/.local/state/mimi/mimi.out.log
+  : > ~/.local/state/mimi/mimi.err.log
+  ```
+
+- launchd opens both files when it spawns the daemon and creates no
+  directories of its own, so `mimi services install` creates
+  `settings.log_file`'s directory for it. Install fails with a
+  `creating log directory` error if that is not possible — fix `log_file` and
+  install again.
+- The paths are baked into the plist at install time. After changing
+  `settings.log_file`, run `mimi services uninstall && mimi services install`
+  to regenerate it — a restart alone keeps the old paths.
+- The Nix modules (`nix/darwin.nix`, `nix/home.nix`) write their own plists,
+  which always use `/tmp/mimi.log` and `/tmp/mimi.err.log` regardless of
+  `settings.log_file`.
 
 ## Permission prompt keeps appearing
 

--- a/internal/service/plist.go
+++ b/internal/service/plist.go
@@ -1,6 +1,9 @@
 package service
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // Label is the launchd service identifier mimi installs itself under.
 const Label = "com.y3owk1n.mimi"
@@ -9,13 +12,19 @@ const Label = "com.y3owk1n.mimi"
 // form [paths.ExpandHome] accepts.
 const launchAgentsDir = "~/Library/LaunchAgents"
 
-// plistTemplate is the launchd plist mimi installs, with the binary and
-// config paths left as tokens for renderPlist to fill in.
-//
-// StandardOutPath/StandardErrorPath are intentionally fixed at /tmp/mimi.log
-// and /tmp/mimi.err.log rather than settings.log_file: that path only ever
-// affects the captured stdout/stderr stream, and the file log sink honors
-// settings.log_file independently. See issue #99.
+// Default paths for the captured stdout/stderr streams, used when
+// settings.log_file gives nothing usable to derive them from. These are the
+// paths the plist has always hardcoded, kept unchanged so the fallback moves
+// nobody's files and stays identical to what the Nix modules install. /tmp is
+// also the one directory guaranteed to exist and be writable before launchd
+// spawns the job. See issue #99.
+const (
+	defaultStdoutPath = "/tmp/mimi.log"
+	defaultStderrPath = "/tmp/mimi.err.log"
+)
+
+// plistTemplate is the launchd plist mimi installs, with the binary, config
+// and captured-stream paths left as tokens for renderPlist to fill in.
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -34,9 +43,9 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/tmp/mimi.log</string>
+    <string>MIMI_STDOUT_PATH</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/mimi.err.log</string>
+    <string>MIMI_STDERR_PATH</string>
     <key>ProcessType</key>
     <string>Interactive</string>
     <key>LimitLoadToSessionType</key>
@@ -54,11 +63,60 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>`
 
 // renderPlist fills plistTemplate with the binary and config paths mimi was
-// given. It touches no filesystem and makes no system call: the same inputs
-// always render the same bytes, which is what lets it be pinned with a plain
-// table test instead of an integration one.
-func renderPlist(binPath, configPath string) string {
-	content := strings.ReplaceAll(plistTemplate, "MIMI_BINARY_PATH", binPath)
+// given, plus the stdout/stderr capture paths derived from logFile. It touches
+// no filesystem and makes no system call: the same inputs always render the
+// same bytes, which is what lets it be pinned with a plain table test instead
+// of an integration one.
+func renderPlist(binPath, configPath, logFile string) string {
+	streams := capturedStreamsFor(logFile)
 
-	return strings.ReplaceAll(content, "MIMI_CONFIG_PATH", configPath)
+	content := strings.ReplaceAll(plistTemplate, "MIMI_BINARY_PATH", binPath)
+	content = strings.ReplaceAll(content, "MIMI_CONFIG_PATH", configPath)
+	content = strings.ReplaceAll(content, "MIMI_STDOUT_PATH", streams.stdout)
+
+	return strings.ReplaceAll(content, "MIMI_STDERR_PATH", streams.stderr)
+}
+
+// capturedStreams is where launchd writes the daemon's stdout and stderr. The
+// two always share a directory, so callers that need it can take it from
+// either.
+type capturedStreams struct {
+	stdout string
+	stderr string
+}
+
+// dir is the directory both captured streams live in.
+func (c capturedStreams) dir() string {
+	return filepath.Dir(c.stdout)
+}
+
+// capturedStreamsFor derives where launchd writes the daemon's stdout and
+// stderr from settings.log_file: same directory, same stem, distinct
+// ".out.log" and ".err.log" suffixes. Neither can ever equal logFile itself —
+// that file belongs to lumberjack, which rotates it, and a second writer
+// appending raw console output to it would corrupt the rotation.
+//
+// logFile is optional and reaches here exactly as config stored it, so it may
+// be empty or — when paths.ExpandHome could not resolve the home directory —
+// still carry a literal "~". launchd expands neither "~" nor a relative path,
+// so anything that is not already absolute falls back to /tmp rather than
+// putting a path launchd cannot open into the plist.
+func capturedStreamsFor(logFile string) capturedStreams {
+	fallback := capturedStreams{stdout: defaultStdoutPath, stderr: defaultStderrPath}
+
+	if !filepath.IsAbs(logFile) {
+		return fallback
+	}
+
+	dir, base := filepath.Dir(logFile), filepath.Base(logFile)
+
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	if stem == "" || stem == "." || stem == string(filepath.Separator) {
+		return fallback
+	}
+
+	return capturedStreams{
+		stdout: filepath.Join(dir, stem+".out.log"),
+		stderr: filepath.Join(dir, stem+".err.log"),
+	}
 }

--- a/internal/service/plist_test.go
+++ b/internal/service/plist_test.go
@@ -6,17 +6,141 @@ import (
 	"testing"
 )
 
-// wantGoldenPlist is what the pre-refactor cmd/mimi/cmd implementation
-// produced for binPath "/usr/local/bin/mimi" and configPath
-// "/Users/test/.config/mimi/config.toml" — captured from that code before it
-// moved, so this pins renderPlist to byte-identical output rather than to a
-// value this test derives the same way the code does.
-const wantGoldenPlist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>com.y3owk1n.mimi</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>/usr/local/bin/mimi</string>\n        <string>start</string>\n        <string>--config</string>\n        <string>/Users/test/.config/mimi/config.toml</string>\n    </array>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>StandardOutPath</key>\n    <string>/tmp/mimi.log</string>\n    <key>StandardErrorPath</key>\n    <string>/tmp/mimi.err.log</string>\n    <key>ProcessType</key>\n    <string>Interactive</string>\n    <key>LimitLoadToSessionType</key>\n    <string>Aqua</string>\n    <key>Nice</key>\n    <integer>-10</integer>\n    <key>ThrottleInterval</key>\n    <integer>10</integer>\n    <key>EnvironmentVariables</key>\n    <dict>\n        <key>PATH</key>\n        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>\n    </dict>\n</dict>\n</plist>"
+// wantGoldenPlist is the full plist renderPlist must produce for binPath
+// "/usr/local/bin/mimi", configPath "/Users/test/.config/mimi/config.toml" and
+// logFile "/Users/test/.local/state/mimi/mimi.log" — written out by hand, not
+// derived the way the code derives it, so this pins renderPlist to
+// byte-identical output.
+//
+// It inherits from the pre-refactor cmd/mimi/cmd output, changed in exactly
+// one place: issue #99 moved StandardOutPath/StandardErrorPath off the
+// hardcoded /tmp/mimi.log and /tmp/mimi.err.log and onto log_file's directory.
+const wantGoldenPlist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>com.y3owk1n.mimi</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>/usr/local/bin/mimi</string>\n        <string>start</string>\n        <string>--config</string>\n        <string>/Users/test/.config/mimi/config.toml</string>\n    </array>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>StandardOutPath</key>\n    <string>/Users/test/.local/state/mimi/mimi.out.log</string>\n    <key>StandardErrorPath</key>\n    <string>/Users/test/.local/state/mimi/mimi.err.log</string>\n    <key>ProcessType</key>\n    <string>Interactive</string>\n    <key>LimitLoadToSessionType</key>\n    <string>Aqua</string>\n    <key>Nice</key>\n    <integer>-10</integer>\n    <key>ThrottleInterval</key>\n    <integer>10</integer>\n    <key>EnvironmentVariables</key>\n    <dict>\n        <key>PATH</key>\n        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>\n    </dict>\n</dict>\n</plist>"
 
-func TestRenderPlist_MatchesThePreRefactorOutputByteForByte(t *testing.T) {
-	got := renderPlist("/usr/local/bin/mimi", "/Users/test/.config/mimi/config.toml")
+func TestRenderPlist_MatchesTheGoldenOutputByteForByte(t *testing.T) {
+	got := renderPlist(
+		"/usr/local/bin/mimi",
+		"/Users/test/.config/mimi/config.toml",
+		"/Users/test/.local/state/mimi/mimi.log",
+	)
 	if got != wantGoldenPlist {
 		t.Errorf("renderPlist() =\n%q\nwant\n%q", got, wantGoldenPlist)
+	}
+}
+
+// TestRenderPlist_CapturedStreamPaths pins where launchd is told to write the
+// daemon's stdout and stderr for each shape settings.log_file can arrive in.
+// Every expected value is written out literally rather than derived, and no
+// case may name log_file itself: lumberjack rotates that file, so a second
+// writer appending to it would corrupt the rotation.
+func TestRenderPlist_CapturedStreamPaths(t *testing.T) {
+	// The /tmp paths every fallback case expects — the ones the plist
+	// hardcoded before issue #99 — spelled out here rather than read from the
+	// package's own constants, so this test disagrees with the code if the
+	// code changes them.
+	const (
+		wantFallbackStdout = "/tmp/mimi.log"
+		wantFallbackStderr = "/tmp/mimi.err.log"
+	)
+
+	tests := []struct {
+		name       string
+		logFile    string
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name:       "derived from log_file's directory with distinct names",
+			logFile:    "/Users/test/.local/state/mimi/mimi.log",
+			wantStdout: "/Users/test/.local/state/mimi/mimi.out.log",
+			wantStderr: "/Users/test/.local/state/mimi/mimi.err.log",
+		},
+		{
+			name:       "log_file with a non-default stem keeps that stem",
+			logFile:    "/var/log/mimi/daemon.jsonl",
+			wantStdout: "/var/log/mimi/daemon.out.log",
+			wantStderr: "/var/log/mimi/daemon.err.log",
+		},
+		{
+			name:       "log_file without an extension",
+			logFile:    "/var/log/mimi-daemon",
+			wantStdout: "/var/log/mimi-daemon.out.log",
+			wantStderr: "/var/log/mimi-daemon.err.log",
+		},
+		{
+			name:       "log_file unset falls back to /tmp",
+			logFile:    "",
+			wantStdout: wantFallbackStdout,
+			wantStderr: wantFallbackStderr,
+		},
+		{
+			// paths.ExpandHome returns the path unchanged when the home
+			// directory cannot be resolved. launchd does not expand "~", so
+			// such a value must not reach the plist.
+			name:       "unexpanded ~ falls back to /tmp",
+			logFile:    "~/.local/state/mimi/mimi.log",
+			wantStdout: wantFallbackStdout,
+			wantStderr: wantFallbackStderr,
+		},
+		{
+			// launchd runs the job from /, so a relative path would land
+			// somewhere the user never asked for.
+			name:       "relative log_file falls back to /tmp",
+			logFile:    "logs/mimi.log",
+			wantStdout: wantFallbackStdout,
+			wantStderr: wantFallbackStderr,
+		},
+		{
+			name:       "log_file that is only an extension falls back to /tmp",
+			logFile:    "/var/log/.log",
+			wantStdout: wantFallbackStdout,
+			wantStderr: wantFallbackStderr,
+		},
+		{
+			name:       "log_file at the filesystem root falls back to /tmp",
+			logFile:    "/",
+			wantStdout: wantFallbackStdout,
+			wantStderr: wantFallbackStderr,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := renderPlist(
+				"/usr/local/bin/mimi",
+				"/Users/test/.config/mimi/config.toml",
+				testCase.logFile,
+			)
+
+			wantOut := "<key>StandardOutPath</key>\n    <string>" + testCase.wantStdout + "</string>"
+			if !strings.Contains(got, wantOut) {
+				t.Errorf(
+					"renderPlist(logFile=%q) does not contain %q:\n%s",
+					testCase.logFile,
+					wantOut,
+					got,
+				)
+			}
+
+			wantErr := "<key>StandardErrorPath</key>\n    <string>" + testCase.wantStderr + "</string>"
+			if !strings.Contains(got, wantErr) {
+				t.Errorf(
+					"renderPlist(logFile=%q) does not contain %q:\n%s",
+					testCase.logFile,
+					wantErr,
+					got,
+				)
+			}
+
+			if testCase.logFile != "" &&
+				strings.Contains(got, "<string>"+testCase.logFile+"</string>") {
+				t.Errorf(
+					"renderPlist(logFile=%q) points a captured stream at log_file itself, which lumberjack rotates:\n%s",
+					testCase.logFile,
+					got,
+				)
+			}
+		})
 	}
 }
 
@@ -25,27 +149,31 @@ func TestRenderPlist_Table(t *testing.T) {
 		name       string
 		binPath    string
 		configPath string
+		logFile    string
 	}{
 		{
 			name:       "typical paths",
 			binPath:    "/opt/homebrew/bin/mimi",
 			configPath: "~/.config/mimi/config.toml",
+			logFile:    "/Users/test/.local/state/mimi/mimi.log",
 		},
 		{
 			name:       "empty inputs",
 			binPath:    "",
 			configPath: "",
+			logFile:    "",
 		},
 		{
 			name:       "path containing the token-like substring MIMI",
 			binPath:    "/Users/mimi-user/bin/mimi",
 			configPath: "/Users/mimi-user/MIMI_CONFIG_PATH-lookalike/config.toml",
+			logFile:    "/Users/mimi-user/MIMI_STDOUT_PATH-lookalike/mimi.log",
 		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := renderPlist(testCase.binPath, testCase.configPath)
+			got := renderPlist(testCase.binPath, testCase.configPath, testCase.logFile)
 
 			wantBin := "<string>" + testCase.binPath + "</string>"
 			if !strings.Contains(got, wantBin) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -35,7 +35,11 @@ func New() *Service {
 
 // Install renders the plist for the running binary and configPath, writes it
 // to ~/Library/LaunchAgents, and loads it with launchctl bootstrap.
-func (s *Service) Install(configPath string) error {
+//
+// logFile is settings.log_file as config resolved it, and is only used to
+// place the daemon's captured stdout/stderr alongside it; an empty value is
+// valid and leaves those streams at their /tmp defaults.
+func (s *Service) Install(configPath, logFile string) error {
 	ctx := context.Background()
 
 	if s.launcher.list(ctx, Label) == nil {
@@ -50,7 +54,19 @@ func (s *Service) Install(configPath string) error {
 		return derrors.Wrapf(err, derrors.CodeServiceFailed, "getting binary path")
 	}
 
-	plistContent := renderPlist(binPath, configPath)
+	plistContent := renderPlist(binPath, configPath, logFile)
+
+	// launchd opens StandardOutPath and StandardErrorPath at spawn time and
+	// creates no directories of its own: a missing one silently discards the
+	// console output of the very first run, which is the startup crash these
+	// streams exist to capture. mimi's own file log only creates the
+	// directory later, once the logger is built.
+	captureDir := capturedStreamsFor(logFile).dir()
+
+	err = os.MkdirAll(captureDir, dirPerm)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "creating log directory")
+	}
 
 	expandedDir := paths.ExpandHome(launchAgentsDir)
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -158,10 +158,15 @@ func TestService_Install_WritesThePlistAndBootstraps(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
+	// A log directory that does not exist yet, as on a machine where the
+	// service is installed before mimi has ever run.
+	logDir := filepath.Join(dir, "state", "mimi")
+	logFile := filepath.Join(logDir, "mimi.log")
+
 	fake := &fakeLauncher{}
 	svc := &Service{launcher: fake}
 
-	err := svc.Install("/Users/test/.config/mimi/config.toml")
+	err := svc.Install("/Users/test/.config/mimi/config.toml", logFile)
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil", err)
 	}
@@ -180,6 +185,27 @@ func TestService_Install_WritesThePlistAndBootstraps(t *testing.T) {
 	if !strings.Contains(string(content), "/Users/test/.config/mimi/config.toml") {
 		t.Errorf("installed plist does not carry the config path:\n%s", content)
 	}
+
+	// The captured streams land beside log_file, never on it.
+	if !strings.Contains(string(content), filepath.Join(logDir, "mimi.out.log")) {
+		t.Errorf("installed plist does not carry the derived stdout path:\n%s", content)
+	}
+
+	if strings.Contains(string(content), "<string>"+logFile+"</string>") {
+		t.Errorf("installed plist points a captured stream at log_file itself:\n%s", content)
+	}
+
+	// launchd opens both files at spawn and creates no directories, so a
+	// missing one silently discards the console output of the very first
+	// run — the startup crash these streams exist to capture.
+	info, err := os.Stat(logDir)
+	if err != nil {
+		t.Fatalf("Install() did not create the captured-stream directory: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Errorf("captured-stream path %s is not a directory", logDir)
+	}
 }
 
 func TestService_Install_FailsWhenAlreadyLoaded(t *testing.T) {
@@ -189,7 +215,10 @@ func TestService_Install_FailsWhenAlreadyLoaded(t *testing.T) {
 	fake := &fakeLauncher{loaded: true}
 	svc := &Service{launcher: fake}
 
-	err := svc.Install("/Users/test/.config/mimi/config.toml")
+	err := svc.Install(
+		"/Users/test/.config/mimi/config.toml",
+		filepath.Join(dir, "state", "mimi", "mimi.log"),
+	)
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}
@@ -222,7 +251,10 @@ func TestService_Install_FailsWhenThePlistAlreadyExists(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := &Service{launcher: fake}
 
-	err = svc.Install("/Users/test/.config/mimi/config.toml")
+	err = svc.Install(
+		"/Users/test/.config/mimi/config.toml",
+		filepath.Join(dir, "state", "mimi", "mimi.log"),
+	)
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}
@@ -233,5 +265,40 @@ func TestService_Install_FailsWhenThePlistAlreadyExists(t *testing.T) {
 
 	if fake.bootstrapped {
 		t.Error("Install() bootstrapped despite a pre-existing plist")
+	}
+}
+
+// TestService_Install_FailsWhenTheCapturedStreamDirectoryCannotBeCreated
+// pins that an unusable log_file directory is reported rather than swallowed:
+// launchd would otherwise load a service whose console output goes nowhere.
+func TestService_Install_FailsWhenTheCapturedStreamDirectoryCannotBeCreated(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// A regular file where the log directory would have to be.
+	blocker := filepath.Join(dir, "state")
+
+	err := os.WriteFile(blocker, []byte("not a directory"), 0o644)
+	if err != nil {
+		t.Fatalf("seeding blocking file: %v", err)
+	}
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	err = svc.Install(
+		"/Users/test/.config/mimi/config.toml",
+		filepath.Join(blocker, "mimi", "mimi.log"),
+	)
+	if err == nil {
+		t.Fatal("Install() = nil, want an error")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	if fake.bootstrapped {
+		t.Error("Install() bootstrapped despite an unusable log directory")
 	}
 }


### PR DESCRIPTION
## Description

This PR moves the console output of a service-installed daemon out of `/tmp` and next to the log file you configured. Until now the generated launchd plist always captured stdout and stderr at `/tmp/mimi.log` and `/tmp/mimi.err.log` — nowhere near `settings.log_file`, undocumented, and in a directory macOS periodically clears, so the one stream that would show a startup crash was the hardest to find after the fact.

The captured streams now land in the same directory as `settings.log_file`, under the same name, as `<name>.out.log` and `<name>.err.log`. They never point at the log file itself: the rotating file-log writer owns that path, and a second process appending raw console output to it would corrupt rotation. Installing the service now also creates that directory, because launchd opens both files when it spawns the daemon and creates no directories of its own.

Deliberate limitation: these two files are still not rotated, while the plist still sets `KeepAlive`, so at `log_level = "debug"` they grow for as long as you stay logged in. That is documented now, with a truncate command, rather than fixed here.

## Related Issues

Closes #99

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config and command surface

No config key is added, renamed, or removed. `settings.log_file` keeps its meaning and stays optional; it now additionally decides where `mimi services install` points the plist's captured streams.

| `settings.log_file`            | stdout                             | stderr                             |
| ------------------------------ | ---------------------------------- | ---------------------------------- |
| `~/.local/state/mimi/mimi.log` | `~/.local/state/mimi/mimi.out.log` | `~/.local/state/mimi/mimi.err.log` |
| `/var/log/mimi/daemon.jsonl`   | `/var/log/mimi/daemon.out.log`     | `/var/log/mimi/daemon.err.log`     |
| unset, or not an absolute path | `/tmp/mimi.log`                    | `/tmp/mimi.err.log`                |

`mimi services install` gains no flag; only its `--help` text and behaviour change. It can now fail with a `creating log directory` error when `settings.log_file`'s directory cannot be created — previously it never touched that directory.

## Potentially breaking

Nothing breaks for an already-installed service: the paths are baked into the plist at install time, so an existing installation keeps writing exactly where it wrote before until it is reinstalled.

Potentially surprising after a reinstall with `log_file` set: `cat /tmp/mimi.log` stops being where the console output is. `docs/TROUBLESHOOTING.md` now spells out where to look, and `mimi services uninstall && mimi services install` is what regenerates the plist after changing `log_file` — a restart alone keeps the old paths.

With `log_file` unset the fallback is byte-for-byte what it was, `/tmp/mimi.log` and `/tmp/mimi.err.log`, which is also what the Nix modules install. Those modules write their own plists and are unchanged by this PR.

## Additional Context

- The fallback also covers a `log_file` that is not absolute — a relative path, or a `~` that could not be expanded because the home directory was unresolvable (the case `paths.ExpandHome` started preserving in #113). launchd expands neither and runs the job from `/`, so such a value must not reach the plist.
- Rejected: pointing the streams at `settings.log_file` itself (corrupts lumberjack's rotation) and sending them to `/dev/null` (loses the pre-logger crash output, the one case they are most useful for). A size cap was considered and left out — capping is rotation by another name, and #99 asks for it to be documented, not implemented.
- The plist renderer stays a pure function pinned by a golden test that compares the full output byte-for-byte; the golden was updated deliberately for the two changed lines, and a table covers each shape `log_file` can arrive in, including that no case can name `log_file` itself.
