### PR TITLE
refactor(cli,action): validate a space argument in one place

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -129,9 +128,9 @@ Examples:
   mimi action space 1        Focus the first Mission Control space
   mimi action space next     Cycle to the next space (with wrap)
   mimi action space prev     Cycle to the previous space (with wrap)`,
-		Args: validateActionSpaceArgs,
+		Args: validateSpaceArg(action.NameSpace),
 		RunE: func(_ *cobra.Command, args []string) error {
-			spaceArg, err := action.ParseSpaceArg([]string{strings.TrimSpace(args[0])})
+			spaceArg, err := action.ParseSpaceArg(action.NameSpace, args)
 			if err != nil {
 				return err
 			}
@@ -162,9 +161,9 @@ Examples:
   mimi action move_window_to_space 2        Move current window to space 2
   mimi action move_window_to_space next     Move window to next space (with wrap)
   mimi action move_window_to_space prev     Move window to previous space (with wrap)`,
-		Args: validateActionMoveWindowToSpaceArgs,
+		Args: validateSpaceArg(action.NameMoveWindowToSpace),
 		RunE: func(_ *cobra.Command, args []string) error {
-			spaceArg, err := action.ParseSpaceArg([]string{strings.TrimSpace(args[0])})
+			spaceArg, err := action.ParseSpaceArg(action.NameMoveWindowToSpace, args)
 			if err != nil {
 				return err
 			}
@@ -297,71 +296,14 @@ func resizeWindowArgsFromFlags(cobraCmd *cobra.Command, preset string) action.Re
 	}
 }
 
-func validateActionSpaceArgs(_ *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return derrors.Newf(
-			derrors.CodeInvalidInput,
-			"space requires exactly one positional argument: a 1-based number, \"next\", or \"prev\" (e.g., mimi action space 1, mimi action space next)",
-		)
+// validateSpaceArg builds the Args validator for an action that takes one
+// space argument. Cobra keeps rejecting the argument before RunE runs — that
+// is what produces the usage output and the exit code — but the rule it
+// rejects with is action.ParseSpaceArg, the one place that rule lives.
+func validateSpaceArg(name action.Name) cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		_, err := action.ParseSpaceArg(name, args)
+
+		return err
 	}
-
-	raw := strings.TrimSpace(args[0])
-	if raw == "" {
-		return derrors.New(derrors.CodeInvalidInput, "space argument cannot be empty")
-	}
-
-	keywords := map[string]bool{"next": true, "prev": true, "previous": true}
-	if keywords[raw] {
-		return nil
-	}
-
-	return validateActionIndexArgs(args, "space")
-}
-
-func validateActionMoveWindowToSpaceArgs(_ *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return derrors.Newf(
-			derrors.CodeInvalidInput,
-			"move_window_to_space requires exactly one positional argument: a 1-based number, \"next\", or \"prev\" (e.g., mimi action move_window_to_space 1, mimi action move_window_to_space next)",
-		)
-	}
-
-	raw := strings.TrimSpace(args[0])
-	if raw == "" {
-		return derrors.New(derrors.CodeInvalidInput, "space argument cannot be empty")
-	}
-
-	keywords := map[string]bool{"next": true, "prev": true, "previous": true}
-	if keywords[raw] {
-		return nil
-	}
-
-	return validateActionIndexArgs(args, "move_window_to_space")
-}
-
-func validateActionIndexArgs(args []string, actionName string) error {
-	if len(args) != 1 {
-		return derrors.Newf(
-			derrors.CodeInvalidInput,
-			"%s requires exactly one positional argument: the 1-based space number (e.g., mimi action %s 1)",
-			actionName,
-			actionName,
-		)
-	}
-
-	raw := strings.TrimSpace(args[0])
-	if raw == "" {
-		return derrors.New(derrors.CodeInvalidInput, "space number cannot be empty")
-	}
-
-	index, parseErr := strconv.Atoi(raw)
-	if parseErr != nil || index < 1 {
-		return derrors.Newf(
-			derrors.CodeInvalidInput,
-			"space number must be a positive integer, got %q",
-			args[0],
-		)
-	}
-
-	return nil
 }

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -2,10 +2,17 @@
 package cmd
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/y3owk1n/mimi/internal/action"
 )
+
+// actionCommandName is the parent every action subcommand hangs off.
+const actionCommandName = "action"
 
 // resizeFlags parses args against a fresh resize_window flag set and returns
 // the typed payload resizeWindowArgsFromFlags builds from it, without
@@ -124,7 +131,7 @@ func TestResizeWindowArgsFromFlags_CarriesThePresetAndTheOtherFlags(t *testing.T
 func TestFocusWindowCommand_RejectsBackwardWithDirection(t *testing.T) {
 	t.Parallel()
 
-	_, err := runCommand(t, "action", "focus_window", "--backward", "--up")
+	_, err := runCommand(t, actionCommandName, "focus_window", "--backward", "--up")
 	if err == nil {
 		t.Fatal("expected an error combining --backward with a direction flag")
 	}
@@ -136,8 +143,227 @@ func TestFocusWindowCommand_RejectsBackwardWithDirection(t *testing.T) {
 func TestSpaceCommand_RejectsZero(t *testing.T) {
 	t.Parallel()
 
-	_, err := runCommand(t, "action", "space", "0")
+	_, err := runCommand(t, actionCommandName, string(action.NameSpace), "0")
 	if err == nil {
 		t.Fatal("expected an error for space 0")
+	}
+}
+
+// spaceArgValidators pairs each action that takes a space argument with the
+// Args validator its subcommand carries, so a case can be run against both
+// without executing either — the validators reject before RunE, which is what
+// keeps these tests off the real desktop.
+func spaceArgValidators() map[action.Name]cobra.PositionalArgs {
+	return map[action.Name]cobra.PositionalArgs{
+		action.NameSpace:             buildSpaceCommand(&cliState{}).Args,
+		action.NameMoveWindowToSpace: buildMoveWindowToSpaceCommand(&cliState{}).Args,
+	}
+}
+
+// malformedSpaceArgs lists every way a space argument can be malformed: it is
+// neither a positive integer nor one of the accepted keywords.
+func malformedSpaceArgs() []struct {
+	name string
+	args []string
+} {
+	return []struct {
+		name string
+		args []string
+	}{
+		{name: "empty", args: []string{""}},
+		{name: "whitespace only", args: []string{"   "}},
+		{name: "non-numeric", args: []string{"foo"}},
+		{name: "zero", args: []string{"0"}},
+		{name: "negative", args: []string{"-1"}},
+		{name: "no argument", args: nil},
+		{name: "two arguments", args: []string{"1", "2"}},
+	}
+}
+
+// TestSpaceArgValidation_SameWordingForBothActions pins mimi#124: one rule
+// decides what a space argument is, so a malformed one reads the same for
+// space and for move_window_to_space, differing only where the action's own
+// name appears.
+func TestSpaceArgValidation_SameWordingForBothActions(t *testing.T) {
+	t.Parallel()
+
+	validators := spaceArgValidators()
+
+	for _, testCase := range malformedSpaceArgs() {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			spaceErr := validators[action.NameSpace](nil, testCase.args)
+			if spaceErr == nil {
+				t.Fatalf("%s %v: expected an error", action.NameSpace, testCase.args)
+			}
+
+			moveErr := validators[action.NameMoveWindowToSpace](nil, testCase.args)
+			if moveErr == nil {
+				t.Fatalf("%s %v: expected an error", action.NameMoveWindowToSpace, testCase.args)
+			}
+
+			normalized := strings.ReplaceAll(
+				moveErr.Error(),
+				string(action.NameMoveWindowToSpace),
+				string(action.NameSpace),
+			)
+			if normalized != spaceErr.Error() {
+				t.Fatalf(
+					"wording differs beyond the action name:\n space: %s\n  move: %s",
+					spaceErr,
+					moveErr,
+				)
+			}
+		})
+	}
+}
+
+// TestSpaceArgValidation_DelegatesToTheOneRule checks the CLI rejects a
+// malformed space argument with the rule itself — action.ParseSpaceArg —
+// rather than a second copy of it. The CLI's copy used to describe the rule as
+// "a positive integer" alone, so a caller who mistyped "nxt" was told the
+// keywords it had just rejected were not accepted at all.
+func TestSpaceArgValidation_DelegatesToTheOneRule(t *testing.T) {
+	t.Parallel()
+
+	validators := spaceArgValidators()
+
+	for _, testCase := range malformedSpaceArgs() {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			for actionName, validate := range validators {
+				gotErr := validate(nil, testCase.args)
+				if gotErr == nil {
+					t.Fatalf("%s %v: expected an error", actionName, testCase.args)
+				}
+
+				_, wantErr := action.ParseSpaceArg(actionName, testCase.args)
+				if wantErr == nil {
+					t.Fatalf("ParseSpaceArg(%s, %v): expected an error", actionName, testCase.args)
+				}
+
+				if gotErr.Error() != wantErr.Error() {
+					t.Errorf(
+						"%s %v rejected with its own wording:\n got: %s\nwant: %s",
+						actionName,
+						testCase.args,
+						gotErr,
+						wantErr,
+					)
+				}
+			}
+		})
+	}
+}
+
+// spaceArgv builds the command line that reaches a space action's Args layer
+// with args as its positional arguments. A "--" goes in front of them so a
+// negative number is read as the space argument it is, rather than as the
+// flags cobra would otherwise take "-1" for.
+func spaceArgv(name action.Name, args []string) []string {
+	argv := make([]string, 0, len(args)+3)
+	argv = append(argv, actionCommandName, string(name))
+
+	if len(args) > 0 {
+		argv = append(argv, "--")
+		argv = append(argv, args...)
+	}
+
+	return argv
+}
+
+// TestSpaceArgValidation_RejectsBeforeRunE checks the Args layer still stops a
+// malformed space argument before the action runs: the tree fails with the one
+// rule's own wording and prints its usage, and RunE is never reached. That is
+// what produces the usage output and the exit code, and delegating the rule
+// must not change it.
+func TestSpaceArgValidation_RejectsBeforeRunE(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []action.Name{action.NameSpace, action.NameMoveWindowToSpace} {
+		t.Run(string(name), func(t *testing.T) {
+			t.Parallel()
+
+			for _, testCase := range malformedSpaceArgs() {
+				t.Run(testCase.name, func(t *testing.T) {
+					t.Parallel()
+
+					var out bytes.Buffer
+
+					ran := false
+					root := newRootCmd()
+					path := []string{actionCommandName, string(name)}
+
+					target, _, err := root.Find(path)
+					if err != nil {
+						t.Fatalf("finding command: %v", err)
+					}
+
+					target.RunE = func(_ *cobra.Command, _ []string) error {
+						ran = true
+
+						return nil
+					}
+
+					root.SetOut(&out)
+					root.SetErr(&out)
+					root.SetArgs(spaceArgv(name, testCase.args))
+
+					err = root.Execute()
+					if err == nil {
+						t.Fatalf("%s %v: expected an error", name, testCase.args)
+					}
+
+					_, wantErr := action.ParseSpaceArg(name, testCase.args)
+					if err.Error() != wantErr.Error() {
+						t.Errorf(
+							"%s %v failed with something other than the rule:\n got: %s\nwant: %s",
+							name,
+							testCase.args,
+							err,
+							wantErr,
+						)
+					}
+
+					if ran {
+						t.Errorf("%s %v reached RunE", name, testCase.args)
+					}
+
+					if !strings.Contains(out.String(), "Usage:") {
+						t.Errorf(
+							"%s %v printed no usage, got: %s",
+							name,
+							testCase.args,
+							out.String(),
+						)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestSpaceArgValidation_AcceptsEveryFormOfASpaceArgument covers the other
+// half of the rule: a 1-based number and each accepted keyword pass the Args
+// layer for both actions, so nothing here reaches the desktop.
+func TestSpaceArgValidation_AcceptsEveryFormOfASpaceArgument(t *testing.T) {
+	t.Parallel()
+
+	accepted := []string{"1", "42", "next", "prev", "previous", " 2 "}
+	validators := spaceArgValidators()
+
+	for _, arg := range accepted {
+		t.Run(arg, func(t *testing.T) {
+			t.Parallel()
+
+			for actionName, validate := range validators {
+				err := validate(nil, []string{arg})
+				if err != nil {
+					t.Errorf("%s %q rejected: %v", actionName, arg, err)
+				}
+			}
+		})
 	}
 }

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -74,18 +74,29 @@ type SpaceArg struct {
 	Direction int // +1 for next, -1 for prev; 0 means absolute index
 }
 
-// ParseSpaceArg parses the one argument the space actions take.
-func ParseSpaceArg(args []string) (SpaceArg, error) {
+// ParseSpaceArg parses the one argument the space actions take. It is the
+// only place the rule lives — a space argument is a 1-based number, "next",
+// "prev", or "previous" — so every path that takes one, direct or daemon,
+// rejects a malformed argument in the same words.
+//
+// name is the action the argument was given to, and appears in those words;
+// it is the only part of them that differs between the two actions.
+func ParseSpaceArg(name Name, args []string) (SpaceArg, error) {
 	if len(args) != 1 {
 		return SpaceArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
-			"space requires exactly one argument: a 1-based number, \"next\", or \"prev\"",
+			"%s requires exactly one argument: a 1-based space number, \"next\", or \"prev\"",
+			name,
 		)
 	}
 
 	raw := strings.TrimSpace(args[0])
 	if raw == "" {
-		return SpaceArg{}, derrors.New(derrors.CodeInvalidInput, "space argument cannot be empty")
+		return SpaceArg{}, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"%s argument cannot be empty: give a 1-based space number, \"next\", or \"prev\"",
+			name,
+		)
 	}
 
 	switch raw {
@@ -99,7 +110,8 @@ func ParseSpaceArg(args []string) (SpaceArg, error) {
 	if parseErr != nil || index < 1 {
 		return SpaceArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
-			"space must be a positive integer, \"next\", or \"prev\", got %q",
+			"%s argument must be a positive integer, \"next\", or \"prev\", got %q",
+			name,
 			raw,
 		)
 	}
@@ -109,8 +121,8 @@ func ParseSpaceArg(args []string) (SpaceArg, error) {
 
 // resolveSpaceArg parses the one argument the space actions take and turns it
 // into the 1-based space number it names.
-func (e *Executor) resolveSpaceArg(args []string) (int, error) {
-	parsed, err := ParseSpaceArg(args)
+func (e *Executor) resolveSpaceArg(name Name, args []string) (int, error) {
+	parsed, err := ParseSpaceArg(name, args)
 	if err != nil {
 		return 0, err
 	}
@@ -363,14 +375,14 @@ func (e *Executor) Execute(name string, args []string) error {
 
 		return e.FocusWindow(parsed.Backward, parsed.Direction)
 	case NameSpace:
-		index, err := e.resolveSpaceArg(args)
+		index, err := e.resolveSpaceArg(NameSpace, args)
 		if err != nil {
 			return err
 		}
 
 		return e.FocusSpace(index)
 	case NameMoveWindowToSpace:
-		index, err := e.resolveSpaceArg(args)
+		index, err := e.resolveSpaceArg(NameMoveWindowToSpace, args)
 		if err != nil {
 			return err
 		}

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -1,6 +1,7 @@
 package action_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/action"
@@ -70,6 +71,103 @@ func TestExecute_InvalidAction(t *testing.T) {
 
 	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
 		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+// TestParseSpaceArg_AcceptedForms covers the accepted half of the one space
+// argument rule: a 1-based number, "next", "prev", or "previous", surrounding
+// whitespace included.
+func TestParseSpaceArg_AcceptedForms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		arg  string
+		want action.SpaceArg
+	}{
+		{name: "first space", arg: "1", want: action.SpaceArg{Index: 1}},
+		{name: "padded number", arg: " 2 ", want: action.SpaceArg{Index: 2}},
+		{name: nextKeyword, arg: nextKeyword, want: action.SpaceArg{Direction: 1}},
+		{name: prevKeyword, arg: prevKeyword, want: action.SpaceArg{Direction: -1}},
+		{name: previousKeyword, arg: previousKeyword, want: action.SpaceArg{Direction: -1}},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, name := range []action.Name{action.NameSpace, action.NameMoveWindowToSpace} {
+				got, err := action.ParseSpaceArg(name, []string{testCase.arg})
+				if err != nil {
+					t.Fatalf("ParseSpaceArg(%s, %q) error = %v, want nil", name, testCase.arg, err)
+				}
+
+				if got != testCase.want {
+					t.Errorf(
+						"ParseSpaceArg(%s, %q) = %+v, want %+v",
+						name,
+						testCase.arg,
+						got,
+						testCase.want,
+					)
+				}
+			}
+		})
+	}
+}
+
+// TestParseSpaceArg_MalformedNamesTheAction checks a rejected argument is
+// reported as invalid input and names the action it was given to — the only
+// part of the wording that differs between the two space actions.
+func TestParseSpaceArg_MalformedNamesTheAction(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "empty", args: []string{""}},
+		{name: "whitespace only", args: []string{"   "}},
+		{name: "non-numeric", args: []string{"foo"}},
+		{name: "zero", args: []string{"0"}},
+		{name: "negative", args: []string{"-1"}},
+		{name: "no argument", args: nil},
+		{name: "two arguments", args: []string{"1", "2"}},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, name := range []action.Name{action.NameSpace, action.NameMoveWindowToSpace} {
+				_, err := action.ParseSpaceArg(name, testCase.args)
+				if err == nil {
+					t.Fatalf(
+						"ParseSpaceArg(%s, %v) error = nil, want an error",
+						name,
+						testCase.args,
+					)
+				}
+
+				if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+					t.Errorf(
+						"ParseSpaceArg(%s, %v) got %v, want CodeInvalidInput",
+						name,
+						testCase.args,
+						err,
+					)
+				}
+
+				if !strings.Contains(err.Error(), string(name)) {
+					t.Errorf(
+						"ParseSpaceArg(%s, %v) did not name the action: %v",
+						name,
+						testCase.args,
+						err,
+					)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

This PR makes `mimi action space` and `mimi action move_window_to_space` reject a malformed space argument in the same words. Each command used to carry its own copy of what a space argument is, so the same mistake read differently depending on which one you typed: a bad number was told it had to be a positive integer, with no mention of the `next` and `prev` keywords the very same command accepts.

One rule now decides it — a 1-based space number, `next`, `prev`, or `previous` — and it names the action that rejected the argument, so the wording is identical for both commands apart from that name, and a command sent to a running daemon reports it the same way as one run directly. The commands still reject a bad argument before doing anything to your desktop, so the usage text they print and the exit code they return are unchanged.

Deliberate limitation: a negative number still has to be written after `--` (`mimi action space -- -1`) for the command to see it as an argument at all — without it the flag parser rejects it first, exactly as before this change.

## Related Issues

Closes #124

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — ran the wider `just test-all`, plus `just fmt-check`, `just vet` and `just build`, all green on a freshly rebased base
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, `docs/CLI.md` documents the accepted argument forms, which are unchanged, and never quoted the error text
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command surface

No command, subcommand, or flag changes. Both commands accept exactly what they accepted before:

```bash
mimi action space 1
mimi action space next
mimi action space prev          # "previous" also accepted, as before
mimi action move_window_to_space 2
```

Only the wording of the error printed for a rejected argument changes, for example:

```
# before
Error: [INVALID_INPUT] space number must be a positive integer, got "foo"
# after
Error: [INVALID_INPUT] space argument must be a positive integer, "next", or "prev", got "foo"
```

## Potentially breaking

Not breaking for anything mimi promises, but worth knowing if you grep output: a script matching on the exact text of these two commands' rejection messages will need updating, since the wording changed. The exit code (1) and the `[INVALID_INPUT]` code prefix are unchanged, so matching on either keeps working. Every argument accepted before is still accepted, and no hook or config surface is involved.

## Additional Context

- The rejection message now reports the argument with surrounding whitespace trimmed (`" 2 "` is reported as `"2"`), a side effect of both paths sharing one parse.
- The rule lives in the action module, where the daemon also reaches it after decoding a request, so a command executed over the socket is validated by the same function that fails fast in the CLI — the arrangement `docs/adr/0001-typed-versioned-daemon-wire.md` records for argument rules.
- The CLI parses the argument twice per invocation — once to reject it before the action runs, once to build the command — because Cobra offers no channel to carry the parsed value from one to the other. It is a string parse of one word; keeping the rejection layer was the explicit requirement.
