### PR TITLE
refactor(config,hooks,daemon): derive hook kinds from one table

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,20 +59,16 @@ type HookEntry struct {
 	Async       bool   `json:"async"       toml:"async"`
 }
 
-type rawHooksConfig struct {
-	AppActivate       []any `json:"onAppActivate"       toml:"on_app_activate"`
-	AppDeactivate     []any `json:"onAppDeactivate"     toml:"on_app_deactivate"`
-	AppLaunch         []any `json:"onAppLaunch"         toml:"on_app_launch"`
-	AppQuit           []any `json:"onAppQuit"           toml:"on_app_quit"`
-	AppHide           []any `json:"onAppHide"           toml:"on_app_hide"`
-	AppUnhide         []any `json:"onAppUnhide"         toml:"on_app_unhide"`
-	WindowFocus       []any `json:"onWindowFocus"       toml:"on_window_focus"`
-	WindowTitleChange []any `json:"onWindowTitleChange" toml:"on_window_title_change"`
-	WindowCreated     []any `json:"onWindowCreated"     toml:"on_window_created"`
-	WindowClosed      []any `json:"onWindowClosed"      toml:"on_window_closed"`
-	WindowResize      []any `json:"onWindowResize"      toml:"on_window_resize"`
-	WorkspaceChanged  []any `json:"onWorkspaceChanged"  toml:"on_workspace_changed"`
-}
+// rawHooksConfig holds the [hooks] table exactly as written, keyed by the TOML
+// key the user typed, so decodeHooks can fold over HookKinds to pull the keys
+// it recognizes instead of restating the twelve field names.
+//
+// The value type is any, not []any: a []any map would make the TOML decoder
+// itself reject every unrecognized key whose value is not an array, which is
+// both a behavior change and the decoder's error rather than one of ours.
+// Unrecognized keys are decoded, ignored here, and left for a later change to
+// report.
+type rawHooksConfig map[string]any
 
 type rawConfig struct {
 	Settings SettingsConfig   `json:"settings" toml:"settings"`
@@ -128,18 +124,23 @@ func decodeHooks(raw rawHooksConfig) (HooksConfig, error) {
 		return entries
 	}
 
-	hooksCfg.AppActivate = decodeField("on_app_activate", raw.AppActivate)
-	hooksCfg.AppDeactivate = decodeField("on_app_deactivate", raw.AppDeactivate)
-	hooksCfg.AppLaunch = decodeField("on_app_launch", raw.AppLaunch)
-	hooksCfg.AppQuit = decodeField("on_app_quit", raw.AppQuit)
-	hooksCfg.AppHide = decodeField("on_app_hide", raw.AppHide)
-	hooksCfg.AppUnhide = decodeField("on_app_unhide", raw.AppUnhide)
-	hooksCfg.WindowFocus = decodeField("on_window_focus", raw.WindowFocus)
-	hooksCfg.WindowTitleChange = decodeField("on_window_title_change", raw.WindowTitleChange)
-	hooksCfg.WindowCreated = decodeField("on_window_created", raw.WindowCreated)
-	hooksCfg.WindowClosed = decodeField("on_window_closed", raw.WindowClosed)
-	hooksCfg.WindowResize = decodeField("on_window_resize", raw.WindowResize)
-	hooksCfg.WorkspaceChanged = decodeField("on_workspace_changed", raw.WorkspaceChanged)
+	for _, kind := range HookKinds {
+		items, isList := rawHookItems(raw[kind.TOMLKey])
+		if !isList {
+			errs = append(
+				errs,
+				fmt.Sprintf(
+					"%s: expected an array of hooks, got %T",
+					kind.TOMLKey,
+					raw[kind.TOMLKey],
+				),
+			)
+
+			continue
+		}
+
+		*kind.Entries(&hooksCfg) = decodeField(kind.TOMLKey, items)
+	}
 
 	if len(errs) > 0 {
 		return hooksCfg, derrors.Newf(
@@ -150,6 +151,31 @@ func decodeHooks(raw rawHooksConfig) (HooksConfig, error) {
 	}
 
 	return hooksCfg, nil
+}
+
+// rawHookItems normalizes the two shapes the TOML decoder produces for a hook
+// list into the one decodeField walks: an inline array (on_x = [...]) arrives
+// as []any, while a sequence of [[hooks.on_x]] tables arrives as
+// []map[string]any.
+//
+// A missing key is an absent list, not a malformed one. The second result is
+// false only when the key is present and holds something that is not a list.
+func rawHookItems(value any) ([]any, bool) {
+	switch list := value.(type) {
+	case nil:
+		return nil, true
+	case []any:
+		return list, true
+	case []map[string]any:
+		items := make([]any, 0, len(list))
+		for _, table := range list {
+			items = append(items, table)
+		}
+
+		return items, true
+	default:
+		return nil, false
+	}
 }
 
 func getString(m map[string]any, key string) string {

--- a/internal/config/decode_test.go
+++ b/internal/config/decode_test.go
@@ -1,0 +1,134 @@
+package config //nolint:testpackage // exercises unexported decodeHooks directly
+
+// decodeHooks reads the [hooks] table out of a map keyed by whatever the user
+// typed, so the shape the TOML decoder hands it is load-bearing in a way the
+// compiler cannot check: an inline array arrives as []any, [[hooks.on_x]]
+// tables arrive as []map[string]any, and an unrecognized key can hold
+// anything at all. Getting that wrong silently drops hooks -- which is the
+// failure mode this whole table exists to prevent.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// decodeTOMLHooks runs src through the same decode path Load uses and returns
+// the resulting hooks plus any error.
+func decodeTOMLHooks(t *testing.T, src string) (HooksConfig, error) {
+	t.Helper()
+
+	var raw rawConfig
+
+	_, err := toml.Decode(src, &raw)
+	if err != nil {
+		t.Fatalf("toml.Decode rejected the fixture: %v", err)
+	}
+
+	return decodeHooks(raw.Hooks)
+}
+
+func TestDecodeHooks_AcceptsEveryHookSpelling(t *testing.T) {
+	t.Parallel()
+
+	hooks, err := decodeTOMLHooks(t, `
+[hooks]
+on_app_activate = ["echo inline-string", { run = "echo inline-table", app = "Safari" }]
+
+[[hooks.on_app_quit]]
+run = "echo array-of-tables"
+async = true
+`)
+	if err != nil {
+		t.Fatalf("decodeHooks: %v", err)
+	}
+
+	if len(hooks.AppActivate) != 2 {
+		t.Errorf("on_app_activate: got %d entries, want 2", len(hooks.AppActivate))
+	}
+
+	if hooks.AppActivate[0].Run != "echo inline-string" {
+		t.Errorf("inline string entry: got %q", hooks.AppActivate[0].Run)
+	}
+
+	if hooks.AppActivate[1].App != "Safari" {
+		t.Errorf("inline table entry lost its app filter: got %q", hooks.AppActivate[1].App)
+	}
+
+	// [[hooks.on_x]] decodes to []map[string]any rather than []any. A decoder
+	// that only understands []any drops these entirely and reports success.
+	if len(hooks.AppQuit) != 1 {
+		t.Fatalf(
+			"on_app_quit ([[hooks.on_app_quit]] form): got %d entries, want 1",
+			len(hooks.AppQuit),
+		)
+	}
+
+	if hooks.AppQuit[0].Run != "echo array-of-tables" {
+		t.Errorf("array-of-tables entry: got %q", hooks.AppQuit[0].Run)
+	}
+
+	if !hooks.AppQuit[0].Async {
+		t.Error("array-of-tables entry lost async = true")
+	}
+}
+
+func TestDecodeHooks_ToleratesUnrecognizedKeysWhateverTheyHold(t *testing.T) {
+	t.Parallel()
+
+	// An unrecognized hook key is currently ignored, whatever its value. That
+	// is a real defect -- the user's typo'd hook never fires and nothing says
+	// so -- but rejecting it is a user-visible change reserved for a separate
+	// fix. This test pins the current behavior so the decoder does not start
+	// hard-failing on it by accident.
+	for _, value := range []string{`"echo x"`, `42`, `{ run = "echo x" }`, `["echo x"]`, `true`} {
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
+			hooks, err := decodeTOMLHooks(
+				t,
+				"[hooks]\non_app_activate = [\"echo real\"]\non_bogus = "+value+"\n",
+			)
+			if err != nil {
+				t.Fatalf("unrecognized key %s should be ignored, got: %v", value, err)
+			}
+
+			if len(hooks.AppActivate) != 1 {
+				t.Errorf(
+					"recognized hook alongside %s: got %d entries, want 1",
+					value,
+					len(hooks.AppActivate),
+				)
+			}
+		})
+	}
+}
+
+func TestDecodeHooks_RejectsARecognizedKeyThatIsNotAList(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeTOMLHooks(t, "[hooks]\non_app_activate = \"echo not-a-list\"\n")
+	if err == nil {
+		t.Fatal("expected an error for a non-list hook value, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "on_app_activate") {
+		t.Errorf("error should name the offending key, got: %v", err)
+	}
+}
+
+func TestDecodeHooks_AbsentKeysDecodeToNothing(t *testing.T) {
+	t.Parallel()
+
+	hooks, err := decodeTOMLHooks(t, "[hooks]\n")
+	if err != nil {
+		t.Fatalf("an empty [hooks] table is valid: %v", err)
+	}
+
+	for _, kind := range HookKinds {
+		if entries := *kind.Entries(&hooks); len(entries) != 0 {
+			t.Errorf("%s: got %d entries from an empty table, want 0", kind.TOMLKey, len(entries))
+		}
+	}
+}

--- a/internal/config/kinds.go
+++ b/internal/config/kinds.go
@@ -1,0 +1,139 @@
+package config
+
+import "github.com/y3owk1n/mimi/internal/events"
+
+// HookGroup classifies a hook kind by the macOS observer machinery it needs,
+// mirroring the three sections users already see in docs/CONFIGURATION.md:
+// "Application Lifecycle", "Window events (requires Accessibility)" and
+// "Workspace events".
+//
+// The group says which kinds belong together, not which observers the daemon
+// switches on for them — that mapping is a policy decision (window hooks also
+// need the app-lifecycle observer, because AX observers attach per process and
+// rely on launch/terminate notifications to attach and detach) and lives in
+// internal/daemon, where it can be read alongside its reason.
+type HookGroup int
+
+// The hook groups. Every HookKind belongs to exactly one.
+const (
+	// GroupApp covers the app lifecycle kinds, which need no extra permission.
+	GroupApp HookGroup = iota
+	// GroupWindow covers the window kinds, which require Accessibility.
+	GroupWindow
+	// GroupWorkspace covers the Space/Desktop kinds.
+	GroupWorkspace
+)
+
+// HookKind describes one hookable event kind as it appears in config: the
+// events.EventKind it publishes as, the TOML key users write under [hooks],
+// its group, and an accessor to its slice inside a HooksConfig.
+type HookKind struct {
+	// Kind is the event kind published on the bus and matched by the registry.
+	Kind events.EventKind
+	// TOMLKey is the key users write under [hooks] in their config file.
+	TOMLKey string
+	// Group classifies the kind; see HookGroup.
+	Group HookGroup
+	// Entries returns a pointer to this kind's entries inside a HooksConfig,
+	// so both decoding (write) and every enumeration (read) can fold over the
+	// same table rather than restating the twelve field names.
+	Entries func(*HooksConfig) *[]HookEntry
+}
+
+// HookKinds is the single source of truth for the hookable event kinds on the
+// config side. Decoding, validation, the hook registry's kind map and the
+// daemon's observer wiring are all folds over this slice, so adding a kind is
+// one row plus one HooksConfig field rather than an edit in six places.
+//
+// The order matches HooksConfig's field order, which is also the order used by
+// configs/default-config.toml and docs/CONFIGURATION.md. It is user-visible:
+// hook errors are reported in this order.
+//
+// The cross-language boundary is a separate concern. eventkinds.h, kindFromInt
+// and internal/native/eventkinds_test.go own the C enum's agreement with
+// events.EventKind, including the kinds deliberately not routed to Go.
+var HookKinds = []HookKind{
+	{
+		Kind:    events.AppActivate,
+		TOMLKey: "on_app_activate",
+		Group:   GroupApp,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.AppActivate },
+	},
+	{
+		Kind:    events.AppDeactivate,
+		TOMLKey: "on_app_deactivate",
+		Group:   GroupApp,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.AppDeactivate },
+	},
+	{
+		Kind:    events.AppLaunch,
+		TOMLKey: "on_app_launch",
+		Group:   GroupApp,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.AppLaunch },
+	},
+	{
+		Kind:    events.AppQuit,
+		TOMLKey: "on_app_quit",
+		Group:   GroupApp,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.AppQuit },
+	},
+	{
+		Kind:    events.AppHide,
+		TOMLKey: "on_app_hide",
+		Group:   GroupApp,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.AppHide },
+	},
+	{
+		Kind:    events.AppUnhide,
+		TOMLKey: "on_app_unhide",
+		Group:   GroupApp,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.AppUnhide },
+	},
+	{
+		Kind:    events.WindowFocus,
+		TOMLKey: "on_window_focus",
+		Group:   GroupWindow,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.WindowFocus },
+	},
+	{
+		Kind:    events.WindowTitleChange,
+		TOMLKey: "on_window_title_change",
+		Group:   GroupWindow,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.WindowTitleChange },
+	},
+	{
+		Kind:    events.WindowCreated,
+		TOMLKey: "on_window_created",
+		Group:   GroupWindow,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.WindowCreated },
+	},
+	{
+		Kind:    events.WindowClosed,
+		TOMLKey: "on_window_closed",
+		Group:   GroupWindow,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.WindowClosed },
+	},
+	{
+		Kind:    events.WindowResize,
+		TOMLKey: "on_window_resize",
+		Group:   GroupWindow,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.WindowResize },
+	},
+	{
+		Kind:    events.WorkspaceChanged,
+		TOMLKey: "on_workspace_changed",
+		Group:   GroupWorkspace,
+		Entries: func(h *HooksConfig) *[]HookEntry { return &h.WorkspaceChanged },
+	},
+}
+
+// HasGroup reports whether at least one hook is defined in group.
+func (h *HooksConfig) HasGroup(group HookGroup) bool {
+	for _, kind := range HookKinds {
+		if kind.Group == group && len(*kind.Entries(h)) > 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/config/kinds_test.go
+++ b/internal/config/kinds_test.go
@@ -1,0 +1,168 @@
+package config //nolint:testpackage // asserts HookKinds against unexported decode internals
+
+// HookKinds is a hand-written slice, so a kind added to HooksConfig without a
+// matching row compiles fine and then silently never fires -- the same failure
+// mode that once left half of a user's hooks uncounted. These tests are the
+// check the compiler cannot give: they pin the table against the two
+// independent enumerations of the same twelve kinds, HooksConfig's fields and
+// events.AllKinds.
+//
+// internal/hooks and internal/observe deliberately keep their own local kind
+// lists in tests for the same reason; folding those onto HookKinds would leave
+// the table checking itself.
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+// runTrue is a harmless hook command; these tests only care that an entry
+// exists, never what it runs.
+const runTrue = "true"
+
+func TestHookKinds_CoversEveryHooksConfigField(t *testing.T) {
+	t.Parallel()
+
+	hooksType := reflect.TypeFor[HooksConfig]()
+
+	if len(HookKinds) != hooksType.NumField() {
+		t.Fatalf(
+			"HookKinds has %d rows but HooksConfig has %d fields; a kind was added to one and not the other",
+			len(HookKinds),
+			hooksType.NumField(),
+		)
+	}
+
+	// Every row must point at a distinct field, so a copy-pasted row that
+	// forgot to change its accessor fails here rather than shadowing a kind.
+	var cfg HooksConfig
+
+	seen := make(map[*[]HookEntry]events.EventKind, len(HookKinds))
+
+	for _, kind := range HookKinds {
+		ptr := kind.Entries(&cfg)
+		if other, dup := seen[ptr]; dup {
+			t.Errorf("%q and %q resolve to the same HooksConfig field", kind.Kind, other)
+		}
+
+		seen[ptr] = kind.Kind
+	}
+}
+
+func TestHookKinds_RowOrderMatchesHooksConfigFieldOrder(t *testing.T) {
+	t.Parallel()
+
+	// The order is user-visible: hook errors are reported in it. Pin it to
+	// HooksConfig's field order, which is also the order of
+	// configs/default-config.toml and docs/CONFIGURATION.md.
+	hooksType := reflect.TypeFor[HooksConfig]()
+
+	for idx, kind := range HookKinds {
+		if idx >= hooksType.NumField() {
+			break
+		}
+
+		field := hooksType.Field(idx)
+
+		got := field.Tag.Get("toml")
+		if got != kind.TOMLKey {
+			t.Errorf(
+				"HookKinds[%d] is %q but HooksConfig field %d (%s) has toml tag %q",
+				idx, kind.TOMLKey, idx, field.Name, got,
+			)
+		}
+	}
+}
+
+func TestHookKinds_CoversEveryHookableEventKind(t *testing.T) {
+	t.Parallel()
+
+	rows := make(map[events.EventKind]struct{}, len(HookKinds))
+	for _, kind := range HookKinds {
+		rows[kind.Kind] = struct{}{}
+	}
+
+	for _, kind := range events.AllKinds {
+		if _, ok := rows[kind]; !ok {
+			t.Errorf("events.AllKinds has %q, which has no row in HookKinds", kind)
+		}
+	}
+
+	for kind := range rows {
+		found := slices.Contains(events.AllKinds, kind)
+
+		if !found {
+			t.Errorf("HookKinds has %q, which is not in events.AllKinds", kind)
+		}
+	}
+}
+
+func TestHookKinds_TOMLKeysAreUniqueAndPrefixed(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]struct{}, len(HookKinds))
+
+	for _, kind := range HookKinds {
+		if _, dup := seen[kind.TOMLKey]; dup {
+			t.Errorf("duplicate TOML key %q", kind.TOMLKey)
+		}
+
+		seen[kind.TOMLKey] = struct{}{}
+
+		if want := "on_" + string(kind.Kind); want != kind.TOMLKey {
+			t.Errorf("kind %q has TOML key %q, want %q", kind.Kind, kind.TOMLKey, want)
+		}
+	}
+}
+
+func TestHooksConfig_HasGroup(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		hooks HooksConfig
+		group HookGroup
+		want  bool
+	}{
+		{"empty config, app group", HooksConfig{}, GroupApp, false},
+		{"empty config, window group", HooksConfig{}, GroupWindow, false},
+		{
+			"app hook counts for app group",
+			HooksConfig{AppActivate: []HookEntry{{Run: runTrue}}},
+			GroupApp,
+			true,
+		},
+		{
+			"app hook does not count for window group",
+			HooksConfig{AppActivate: []HookEntry{{Run: runTrue}}},
+			GroupWindow,
+			false,
+		},
+		{
+			"window resize counts for window group",
+			HooksConfig{WindowResize: []HookEntry{{Run: runTrue}}},
+			GroupWindow,
+			true,
+		},
+		{
+			"workspace hook counts for workspace group",
+			HooksConfig{WorkspaceChanged: []HookEntry{{Run: runTrue}}},
+			GroupWorkspace,
+			true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			hooks := testCase.hooks
+			if got := hooks.HasGroup(testCase.group); got != testCase.want {
+				t.Errorf("HasGroup(%v) = %v, want %v", testCase.group, got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/y3owk1n/mimi/configs"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
-	"github.com/y3owk1n/mimi/internal/events"
 	"github.com/y3owk1n/mimi/internal/paths"
 )
 
@@ -188,10 +187,13 @@ func validate(cfg *Config) error {
 		errs = append(errs, "settings.resize_debounce_ms must be >= 0")
 	}
 
-	for kind, entries := range allHookEntries(cfg) {
-		for i, e := range entries {
+	// HookKinds is a slice, so these errors come out in its declared order.
+	// The map this replaced meant validate reported the same broken config in
+	// a different order on every run.
+	for _, kind := range HookKinds {
+		for i, e := range *kind.Entries(&cfg.Hooks) {
 			if e.Run == "" {
-				errs = append(errs, fmt.Sprintf("hooks.%s[%d]: run command is empty", kind, i))
+				errs = append(errs, fmt.Sprintf("hooks.%s[%d]: run command is empty", kind.Kind, i))
 			}
 		}
 	}
@@ -205,23 +207,6 @@ func validate(cfg *Config) error {
 	}
 
 	return nil
-}
-
-func allHookEntries(cfg *Config) map[string][]HookEntry {
-	return map[string][]HookEntry{
-		string(events.AppActivate):       cfg.Hooks.AppActivate,
-		string(events.AppDeactivate):     cfg.Hooks.AppDeactivate,
-		string(events.AppLaunch):         cfg.Hooks.AppLaunch,
-		string(events.AppQuit):           cfg.Hooks.AppQuit,
-		string(events.AppHide):           cfg.Hooks.AppHide,
-		string(events.AppUnhide):         cfg.Hooks.AppUnhide,
-		string(events.WindowFocus):       cfg.Hooks.WindowFocus,
-		string(events.WindowTitleChange): cfg.Hooks.WindowTitleChange,
-		string(events.WindowCreated):     cfg.Hooks.WindowCreated,
-		string(events.WindowClosed):      cfg.Hooks.WindowClosed,
-		string(events.WindowResize):      cfg.Hooks.WindowResize,
-		string(events.WorkspaceChanged):  cfg.Hooks.WorkspaceChanged,
-	}
 }
 
 func expandPaths(cfg *Config) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -360,28 +360,24 @@ func removePID(path string) {
 }
 
 func hasWindowEvents(cfg *config.Config) bool {
-	return len(cfg.Hooks.WindowFocus) > 0 ||
-		len(cfg.Hooks.WindowTitleChange) > 0 ||
-		len(cfg.Hooks.WindowCreated) > 0 ||
-		len(cfg.Hooks.WindowClosed) > 0 ||
-		len(cfg.Hooks.WindowResize) > 0
+	return cfg.Hooks.HasGroup(config.GroupWindow)
 }
 
 func hasAppEvents(cfg *config.Config) bool {
-	return len(cfg.Hooks.AppActivate) > 0 ||
-		len(cfg.Hooks.AppDeactivate) > 0 ||
-		len(cfg.Hooks.AppLaunch) > 0 ||
-		len(cfg.Hooks.AppQuit) > 0 ||
-		len(cfg.Hooks.AppHide) > 0 ||
-		len(cfg.Hooks.AppUnhide) > 0
+	return cfg.Hooks.HasGroup(config.GroupApp)
 }
 
 func hasWorkspaceEvents(cfg *config.Config) bool {
-	return len(cfg.Hooks.WorkspaceChanged) > 0
+	return cfg.Hooks.HasGroup(config.GroupWorkspace)
 }
 
 func getObserverConfig(cfg *config.Config) native.ObserverConfig {
 	return native.ObserverConfig{
+		// Window hooks need the app-lifecycle observer too, not just the AX
+		// observers: AX observers attach per process, so the daemon relies on
+		// launch and terminate notifications to attach and detach them. This
+		// union is policy, which is why it lives here rather than as a column
+		// on config.HookKinds.
 		AppLifecycle: hasWindowEvents(cfg) || hasAppEvents(cfg),
 		Workspace:    hasWorkspaceEvents(cfg),
 	}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -64,8 +64,3 @@ type Event struct {
 	At          time.Time         `json:"at"`
 	Extra       map[string]string `json:"extra,omitempty"`
 }
-
-// Publisher is the interface for publishing events to the bus.
-type Publisher interface {
-	Publish(e Event)
-}

--- a/internal/hooks/registry.go
+++ b/internal/hooks/registry.go
@@ -86,24 +86,15 @@ func (h *Hook) Matches(evt events.Event) (bool, string) {
 
 func buildMap(cfg *config.Config) (map[events.EventKind][]Hook, error) {
 	hookMap := make(map[events.EventKind][]Hook)
-	entries := map[events.EventKind][]config.HookEntry{
-		events.AppActivate:       cfg.Hooks.AppActivate,
-		events.AppDeactivate:     cfg.Hooks.AppDeactivate,
-		events.AppLaunch:         cfg.Hooks.AppLaunch,
-		events.AppQuit:           cfg.Hooks.AppQuit,
-		events.AppHide:           cfg.Hooks.AppHide,
-		events.AppUnhide:         cfg.Hooks.AppUnhide,
-		events.WindowFocus:       cfg.Hooks.WindowFocus,
-		events.WindowTitleChange: cfg.Hooks.WindowTitleChange,
-		events.WindowCreated:     cfg.Hooks.WindowCreated,
-		events.WindowClosed:      cfg.Hooks.WindowClosed,
-		events.WindowResize:      cfg.Hooks.WindowResize,
-		events.WorkspaceChanged:  cfg.Hooks.WorkspaceChanged,
-	}
 
-	for kind, hookEntries := range entries {
+	// Folding over config.HookKinds rather than a locally built map also
+	// settles which error a config with several bad patterns reports. This
+	// returns on the first failure; ranging a map made "first" mean first in
+	// the map's random iteration order, so the same config could blame a
+	// different pattern on each run. It is now the first one in the file.
+	for _, kind := range config.HookKinds {
 		var hooks []Hook
-		for _, entry := range hookEntries {
+		for _, entry := range *kind.Entries(&cfg.Hooks) {
 			hook := Hook{Entry: entry}
 			if entry.Title != "" {
 				re, err := regexp.Compile(entry.Title)
@@ -136,7 +127,7 @@ func buildMap(cfg *config.Config) (map[events.EventKind][]Hook, error) {
 		}
 
 		if len(hooks) > 0 {
-			hookMap[kind] = hooks
+			hookMap[kind.Kind] = hooks
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR reworks how mimi knows which hook kinds exist. The twelve hookable event
kinds were written out by hand in six different places, with nothing checking
that the six lists agreed. Adding a kind meant finding all six; missing one
produced a hook that quietly never fired, which is exactly how the app hooks
went uncounted by `mimi config validate` a while back.

There is now one table that every one of those places derives from, so adding a
kind is a single edit. No hook kinds are added, removed or renamed, and every
config file that worked before works the same way after.

Two things a user can see do change, both because the code no longer walks a Go
map to produce them — see below.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no configuration key, command, flag or hook variable changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Changed output

No configuration surface changes. Three differences are visible from the command
line, all of them in error output:

**1. `mimi config validate` now reports hook errors in a stable order.** It used
to range over a map, so the same broken config printed its errors in a different
order on every run. They now come out in config-file order — app hooks, window
hooks, then workspace. Same messages, same exit code.

**2. A config with several bad `app` / `bundle_id` / `title` patterns now names
the first bad one in the file.** Loading stops at the first pattern that fails to
compile, and that "first" used to be whichever the map happened to yield.

**3. A recognised hook key holding something other than an array reports
differently.** Both before and after, a config like `on_app_activate = "echo hi"`
is rejected with a `SERIALIZATION_FAILED` error, so no config changes from
working to broken. Only the text differs:

```
before: parsing config: toml: line 2 (last key "hooks.on_app_activate"):
        incompatible types: TOML value has type string; destination has type slice
after:  decoding hooks: hook decode errors:
          - on_app_activate: expected an array of hooks, got string
```

The new message names the offending key but drops the line number.

## Potential breaking changes

Nothing that breaks a working config, a hook script, or a command invocation.
The one thing worth flagging: anything that scrapes `mimi config validate`
stderr and depends on the *order* of the error lines, or on the exact wording of
the third case above, would need updating. Ordering was previously random per
run, so a dependency on it could not have been reliable in the first place.

## Additional Context

An unrecognised key under `[hooks]` — a typo like `on_window_focussed` — is still
silently ignored, and `mimi config validate` still reports the config as valid.
That is a real defect and it is deliberately left alone here so this change stays
a refactor; a follow-up `fix` PR will reject it, name the key, and exit non-zero.
Tests in this PR pin the current tolerant behaviour so the decoder cannot start
hard-failing on it by accident in the meantime.

The C-side event kind enum and its agreement with the Go constants are untouched.
That boundary already has a test that reads the header as a fixture and forces a
conscious decision about any new constant, which defends it better than folding
it into this table would.

Three new test files check the table against the two independent enumerations
that remain — the hooks config struct's fields and the exported list of kinds —
plus the shapes the TOML decoder produces for a hook list. The last of those
matters more than it looks: an inline array and a sequence of `[[hooks.on_x]]`
tables arrive as different Go types, and handling only one of them silently drops
every hook written the other way.
