### PR TITLE
fix(config,cli,daemon): reject unrecognised hook keys and unify hook validation errors

### DIFF
--- a/cmd/mimi/cmd/config.go
+++ b/cmd/mimi/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -118,8 +119,10 @@ func newConfigValidateCmd(state *cliState) *cobra.Command {
 		Short: "Parse and validate the config file, reporting any errors",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := config.Load(state.configPath)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Config invalid:\n  %s\n", err)
+
+			problems := configProblems(cfg, err)
+			if problems != "" {
+				fmt.Fprint(os.Stderr, problems)
 				os.Exit(1)
 			}
 
@@ -129,6 +132,49 @@ func newConfigValidateCmd(state *cliState) *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// configProblems renders everything wrong with a loaded config as the text
+// `mimi config validate` prints, or "" when there is nothing wrong.
+//
+// It takes both results of config.Load because the two kinds of problem arrive
+// separately: a failed check comes back as the error, while a hook key mimi
+// does not recognize is recorded on the config, which Load still returns when
+// validation fails. Reporting them together is the point -- a user fixing a
+// typo should not have to fix an unrelated error first to discover it.
+func configProblems(cfg *config.Config, loadErr error) string {
+	var unknown []string
+	if cfg != nil {
+		unknown = cfg.UnknownHookKeys
+	}
+
+	if loadErr == nil && len(unknown) == 0 {
+		return ""
+	}
+
+	var report strings.Builder
+
+	report.WriteString("Config invalid:\n")
+
+	if loadErr != nil {
+		fmt.Fprintf(&report, "  %s\n", loadErr)
+	}
+
+	// A hook kind mimi does not know is a hook that will never fire. The
+	// daemon carries on without it; validate exists to say so.
+	for _, key := range unknown {
+		fmt.Fprintf(&report, "  hooks.%s: not a recognized hook kind\n", key)
+	}
+
+	if len(unknown) > 0 {
+		fmt.Fprintf(
+			&report,
+			"\nRecognized hook kinds:\n  %s\n",
+			strings.Join(config.HookKindNames(), "\n  "),
+		)
+	}
+
+	return report.String()
 }
 
 // countHooks totals the hooks the config carries, across every kind.

--- a/cmd/mimi/cmd/config_problems_test.go
+++ b/cmd/mimi/cmd/config_problems_test.go
@@ -1,0 +1,81 @@
+//nolint:testpackage // tests configProblems, an unexported function
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// configProblems is where `mimi config validate` decides whether to fail, so
+// this is what pins the exit-1 contract. The command itself is a thin shell
+// that prints this text and calls os.Exit, which a test cannot survive.
+
+func TestConfigProblems_SaysNothingAboutAGoodConfig(t *testing.T) {
+	t.Parallel()
+
+	if got := configProblems(&config.Config{}, nil); got != "" {
+		t.Errorf("a good config should produce no report, got %q", got)
+	}
+}
+
+func TestConfigProblems_NamesAnUnrecognizedKeyAndListsTheValidOnes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{UnknownHookKeys: []string{"on_window_focussed"}}
+
+	got := configProblems(cfg, nil)
+	if got == "" {
+		t.Fatal("an unrecognized hook key must be reported")
+	}
+
+	if !strings.Contains(got, "hooks.on_window_focussed: not a recognized hook kind") {
+		t.Errorf("report should name the key the user typed, got:\n%s", got)
+	}
+
+	// The suggestion is the whole point: it turns "wrong" into "here is right".
+	for _, name := range config.HookKindNames() {
+		if !strings.Contains(got, name) {
+			t.Errorf("report should list the recognized kind %q, got:\n%s", name, got)
+		}
+	}
+}
+
+// TestConfigProblems_ReportsAnUnrecognizedKeyAlongsideOtherErrors is the
+// regression guard for the reason Load returns a config with its validation
+// error. Reporting only the error hides the typo until the user fixes
+// something unrelated and runs again -- which is the silent-drop defect this
+// whole change exists to remove, wearing a different hat.
+func TestConfigProblems_ReportsAnUnrecognizedKeyAlongsideOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{UnknownHookKeys: []string{"on_window_focussed"}}
+	loadErr := derrors.New(
+		derrors.CodeInvalidConfig,
+		"hooks.on_app_activate[0]: run command is empty",
+	)
+
+	got := configProblems(cfg, loadErr)
+
+	if !strings.Contains(got, "run command is empty") {
+		t.Errorf("report should carry the load error, got:\n%s", got)
+	}
+
+	if !strings.Contains(got, "hooks.on_window_focussed: not a recognized hook kind") {
+		t.Errorf("report should name the unrecognized key too, got:\n%s", got)
+	}
+}
+
+func TestConfigProblems_ToleratesANilConfig(t *testing.T) {
+	t.Parallel()
+
+	// Load returns a nil config for failures earlier than validation.
+	loadErr := derrors.New(derrors.CodeConfigIOFailed, "reading config")
+
+	got := configProblems(nil, loadErr)
+	if !strings.Contains(got, "reading config") {
+		t.Errorf("report should carry the load error, got:\n%s", got)
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -208,7 +208,22 @@ Create a default config at `~/.config/mimi/config.toml`.
 
 ### `mimi config validate`
 
-Parse and validate the config file.
+Parse and validate the config file. Exits 0 and prints the hook count when the
+config is good, exits 1 and prints the problems to stderr when it is not.
+
+A key under `[hooks]` that names no hook kind is a failure here — it is a hook
+that would never fire. The daemon is more forgiving: it logs a warning and runs
+with the hooks it did understand, so a typo does not stop mimi from starting.
+
+```
+$ mimi config validate
+Config invalid:
+  hooks.on_window_focussed: not a recognized hook kind
+
+Recognized hook kinds:
+  on_app_activate
+  ...
+```
 
 ### `mimi config dump`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -118,6 +118,11 @@ show_workspace_number = true   # show active space number in menu bar — restar
 
 ## Hooks
 
+The hook kinds below are the complete set — `[hooks]` accepts no other keys. A
+key that is not one of them is a hook that can never fire, so `mimi config
+validate` rejects it and the daemon logs a warning at startup and on reload
+while running the hooks it did understand.
+
 ### Application Lifecycle
 
 | Hook | Fires when |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
@@ -12,6 +13,14 @@ type Config struct {
 	Settings SettingsConfig `json:"settings" toml:"settings"`
 	Hooks    HooksConfig    `json:"hooks"    toml:"hooks"`
 	Systray  SystrayConfig  `json:"systray"  toml:"systray"`
+
+	// UnknownHookKeys lists the keys found under [hooks] that name no hook
+	// kind, sorted. Loading records them rather than reporting them so each
+	// caller can decide: the daemon warns and carries on with the hooks it did
+	// understand, while `mimi config validate` names them and fails. It is not
+	// part of the config file, so it carries no toml tag, and it is excluded
+	// from JSON so `mimi config dump` keeps printing the config as written.
+	UnknownHookKeys []string `json:"-" toml:"-"`
 }
 
 // SettingsConfig holds the [settings] section of the config.
@@ -81,7 +90,14 @@ type rawSystrayConfig struct {
 	ShowWorkspaceNumber *bool `json:"showWorkspaceNumber" toml:"show_workspace_number"`
 }
 
-func decodeHooks(raw rawHooksConfig) (HooksConfig, error) {
+// decodeHooks turns the raw [hooks] table into a HooksConfig, and also returns
+// the keys it did not recognize so the caller can decide what to do about them.
+//
+// It reports only structural problems -- a key that is not a list, an entry
+// that is neither a string nor a table. Whether a decoded entry actually says
+// what to run is validate's business, so that a hook with no command reads the
+// same however it was written.
+func decodeHooks(raw rawHooksConfig) (HooksConfig, []string, error) {
 	var (
 		hooksCfg HooksConfig
 		errs     []string
@@ -108,20 +124,21 @@ func decodeHooks(raw rawHooksConfig) (HooksConfig, error) {
 					entry.Async = async
 				}
 
-				if entry.Run == "" {
-					errs = append(errs, fmt.Sprintf("%s[%d]: 'run' field is required", field, idx))
-				}
-
 				entries = append(entries, entry)
 			default:
 				errs = append(
 					errs,
-					fmt.Sprintf("%s[%d]: expected string or table, got %T", field, idx, item),
+					fmt.Sprintf("hooks.%s[%d]: expected string or table, got %T", field, idx, item),
 				)
 			}
 		}
 
 		return entries
+	}
+
+	recognized := make(map[string]struct{}, len(HookKinds))
+	for _, name := range HookKindNames() {
+		recognized[name] = struct{}{}
 	}
 
 	for _, kind := range HookKinds {
@@ -130,7 +147,7 @@ func decodeHooks(raw rawHooksConfig) (HooksConfig, error) {
 			errs = append(
 				errs,
 				fmt.Sprintf(
-					"%s: expected an array of hooks, got %T",
+					"hooks.%s: expected an array of hooks, got %T",
 					kind.TOMLKey,
 					raw[kind.TOMLKey],
 				),
@@ -142,15 +159,27 @@ func decodeHooks(raw rawHooksConfig) (HooksConfig, error) {
 		*kind.Entries(&hooksCfg) = decodeField(kind.TOMLKey, items)
 	}
 
+	var unknown []string
+
+	for key := range raw {
+		if _, ok := recognized[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+
+	// Map iteration order is random; sort so a config with several typos
+	// reports them the same way on every run.
+	slices.Sort(unknown)
+
 	if len(errs) > 0 {
-		return hooksCfg, derrors.Newf(
+		return hooksCfg, unknown, derrors.Newf(
 			derrors.CodeInvalidConfig,
 			"hook decode errors:\n  - %s",
 			strings.Join(errs, "\n  - "),
 		)
 	}
 
-	return hooksCfg, nil
+	return hooksCfg, unknown, nil
 }
 
 // rawHookItems normalizes the two shapes the TOML decoder produces for a hook

--- a/internal/config/decode_test.go
+++ b/internal/config/decode_test.go
@@ -8,15 +8,19 @@ package config //nolint:testpackage // exercises unexported decodeHooks directly
 // failure mode this whole table exists to prevent.
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
 
 // decodeTOMLHooks runs src through the same decode path Load uses and returns
-// the resulting hooks plus any error.
-func decodeTOMLHooks(t *testing.T, src string) (HooksConfig, error) {
+// the resulting hooks, the keys it did not recognize, and any error.
+func decodeTOMLHooks(t *testing.T, src string) (HooksConfig, []string, error) {
 	t.Helper()
 
 	var raw rawConfig
@@ -29,10 +33,25 @@ func decodeTOMLHooks(t *testing.T, src string) (HooksConfig, error) {
 	return decodeHooks(raw.Hooks)
 }
 
+// writeConfig writes src to a temp file and returns its path, for tests that
+// need to go through Load rather than decodeHooks directly.
+func writeConfig(t *testing.T, src string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+
+	err := os.WriteFile(path, []byte(src), 0o600)
+	if err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	return path
+}
+
 func TestDecodeHooks_AcceptsEveryHookSpelling(t *testing.T) {
 	t.Parallel()
 
-	hooks, err := decodeTOMLHooks(t, `
+	hooks, unknown, err := decodeTOMLHooks(t, `
 [hooks]
 on_app_activate = ["echo inline-string", { run = "echo inline-table", app = "Safari" }]
 
@@ -42,6 +61,10 @@ async = true
 `)
 	if err != nil {
 		t.Fatalf("decodeHooks: %v", err)
+	}
+
+	if len(unknown) != 0 {
+		t.Errorf("recognized keys reported as unknown: %v", unknown)
 	}
 
 	if len(hooks.AppActivate) != 2 {
@@ -74,24 +97,27 @@ async = true
 	}
 }
 
-func TestDecodeHooks_ToleratesUnrecognizedKeysWhateverTheyHold(t *testing.T) {
+func TestDecodeHooks_ReportsUnrecognizedKeysWhateverTheyHold(t *testing.T) {
 	t.Parallel()
 
-	// An unrecognized hook key is currently ignored, whatever its value. That
-	// is a real defect -- the user's typo'd hook never fires and nothing says
-	// so -- but rejecting it is a user-visible change reserved for a separate
-	// fix. This test pins the current behavior so the decoder does not start
-	// hard-failing on it by accident.
+	// An unrecognized key is named, not rejected here: decoding records it and
+	// leaves the decision to the caller, so the daemon can carry on while
+	// validate fails. Its value is irrelevant -- the key is wrong whatever it
+	// holds, and decoding must not choke on the shape.
 	for _, value := range []string{`"echo x"`, `42`, `{ run = "echo x" }`, `["echo x"]`, `true`} {
 		t.Run(value, func(t *testing.T) {
 			t.Parallel()
 
-			hooks, err := decodeTOMLHooks(
+			hooks, unknown, err := decodeTOMLHooks(
 				t,
 				"[hooks]\non_app_activate = [\"echo real\"]\non_bogus = "+value+"\n",
 			)
 			if err != nil {
-				t.Fatalf("unrecognized key %s should be ignored, got: %v", value, err)
+				t.Fatalf("an unrecognized key should not fail decoding, got: %v", err)
+			}
+
+			if len(unknown) != 1 || unknown[0] != "on_bogus" {
+				t.Errorf("unknown keys: got %v, want [on_bogus]", unknown)
 			}
 
 			if len(hooks.AppActivate) != 1 {
@@ -105,30 +131,128 @@ func TestDecodeHooks_ToleratesUnrecognizedKeysWhateverTheyHold(t *testing.T) {
 	}
 }
 
+func TestDecodeHooks_SortsUnrecognizedKeys(t *testing.T) {
+	t.Parallel()
+
+	_, unknown, err := decodeTOMLHooks(t, `
+[hooks]
+on_zebra = ["echo z"]
+on_apple = ["echo a"]
+on_mango = ["echo m"]
+`)
+	if err != nil {
+		t.Fatalf("decodeHooks: %v", err)
+	}
+
+	want := []string{"on_apple", "on_mango", "on_zebra"}
+	if len(unknown) != len(want) {
+		t.Fatalf("unknown keys: got %v, want %v", unknown, want)
+	}
+
+	for i, key := range want {
+		if unknown[i] != key {
+			t.Fatalf("unknown keys are not sorted: got %v, want %v", unknown, want)
+		}
+	}
+}
+
 func TestDecodeHooks_RejectsARecognizedKeyThatIsNotAList(t *testing.T) {
 	t.Parallel()
 
-	_, err := decodeTOMLHooks(t, "[hooks]\non_app_activate = \"echo not-a-list\"\n")
+	_, _, err := decodeTOMLHooks(t, "[hooks]\non_app_activate = \"echo not-a-list\"\n")
 	if err == nil {
 		t.Fatal("expected an error for a non-list hook value, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "on_app_activate") {
-		t.Errorf("error should name the offending key, got: %v", err)
+	if !strings.Contains(err.Error(), "hooks.on_app_activate") {
+		t.Errorf("error should name the offending key as the user typed it, got: %v", err)
+	}
+}
+
+func TestDecodeHooks_LeavesTheEmptyCommandCheckToValidate(t *testing.T) {
+	t.Parallel()
+
+	// Decoding used to reject a table with no run field while a bare empty
+	// string fell through to validate, so one mistake had two messages and two
+	// error codes depending on how it was written. Decoding now says nothing
+	// about it.
+	_, _, err := decodeTOMLHooks(t, "[hooks]\non_app_activate = [{ app = \"Safari\" }]\n")
+	if err != nil {
+		t.Fatalf("decoding should not judge a missing run command, got: %v", err)
 	}
 }
 
 func TestDecodeHooks_AbsentKeysDecodeToNothing(t *testing.T) {
 	t.Parallel()
 
-	hooks, err := decodeTOMLHooks(t, "[hooks]\n")
+	hooks, unknown, err := decodeTOMLHooks(t, "[hooks]\n")
 	if err != nil {
 		t.Fatalf("an empty [hooks] table is valid: %v", err)
+	}
+
+	if len(unknown) != 0 {
+		t.Errorf("empty table reported unknown keys: %v", unknown)
 	}
 
 	for _, kind := range HookKinds {
 		if entries := *kind.Entries(&hooks); len(entries) != 0 {
 			t.Errorf("%s: got %d entries from an empty table, want 0", kind.TOMLKey, len(entries))
 		}
+	}
+}
+
+func TestLoad_RecordsUnknownHookKeysWithoutFailing(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfig(
+		t,
+		"[hooks]\non_app_activate = [\"echo real\"]\non_window_focussed = [\"echo typo\"]\n",
+	)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("a typo'd hook key must not stop the config loading: %v", err)
+	}
+
+	if len(cfg.UnknownHookKeys) != 1 || cfg.UnknownHookKeys[0] != "on_window_focussed" {
+		t.Errorf("UnknownHookKeys: got %v, want [on_window_focussed]", cfg.UnknownHookKeys)
+	}
+
+	if len(cfg.Hooks.AppActivate) != 1 {
+		t.Errorf(
+			"the recognized hook should still load, got %d entries",
+			len(cfg.Hooks.AppActivate),
+		)
+	}
+}
+
+func TestLoad_NamesEmptyCommandsByTheKeyTheUserTyped(t *testing.T) {
+	t.Parallel()
+
+	// Both spellings of "a hook with no command" must report identically: the
+	// key as written, not the event kind it publishes as.
+	for name, src := range map[string]string{
+		"bare string": "[hooks]\non_app_activate = [\"\"]\n",
+		"table":       "[hooks]\non_app_activate = [{ app = \"Safari\" }]\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Load(writeConfig(t, src))
+			if err == nil {
+				t.Fatal("expected a hook with no command to be rejected")
+			}
+
+			if !strings.Contains(err.Error(), "hooks.on_app_activate[0]: run command is empty") {
+				t.Errorf("got: %v", err)
+			}
+
+			// Same message and same code, whichever way it was written. The
+			// table spelling used to fail during decoding under
+			// CodeSerializationFailed instead.
+			if !derrors.IsCode(err, derrors.CodeInvalidConfig) {
+				t.Errorf("code: got %v, want %v", derrors.GetCode(err), derrors.CodeInvalidConfig)
+			}
+		})
 	}
 }

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -1,0 +1,124 @@
+package config //nolint:testpackage // pins HookKinds against the documented tables
+
+// docs/CONFIGURATION.md lists every hook kind in three tables, one per group.
+// That is a fourth hand-maintained enumeration of the same twelve kinds, and
+// the only one a user actually reads -- a kind missing from it is a feature
+// nobody can find, and a kind listed there but absent from the code is a
+// promise mimi does not keep.
+//
+// The compiler cannot check Markdown, so this test reads the document as a
+// fixture, the same trick internal/native/eventkinds_test.go uses on
+// eventkinds.h. It checks membership and grouping; the prose descriptions in
+// the second column are left to human judgement.
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// hookTableHeadings maps each "### ..." heading in the Hooks section of
+// docs/CONFIGURATION.md onto the group its table documents.
+var hookTableHeadings = map[string]HookGroup{
+	"Application Lifecycle":                  GroupApp,
+	"Window events (requires Accessibility)": GroupWindow,
+	"Workspace events":                       GroupWorkspace,
+}
+
+var (
+	headingRe  = regexp.MustCompile(`(?m)^### (.+)$`)
+	hookRowRe  = regexp.MustCompile("(?m)^\\| `(on_[a-z_]+)` \\|")
+	hooksSecRe = regexp.MustCompile(`(?ms)^## Hooks$.*?^## `)
+)
+
+// documentedHookKinds parses the Hooks section of docs/CONFIGURATION.md into a
+// map of TOML key -> the group whose table it appeared under.
+func documentedHookKinds(t *testing.T) map[string]HookGroup {
+	t.Helper()
+
+	// go test runs with the package directory as the working directory.
+	data, err := os.ReadFile("../../docs/CONFIGURATION.md")
+	if err != nil {
+		t.Fatalf("reading docs/CONFIGURATION.md: %v", err)
+	}
+
+	section := hooksSecRe.FindString(string(data))
+	if section == "" {
+		t.Fatal("docs/CONFIGURATION.md: found no '## Hooks' section; this parser is stale")
+	}
+
+	documented := make(map[string]HookGroup)
+
+	headings := headingRe.FindAllStringSubmatchIndex(section, -1)
+	if len(headings) == 0 {
+		t.Fatal(
+			"docs/CONFIGURATION.md: the Hooks section has no '###' subheadings; this parser is stale",
+		)
+	}
+
+	for idx, heading := range headings {
+		title := section[heading[2]:heading[3]]
+
+		group, wanted := hookTableHeadings[title]
+		if !wanted {
+			continue
+		}
+
+		end := len(section)
+		if idx+1 < len(headings) {
+			end = headings[idx+1][0]
+		}
+
+		for _, row := range hookRowRe.FindAllStringSubmatch(section[heading[1]:end], -1) {
+			if previous, dup := documented[row[1]]; dup {
+				t.Errorf("%s is documented twice (groups %v and %v)", row[1], previous, group)
+			}
+
+			documented[row[1]] = group
+		}
+	}
+
+	return documented
+}
+
+func TestHookKinds_MatchTheDocumentedTables(t *testing.T) {
+	t.Parallel()
+
+	documented := documentedHookKinds(t)
+
+	if len(documented) == 0 {
+		t.Fatal("parsed no hook rows out of docs/CONFIGURATION.md; this parser is stale")
+	}
+
+	for _, kind := range HookKinds {
+		group, ok := documented[kind.TOMLKey]
+		if !ok {
+			t.Errorf("%s is a hook kind but is not listed in docs/CONFIGURATION.md", kind.TOMLKey)
+
+			continue
+		}
+
+		if group != kind.Group {
+			t.Errorf(
+				"%s is documented under the %v table but the code puts it in %v",
+				kind.TOMLKey, group, kind.Group,
+			)
+		}
+	}
+
+	for key := range documented {
+		found := false
+
+		for _, kind := range HookKinds {
+			if kind.TOMLKey == key {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			t.Errorf("docs/CONFIGURATION.md documents %s, which is not a hook kind", key)
+		}
+	}
+}

--- a/internal/config/kinds.go
+++ b/internal/config/kinds.go
@@ -127,6 +127,18 @@ var HookKinds = []HookKind{
 	},
 }
 
+// HookKindNames lists every recognized hook key, in the order HookKinds
+// declares them, which is the order docs/CONFIGURATION.md and the default
+// config use. It is what mimi shows a user who typed a key it does not know.
+func HookKindNames() []string {
+	names := make([]string, 0, len(HookKinds))
+	for _, kind := range HookKinds {
+		names = append(names, kind.TOMLKey)
+	}
+
+	return names
+}
+
 // HasGroup reports whether at least one hook is defined in group.
 func (h *HooksConfig) HasGroup(group HookGroup) bool {
 	for _, kind := range HookKinds {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -88,6 +88,17 @@ func WriteDefault(path string) error {
 }
 
 // Load parses and validates the config from a TOML file.
+//
+// A validation failure returns the config it managed to build alongside the
+// error, so a caller whose job is reporting problems -- `mimi config validate`
+// -- can show everything wrong in one pass instead of one problem per run.
+// That matters for unrecognized hook keys in particular: they are recorded on
+// the config rather than raised as errors, so a config that also fails
+// validation would otherwise hide them until the other error was fixed.
+//
+// Callers that want a usable config must check the error first, as all of them
+// do. Failures before validation -- an unreadable file, malformed TOML, a hook
+// key holding something that is not a list -- return a nil config.
 func Load(path string) (*Config, error) {
 	path = paths.ExpandHome(path)
 
@@ -103,14 +114,15 @@ func Load(path string) (*Config, error) {
 		return nil, derrors.Wrapf(err, derrors.CodeSerializationFailed, "parsing config")
 	}
 
-	hooks, err := decodeHooks(raw.Hooks)
+	hooks, unknownHookKeys, err := decodeHooks(raw.Hooks)
 	if err != nil {
-		return nil, derrors.Wrapf(err, derrors.CodeSerializationFailed, "decoding hooks")
+		return nil, derrors.Wrapf(err, derrors.CodeInvalidConfig, "decoding hooks")
 	}
 
 	cfg := &Config{
-		Settings: raw.Settings,
-		Hooks:    hooks,
+		Settings:        raw.Settings,
+		Hooks:           hooks,
+		UnknownHookKeys: unknownHookKeys,
 	}
 
 	systrayEnabledSet := raw.Systray.Enabled != nil
@@ -126,7 +138,7 @@ func Load(path string) (*Config, error) {
 
 	err = validate(cfg)
 	if err != nil {
-		return nil, err
+		return cfg, err
 	}
 
 	expandPaths(cfg)
@@ -190,10 +202,19 @@ func validate(cfg *Config) error {
 	// HookKinds is a slice, so these errors come out in its declared order.
 	// The map this replaced meant validate reported the same broken config in
 	// a different order on every run.
+	//
+	// Entries are named by the key the user typed, not by the event kind they
+	// publish as, so the error points at a line they can find in their file.
+	// This is the only check on a hook's command: decoding deliberately leaves
+	// it alone so that a hook written as a bare string and one written as a
+	// table report the same way.
 	for _, kind := range HookKinds {
 		for i, e := range *kind.Entries(&cfg.Hooks) {
 			if e.Run == "" {
-				errs = append(errs, fmt.Sprintf("hooks.%s[%d]: run command is empty", kind.Kind, i))
+				errs = append(
+					errs,
+					fmt.Sprintf("hooks.%s[%d]: run command is empty", kind.TOMLKey, i),
+				)
 			}
 		}
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -37,6 +38,8 @@ func Run(cfg *config.Config, logger *zap.SugaredLogger, configPath string, versi
 	)
 
 	runDone := make(chan error, 1)
+
+	warnUnknownHookKeys(cfg, logger)
 
 	reload := func(ctx context.Context, path string) error {
 		process, err := os.FindProcess(os.Getpid())
@@ -274,7 +277,28 @@ func applyReload(
 		return
 	}
 
+	warnUnknownHookKeys(newCfg, logger)
 	logger.Infow("config reloaded", "trigger", trigger)
+}
+
+// warnUnknownHookKeys notes that the config asked for hook kinds mimi does not
+// have. The daemon runs anyway on the hooks it did understand, so this is a
+// warning rather than a refusal to start; `mimi config validate` is the one
+// that fails.
+//
+// The keys themselves stay out of the log -- they are the user's config text.
+// The count says something is wrong and the recognized set says what is
+// allowed, which is enough to send someone to validate.
+func warnUnknownHookKeys(cfg *config.Config, logger *zap.SugaredLogger) {
+	if len(cfg.UnknownHookKeys) == 0 {
+		return
+	}
+
+	logger.Warnw(
+		"config names hook kinds that do not exist; those hooks will never fire",
+		"count", len(cfg.UnknownHookKeys),
+		"recognized", strings.Join(config.HookKindNames(), "|"),
+	)
 }
 
 func runSignalLoop(

--- a/internal/daemon/unknown_hook_keys_test.go
+++ b/internal/daemon/unknown_hook_keys_test.go
@@ -1,0 +1,75 @@
+//nolint:testpackage // tests warnUnknownHookKeys, an unexported function
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/y3owk1n/mimi/internal/config"
+)
+
+// The daemon warns about hook kinds it does not recognize rather than refusing
+// to start: the hooks it did understand still work, and a typo in a config
+// should not take mimi down. `mimi config validate` is the command that fails.
+//
+// The keys themselves are the user's config text, so they stay out of the log
+// under the same rule that keeps window titles and hook commands out of it.
+func TestWarnUnknownHookKeys_CountsWithoutNamingTheKeys(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core).Sugar()
+
+	const typo = "on_window_focussed"
+
+	warnUnknownHookKeys(&config.Config{UnknownHookKeys: []string{typo, "on_another_typo"}}, logger)
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one warning, got %d", len(entries))
+	}
+
+	fields := entries[0].ContextMap()
+
+	count, isInt := fields["count"].(int64)
+	if !isInt || count != 2 {
+		t.Errorf("count field: got %v, want 2", fields["count"])
+	}
+
+	// The recognized set is what makes the warning actionable without naming
+	// what the user typed.
+	recognized, isString := fields["recognized"].(string)
+	if !isString || !strings.Contains(recognized, "on_app_activate") {
+		t.Errorf("recognized field should list the valid keys, got %v", fields["recognized"])
+	}
+
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, typo) {
+			t.Errorf("log message leaked the user's key: %q", entry.Message)
+		}
+
+		for key, val := range entry.ContextMap() {
+			str, isText := val.(string)
+			if isText && strings.Contains(str, typo) {
+				t.Errorf("log field %q leaked the user's key: %q", key, str)
+			}
+		}
+	}
+}
+
+func TestWarnUnknownHookKeys_SaysNothingWhenThereAreNone(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core).Sugar()
+
+	warnUnknownHookKeys(&config.Config{}, logger)
+
+	if got := logs.Len(); got != 0 {
+		t.Errorf("a clean config should log nothing, got %d entries", got)
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a hook typo being invisible. A key under `[hooks]` that named no
hook kind — `on_window_focussed` instead of `on_window_focus` — was read,
dropped, and never mentioned again. The hook never fired, and `mimi config
validate` called the config valid, so there was nothing anywhere to tell you the
hook was dead.

`mimi config validate` now names the key, lists the kinds it does accept, and
exits 1. The daemon still starts: it logs a warning and runs the hooks it did
understand, because a typo in one hook should not take mimi down.

This PR also fixes one mistake reporting two different ways. A hook with no
command failed during decoding when written as a table and during validation
when written as an empty string, with different wording and a different error
code each way. It now reports the same message under the same code however it
was written.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — `docs/CLI.md` and `docs/CONFIGURATION.md`
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config and command surface

No configuration key is added, removed or renamed. `[hooks]` accepts the same
twelve keys as before — the change is that it now accepts *only* those twelve,
where previously anything else was quietly ignored.

`mimi config validate` gains a failure case and a documented exit code:

```
$ mimi config validate
Config invalid:
  hooks.on_window_focussed: not a recognized hook kind

Recognized hook kinds:
  on_app_activate
  on_app_deactivate
  on_app_launch
  on_app_quit
  on_app_hide
  on_app_unhide
  on_window_focus
  on_window_title_change
  on_window_created
  on_window_closed
  on_window_resize
  on_workspace_changed
```

Exit 0 when the config is good, exit 1 when it is not. Both kinds of problem are
reported in the same run, so a typo is not hidden behind an unrelated error.

Hook errors now name the entry by the key as written rather than by the event
kind it publishes as — `hooks.on_app_activate[0]` where it used to say
`hooks.app_activate[0]`. The kind name is still what hook scripts receive in
`mimi_EVENT_KIND`; only config error text changed.

## Potential breaking changes

**A config with an unrecognised `[hooks]` key now fails `mimi config validate`.**
It did not before. Nothing about the daemon changes for such a config — it starts
and behaves exactly as it did, minus the hook that was never running anyway — so
this breaks no working setup. What it can break is a CI step or script that runs
`mimi config validate` and gates on its exit code: a config carrying a typo that
passed yesterday will fail today. That is the point of the change, and the fix is
to correct or delete the key it names.

**Error text and error codes changed for invalid configs.** A hook with no
command now reports `run command is empty` under `INVALID_CONFIG` in both
spellings, where the table spelling previously said `'run' field is required`
under `SERIALIZATION_FAILED`. A hook key holding something that is not an array,
and a malformed entry inside a hook list, also moved from `SERIALIZATION_FAILED`
to `INVALID_CONFIG`. Anything parsing that output or those codes needs updating;
no valid config changes behaviour.

## Additional Context

`config.Load` now returns the config it built alongside a validation error rather
than a nil config. Every caller checks the error first, so nothing else is
affected; it exists so `validate` can report a typo and a failed check in one
pass. Failures earlier than validation — unreadable file, malformed TOML — still
return nil.

The daemon's warning carries the count of unrecognised keys and the accepted set,
never the keys themselves, under the same rule that keeps window titles and hook
commands out of the log. A test asserts the user's key never reaches a log entry.

`docs/CONFIGURATION.md` lists the hook kinds in three tables, which was a fourth
hand-maintained copy of the same list and the only one users read. A test now
parses those tables and checks them against the code — membership and grouping —
the same approach `internal/native/eventkinds_test.go` already uses on
`eventkinds.h`. Renaming a single row in the docs fails it.
