### PR TITLE
refactor(geometry,action): make an unknown resize preset unrepresentable

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -223,13 +223,14 @@ Examples:
 			preset := ""
 
 			if len(args) > 0 {
+				// The rule lives in action.ParseResizePreset, which the conversion
+				// this payload feeds applies again — this is the fail-fast
+				// copy of the call, not a second copy of the rule.
 				preset = strings.TrimSpace(args[0])
-				if !action.IsResizePreset(preset) {
-					return derrors.Newf(
-						derrors.CodeInvalidInput,
-						"unknown preset %q (valid: left-half, right-half, top-half, bottom-half, top-left, top-right, bottom-left, bottom-right, center, fill)",
-						preset,
-					)
+
+				_, err := action.ParseResizePreset(preset)
+				if err != nil {
+					return err
 				}
 			}
 

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -124,6 +124,27 @@ func TestResizeWindowArgsFromFlags_CarriesThePresetAndTheOtherFlags(t *testing.T
 	}
 }
 
+// TestResizeWindowCommand_RejectsAnUnknownPreset covers mimi#125 at the CLI:
+// an unknown preset is rejected before anything reaches the desktop, and with
+// action.ParseResizePreset's own wording rather than a second copy of the valid
+// name list that could drift from it. This fails during argument validation,
+// not execution, so it is safe to run through the real command tree.
+func TestResizeWindowCommand_RejectsAnUnknownPreset(t *testing.T) {
+	t.Parallel()
+
+	const unknownPreset = "left-third"
+
+	_, err := runCommand(t, actionCommandName, "resize_window", unknownPreset)
+	if err == nil {
+		t.Fatalf("resize_window %s: expected an error", unknownPreset)
+	}
+
+	_, wantErr := action.ParseResizePreset(unknownPreset)
+	if err.Error() != wantErr.Error() {
+		t.Errorf("rejected with its own wording:\n got: %s\nwant: %s", err, wantErr)
+	}
+}
+
 // TestFocusWindowCommand_RejectsBackwardWithDirection checks the CLI surfaces
 // action.NewFocusWindowArgs' validation before ever reaching the desktop —
 // this fails during flag validation, not execution, so it is safe to run

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -161,9 +161,29 @@ func (e *Executor) resolveSpaceArgTyped(parsed SpaceArg) (int, error) {
 	return ((current - 1 + parsed.Direction + count) % count) + 1, nil
 }
 
-// IsResizePreset reports whether s is a known resize window preset.
-func IsResizePreset(s string) bool {
-	return geometry.IsPreset(s)
+// ParseResizePreset maps the name resize_window's positional argument carries onto
+// the preset it names, and is the one place a name that is not one of them is
+// rejected. Every path that takes a preset — the CLI's own argument check, the
+// conversion from a command's arguments, and the string parser the daemon
+// still decodes with — goes through it, so an unknown name is rejected in the
+// same words wherever it arrives from.
+//
+// The rejection lists the ten valid names, read from the geometry's own table
+// rather than restated here, since mistyping one is the likely way to get
+// here. The empty name is not a preset either: a command that names no preset
+// never asks for one.
+func ParseResizePreset(name string) (geometry.Preset, error) {
+	preset, ok := geometry.ParsePreset(name)
+	if !ok {
+		return geometry.Preset{}, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"unknown preset %q (valid: %s)",
+			name,
+			strings.Join(geometry.PresetNames(), ", "),
+		)
+	}
+
+	return preset, nil
 }
 
 // ParseResizeRequest turns resize_window's command line into the geometry
@@ -186,9 +206,18 @@ func ParseResizeRequest(rawArgs []string) (geometry.Request, error) {
 
 	args := rawArgs
 
-	// Check for preset as first positional arg
-	if len(args) > 0 && IsResizePreset(args[0]) {
-		req.Preset = args[0]
+	// The preset is the one positional argument resize_window takes, so
+	// anything leading that is not a flag is meant as one. A name that is not
+	// a preset is rejected here, on the rule the CLI rejects it with, rather
+	// than falling through to the flag loop to be reported as a stray
+	// argument.
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		preset, err := ParseResizePreset(args[0])
+		if err != nil {
+			return req, err
+		}
+
+		req.Preset = preset
 		args = args[1:]
 	}
 

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
 )
 
 const (
@@ -23,6 +24,10 @@ const (
 	presetBottomRight = "bottom-right"
 	presetCenter      = "center"
 	presetFill        = "fill"
+
+	// unknownPreset is a name that is not one of the ten, and never becomes
+	// one: the input every rejection case below is written against.
+	unknownPreset = "left-third"
 
 	flagWidth         = "--width"
 	flagHeight        = "--height"
@@ -259,48 +264,84 @@ func TestExecute_MoveWindowToSpaceNextPrev(t *testing.T) {
 	}
 }
 
-func TestIsResizePreset(t *testing.T) {
-	t.Parallel()
+// everyPreset lists the ten preset names resize_window takes. The cases below
+// are written against this list rather than against the geometry's own, so a
+// preset silently leaving the table is a failure rather than a case that stops
+// running.
+func everyPreset() []string {
+	return []string{
+		presetLeftHalf, presetRightHalf, presetTopHalf, presetBottomHalf,
+		presetTopLeft, presetTopRight, presetBottomLeft, presetBottomRight,
+		presetCenter, presetFill,
+	}
+}
 
-	cases := []struct {
-		name  string
-		input string
-		want  bool
-	}{
-		{name: presetLeftHalf, input: presetLeftHalf, want: true},
-		{name: presetRightHalf, input: presetRightHalf, want: true},
-		{name: presetTopHalf, input: presetTopHalf, want: true},
-		{name: presetBottomHalf, input: presetBottomHalf, want: true},
-		{name: presetTopLeft, input: presetTopLeft, want: true},
-		{name: presetTopRight, input: presetTopRight, want: true},
-		{name: presetBottomLeft, input: presetBottomLeft, want: true},
-		{name: presetBottomRight, input: presetBottomRight, want: true},
-		{name: presetCenter, input: presetCenter, want: true},
-		{name: presetFill, input: presetFill, want: true},
-		{name: "unknown", input: "left-third", want: false},
+// presetFor is the preset a name names, for the cases that expect one to reach
+// the geometry.
+func presetFor(t *testing.T, name string) geometry.Preset {
+	t.Helper()
+
+	preset, ok := geometry.ParsePreset(name)
+	if !ok {
+		t.Fatalf("ParsePreset(%q) is not a preset", name)
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	return preset
+}
+
+// assertListsEveryPreset checks a rejection names all ten presets, which is
+// what makes it useful to whoever mistyped one.
+func assertListsEveryPreset(t *testing.T, err error) {
+	t.Helper()
+
+	for _, name := range everyPreset() {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("rejection does not list %q: %v", name, err)
+		}
+	}
+}
+
+// TestResizePreset covers mimi#125: one rule decides whether a name is a
+// preset, and it hands back the preset itself rather than a boolean beside it,
+// so a caller cannot carry an unrecognized name past the check.
+func TestResizePreset(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range everyPreset() {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := action.IsResizePreset(tc.input); got != tc.want {
-				t.Fatalf("IsResizePreset(%q) = %v, want %v", tc.input, got, tc.want)
+			got, err := action.ParseResizePreset(name)
+			if err != nil {
+				t.Fatalf("ParseResizePreset(%q) error = %v", name, err)
+			}
+
+			if got != presetFor(t, name) {
+				t.Fatalf("ParseResizePreset(%q) = %q, want %q", name, got, name)
 			}
 		})
 	}
+
+	t.Run("unknown", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := action.ParseResizePreset(unknownPreset)
+		if err == nil {
+			t.Fatalf("ParseResizePreset(%q) expected error", unknownPreset)
+		}
+
+		if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+			t.Fatalf("expected CodeInvalidInput, got %v", err)
+		}
+
+		assertListsEveryPreset(t, err)
+	})
 }
 
 func TestExecute_ResizeWindowPresets(t *testing.T) {
 	t.Parallel()
 
-	presets := []string{
-		presetLeftHalf, presetRightHalf, presetTopHalf, presetBottomHalf,
-		presetTopLeft, presetTopRight, presetBottomLeft, presetBottomRight,
-		presetCenter, presetFill,
-	}
-
-	for _, preset := range presets {
+	for _, preset := range everyPreset() {
 		t.Run(preset, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -93,7 +93,11 @@ func validateFocusWindowCombo(direction string, backward bool) error {
 // from one given as its zero value — the same distinction
 // cobraCmd.Flags().Changed(...) makes at the CLI layer.
 type ResizeWindowArgs struct {
-	// Preset is a named tiling shortcut, or "" for none.
+	// Preset is a named tiling shortcut, or "" for none. It stays a raw name
+	// rather than a geometry.Preset because this is the payload the socket
+	// carries, and a value whose fields are unexported does not survive the
+	// trip; ResizeRequestFromArgs is what turns it into one, and rejects a
+	// name that is not a preset.
 	Preset string
 
 	Width    int
@@ -128,6 +132,20 @@ type ResizeWindowArgs struct {
 // zero-collapses-to-keep convention (see ParseResizeRequest's doc comment),
 // without the string flags that convention was written against.
 func ResizeRequestFromArgs(args ResizeWindowArgs) (geometry.Request, error) {
+	// The preset is checked first, as the positional argument it is, so a
+	// command carrying both a mistyped preset and a bad flag is rejected for
+	// the preset on this path too.
+	var preset geometry.Preset
+
+	if args.Preset != "" {
+		named, err := ParseResizePreset(args.Preset)
+		if err != nil {
+			return geometry.Request{}, err
+		}
+
+		preset = named
+	}
+
 	if args.WidthSet && args.Width < 0 {
 		return geometry.Request{}, derrors.Newf(
 			derrors.CodeInvalidInput,
@@ -160,7 +178,7 @@ func ResizeRequestFromArgs(args ResizeWindowArgs) (geometry.Request, error) {
 		)
 	}
 
-	req := geometry.Request{Preset: args.Preset}
+	req := geometry.Request{Preset: preset}
 
 	width, widthPercent := 0.0, 0.0
 	if args.WidthSet {

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -142,7 +142,7 @@ func TestResizeRequestFromArgs_MatchesParseResizeRequest(t *testing.T) {
 		{
 			name: "a preset carries through",
 			args: action.ResizeWindowArgs{Preset: presetLeftHalf},
-			want: geometry.Request{Preset: presetLeftHalf},
+			want: geometry.Request{Preset: presetFor(t, presetLeftHalf)},
 		},
 	}
 
@@ -185,6 +185,48 @@ func TestResizeRequestFromArgs_InvalidWidthPercent(t *testing.T) {
 
 	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
 		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+// TestResizeRequestFromArgs_RejectsAnUnknownPreset covers mimi#125: the
+// conversion from a command's raw arguments to a geometry request is where a
+// preset name becomes a preset, so a name that is not one is rejected there —
+// on every path a command can be built on, the daemon's included, rather than
+// only on the one the CLI's own argument check stands in front of.
+func TestResizeRequestFromArgs_RejectsAnUnknownPreset(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.ResizeRequestFromArgs(action.ResizeWindowArgs{Preset: unknownPreset})
+	if err == nil {
+		t.Fatalf("ResizeRequestFromArgs(preset %s) expected error", unknownPreset)
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+
+	assertListsEveryPreset(t, err)
+}
+
+// TestResizeRequestFromArgs_AcceptsEveryPreset is the other half of the rule:
+// each of the ten names still converts, and reaches the geometry as the preset
+// it names.
+func TestResizeRequestFromArgs_AcceptsEveryPreset(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range everyPreset() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := action.ResizeRequestFromArgs(action.ResizeWindowArgs{Preset: name})
+			if err != nil {
+				t.Fatalf("ResizeRequestFromArgs(preset %s) error = %v", name, err)
+			}
+
+			if got.Preset != presetFor(t, name) {
+				t.Fatalf("Preset = %q, want %q", got.Preset, name)
+			}
+		})
 	}
 }
 

--- a/internal/action/resize_desktop_test.go
+++ b/internal/action/resize_desktop_test.go
@@ -87,7 +87,8 @@ func TestExecutor_ResizeWindow_ErrorPaths(t *testing.T) {
 
 			testCase.breakIt(desktop)
 
-			err := action.NewExecutor(desktop).ResizeWindow(geometry.Request{Preset: "fill"})
+			err := action.NewExecutor(desktop).
+				ResizeWindow(geometry.Request{Preset: presetFor(t, presetFill)})
 			if err == nil {
 				t.Fatal("ResizeWindow() error = nil, want an error")
 			}

--- a/internal/action/resize_test.go
+++ b/internal/action/resize_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/geometry"
 )
 
@@ -27,7 +28,7 @@ func TestParseResizeRequest_MapsFlagsOntoTheGeometryRequest(t *testing.T) {
 		{
 			name: "a preset is taken from the first positional argument",
 			args: []string{presetLeftHalf},
-			want: geometry.Request{Preset: presetLeftHalf},
+			want: geometry.Request{Preset: presetFor(t, presetLeftHalf)},
 		},
 		{
 			name: "absolute sizes",
@@ -88,6 +89,31 @@ func TestParseResizeRequest_MapsFlagsOntoTheGeometryRequest(t *testing.T) {
 
 			assertRequest(t, got, testCase.want)
 		})
+	}
+}
+
+// TestParseResizeRequest_RejectsAnUnknownPreset covers mimi#125 on the path a
+// command from outside the CLI takes: the daemon decodes a request's string
+// arguments here, and a preset name it does not know is now rejected on the
+// same rule — and so in the same words — as the CLI's own check. It used to
+// fall past the preset check and be reported as a stray positional argument.
+func TestParseResizeRequest_RejectsAnUnknownPreset(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.ParseResizeRequest([]string{unknownPreset, flagWidth, "800"})
+	if err == nil {
+		t.Fatalf("ParseResizeRequest(%s) expected error", unknownPreset)
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+
+	assertListsEveryPreset(t, err)
+
+	_, wantErr := action.ParseResizePreset(unknownPreset)
+	if err.Error() != wantErr.Error() {
+		t.Errorf("rejected with its own wording:\n got: %s\nwant: %s", err, wantErr)
 	}
 }
 

--- a/internal/geometry/resize.go
+++ b/internal/geometry/resize.go
@@ -32,9 +32,9 @@ type Screen struct {
 // Request is what the user asked for. Every field is optional; the zero
 // Request keeps the window's current size and centers it.
 type Request struct {
-	// Preset is a named tiling shortcut, or "" for none. An unknown name is
-	// ignored — IsPreset is what turns one into an error, at parse time.
-	Preset string
+	// Preset is a named tiling shortcut, or the zero Preset for none. Only
+	// ParsePreset produces one, so an unknown name never reaches here.
+	Preset Preset
 	// Width and Height are the size asked for: a length in points, a share of
 	// the visible frame, or the window's current size.
 	Width  Dimension
@@ -111,8 +111,9 @@ func (d Dimension) resolve(current, available float64) float64 {
 // Resize returns the frame a window at cur should be moved to on scr to
 // satisfy req.
 //
-// It is total: every input produces a frame. An unknown preset name is
-// ignored, and nothing here reports an error.
+// It is total: every input produces a frame, and nothing here reports an
+// error. Every field of req is either optional or a value only this package
+// can produce, so there is no input left for it to reject.
 //
 // cur and the returned frame are in window coordinates — y-down, origin at the
 // primary display's top-left — while scr.Visible is in screen coordinates.
@@ -282,14 +283,14 @@ func marginOn(flush bool, size float64) float64 {
 
 // expandPreset fills in what the request's named preset asks for: its
 // percentages wherever the request keeps the current size, and its anchor
-// wherever the request left one unset. An unknown name — including the empty
-// one — leaves the request untouched.
+// wherever the request left one unset. The zero Preset — no preset — leaves
+// the request untouched.
 //
 // Nothing the preset supplies overrides a value the request already carries,
 // so an explicit --width, --height or --anchor always wins over the preset's
 // own.
 func expandPreset(req Request) Request {
-	named, ok := presets[req.Preset]
+	named, ok := presetNamed(req.Preset.name)
 	if !ok {
 		return req
 	}
@@ -445,27 +446,97 @@ const (
 	centerHeight = 80.0
 )
 
-// presets are the named tiling shortcuts resize_window accepts as its
-// positional argument.
-var presets = map[string]preset{
-	"left-half":    {widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopLeft},
-	"right-half":   {widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopRight},
-	"top-half":     {widthPercent: wholeScreen, heightPercent: halfScreen, anchor: TopLeft},
-	"bottom-half":  {widthPercent: wholeScreen, heightPercent: halfScreen, anchor: BottomLeft},
-	"top-left":     {widthPercent: halfScreen, heightPercent: halfScreen, anchor: TopLeft},
-	"top-right":    {widthPercent: halfScreen, heightPercent: halfScreen, anchor: TopRight},
-	"bottom-left":  {widthPercent: halfScreen, heightPercent: halfScreen, anchor: BottomLeft},
-	"bottom-right": {widthPercent: halfScreen, heightPercent: halfScreen, anchor: BottomRight},
-	"center":       {widthPercent: centerWidth, heightPercent: centerHeight, anchor: Center},
-	"fill":         {widthPercent: wholeScreen, heightPercent: wholeScreen, anchor: TopLeft},
+// namedPreset pairs a preset with the name resize_window takes it by.
+type namedPreset struct {
+	name   string
+	preset preset
 }
 
-// IsPreset reports whether name is one of the named resize presets.
-//
-// Resize ignores a name it does not know, so callers that want an unknown
-// preset to be an error — the CLI does — check it with this first.
-func IsPreset(name string) bool {
-	_, ok := presets[name]
+// presets are the named tiling shortcuts resize_window accepts as its
+// positional argument, in the order the CLI's help and docs/CLI.md list them:
+// the halves, then the quadrants, then the two that need neither word. The
+// order is user-visible through PresetNames, which is what an unknown name is
+// rejected with, so this is the one place it is decided.
+var presets = []namedPreset{
+	{"left-half", preset{widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopLeft}},
+	{"right-half", preset{widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopRight}},
+	{"top-half", preset{widthPercent: wholeScreen, heightPercent: halfScreen, anchor: TopLeft}},
+	{
+		"bottom-half",
+		preset{widthPercent: wholeScreen, heightPercent: halfScreen, anchor: BottomLeft},
+	},
+	{"top-left", preset{widthPercent: halfScreen, heightPercent: halfScreen, anchor: TopLeft}},
+	{"top-right", preset{widthPercent: halfScreen, heightPercent: halfScreen, anchor: TopRight}},
+	{
+		"bottom-left",
+		preset{widthPercent: halfScreen, heightPercent: halfScreen, anchor: BottomLeft},
+	},
+	{
+		"bottom-right",
+		preset{widthPercent: halfScreen, heightPercent: halfScreen, anchor: BottomRight},
+	},
+	{"center", preset{widthPercent: centerWidth, heightPercent: centerHeight, anchor: Center}},
+	{"fill", preset{widthPercent: wholeScreen, heightPercent: wholeScreen, anchor: TopLeft}},
+}
 
-	return ok
+// Preset is one of the named tiling shortcuts, in the form a Request holds it.
+//
+// Its name is unexported and ParsePreset is the only thing that fills it in,
+// so a Preset naming something that is not a preset cannot be built at all —
+// which is what stops an unknown name traveling as far as Resize, where it
+// used to be ignored. The zero Preset is no preset, and is what the zero
+// Request asks for.
+//
+// It is deliberately not a wire type: encoding/json renders a struct whose
+// every field is unexported as {} and reports no error. What travels over the
+// daemon's socket is the raw preset name, parsed into a Preset once decoded,
+// on the terms docs/adr/0001-typed-versioned-daemon-wire.md sets out.
+type Preset struct {
+	name string
+}
+
+// String returns the name the preset is asked for by, or "" for no preset.
+func (p Preset) String() string {
+	return p.name
+}
+
+// ParsePreset maps a preset name onto the preset it names, and reports whether
+// the name is one of them.
+//
+// An unknown name reports false alongside the zero Preset, which means no
+// preset rather than that name — following ParseAnchor, callers have to read
+// the boolean.
+func ParsePreset(name string) (Preset, bool) {
+	_, ok := presetNamed(name)
+	if !ok {
+		return Preset{}, false
+	}
+
+	return Preset{name: name}, true
+}
+
+// PresetNames returns every preset name, in the order presets lists them. It
+// is what a caller rejecting an unknown name tells the user about, so the
+// valid names are read from the table rather than restated beside it.
+func PresetNames() []string {
+	names := make([]string, 0, len(presets))
+	for _, named := range presets {
+		names = append(names, named.name)
+	}
+
+	return names
+}
+
+// presetNamed returns the preset the given name asks for, and reports whether
+// there is one. The table is ten entries long and its order is what
+// PresetNames reports, so it is scanned by name the way ParseAnchor scans
+// anchorNames.
+func presetNamed(name string) (preset, bool) {
+	for _, named := range presets {
+		if named.name == name {
+			return named.preset, true
+		}
+	}
+
+	return preset{}, false
 }

--- a/internal/geometry/resize_test.go
+++ b/internal/geometry/resize_test.go
@@ -3,6 +3,7 @@ package geometry_test
 import (
 	"fmt"
 	"math"
+	"slices"
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/geometry"
@@ -32,6 +33,26 @@ const (
 	presetCenter      = "center"
 	presetFill        = "fill"
 )
+
+// The presets the cases below place windows with, in the form a request holds
+// them.
+var (
+	leftHalf   = presetFor(presetLeftHalf)
+	rightHalf  = presetFor(presetRightHalf)
+	bottomHalf = presetFor(presetBottomHalf)
+	center     = presetFor(presetCenter)
+	fill       = presetFor(presetFill)
+)
+
+// presetFor is ParsePreset for the names this file spells out as constants,
+// which TestParsePreset pins as ten of the ten. A name that somehow stopped
+// being one yields the zero preset, and the frame the case expects then fails
+// to match.
+func presetFor(name string) geometry.Preset {
+	preset, _ := geometry.ParsePreset(name)
+
+	return preset
+}
 
 // The frame every recorded resize case started from.
 var startFrame = geometry.Rect{X: 300, Y: 180, W: 700, H: 500}
@@ -204,7 +225,7 @@ func TestResize_ExpandsEveryPreset(t *testing.T) {
 		t.Run(testCase.preset, func(t *testing.T) {
 			t.Parallel()
 
-			req := geometry.Request{Preset: testCase.preset}
+			req := geometry.Request{Preset: presetFor(testCase.preset)}
 
 			got := geometry.Resize(startFrame, singleDisplay, req)
 			if got != testCase.want {
@@ -220,26 +241,13 @@ func TestResize_PresetSizesAreDefaults(t *testing.T) {
 	// left-half is 50% x 100%; an explicit width replaces its width and leaves
 	// its height and anchor in place.
 	got := geometry.Resize(startFrame, singleDisplay, geometry.Request{
-		Preset: presetLeftHalf,
+		Preset: leftHalf,
 		Width:  geometry.Absolute(800),
 	})
 
 	want := geometry.Rect{X: 0, Y: 30, W: 800, H: 1050}
 	if got != want {
 		t.Errorf("Resize(left-half --width 800) = %v, want %v", got, want)
-	}
-}
-
-func TestResize_IgnoresAnUnknownPreset(t *testing.T) {
-	t.Parallel()
-
-	// Resize is total, so an unknown name cannot be an error here; the CLI
-	// rejects one at parse time with IsPreset.
-	got := geometry.Resize(startFrame, singleDisplay, geometry.Request{Preset: "left-third"})
-
-	want := geometry.Resize(startFrame, singleDisplay, geometry.Request{})
-	if got != want {
-		t.Errorf("Resize(preset left-third) = %v, want the presetless %v", got, want)
 	}
 }
 
@@ -262,17 +270,17 @@ func TestResize_AppliesMargins(t *testing.T) {
 			// Left, top and bottom abut the visible frame and take a full 8pt
 			// margin; the right edge is internal and takes half of one.
 			name: "a half-screen preset takes a full margin on the edges it abuts",
-			req:  geometry.Request{Preset: presetLeftHalf},
+			req:  geometry.Request{Preset: leftHalf},
 			want: geometry.Rect{X: 8, Y: 38, W: 948, H: 1034},
 		},
 		{
 			name: "a filling preset takes a full margin on all four edges",
-			req:  geometry.Request{Preset: presetFill},
+			req:  geometry.Request{Preset: fill},
 			want: geometry.Rect{X: 8, Y: 38, W: 1904, H: 1034},
 		},
 		{
 			name: "a preset that abuts nothing takes half a margin on all four edges",
-			req:  geometry.Request{Preset: presetCenter},
+			req:  geometry.Request{Preset: center},
 			want: geometry.Rect{X: 388, Y: 139, W: 1144, H: 832},
 		},
 		{
@@ -327,25 +335,25 @@ func TestResize_MarginPreferenceOverridesTheSystemSetting(t *testing.T) {
 		{
 			name: "no preference follows a system setting that is on",
 			scr:  withMargins,
-			req:  geometry.Request{Preset: presetLeftHalf},
+			req:  geometry.Request{Preset: leftHalf},
 			want: inset,
 		},
 		{
 			name: "no preference follows a system setting that is off",
 			scr:  singleDisplay,
-			req:  geometry.Request{Preset: presetLeftHalf},
+			req:  geometry.Request{Preset: leftHalf},
 			want: full,
 		},
 		{
 			name: "margins off overrides a system setting that is on",
 			scr:  withMargins,
-			req:  geometry.Request{Preset: presetLeftHalf, UseMargins: &disabled},
+			req:  geometry.Request{Preset: leftHalf, UseMargins: &disabled},
 			want: full,
 		},
 		{
 			name: "margins on overrides a system setting that is off",
 			scr:  singleDisplay,
-			req:  geometry.Request{Preset: presetLeftHalf, UseMargins: &enabled},
+			req:  geometry.Request{Preset: leftHalf, UseMargins: &enabled},
 			want: inset,
 		},
 	}
@@ -392,31 +400,31 @@ func TestResize_PlacesWindowsOnSecondaryDisplays(t *testing.T) {
 		{
 			name: "filling the display to the left",
 			scr:  toTheLeft,
-			req:  geometry.Request{Preset: presetFill},
+			req:  geometry.Request{Preset: fill},
 			want: geometry.Rect{X: -1920, Y: 0, W: 1920, H: 1080},
 		},
 		{
 			name: "the right half of the display to the left",
 			scr:  toTheLeft,
-			req:  geometry.Request{Preset: presetRightHalf},
+			req:  geometry.Request{Preset: rightHalf},
 			want: geometry.Rect{X: -960, Y: 0, W: 960, H: 1080},
 		},
 		{
 			name: "margins on the display to the left",
 			scr:  toTheLeft,
-			req:  geometry.Request{Preset: presetFill, UseMargins: new(true)},
+			req:  geometry.Request{Preset: fill, UseMargins: new(true)},
 			want: geometry.Rect{X: -1912, Y: 8, W: 1904, H: 1064},
 		},
 		{
 			name: "filling the display above sits a whole primary height up",
 			scr:  above,
-			req:  geometry.Request{Preset: presetFill},
+			req:  geometry.Request{Preset: fill},
 			want: geometry.Rect{X: 0, Y: -1080, W: 1920, H: 1080},
 		},
 		{
 			name: "the bottom half of the display above still ends at the primary's top",
 			scr:  above,
-			req:  geometry.Request{Preset: presetBottomHalf},
+			req:  geometry.Request{Preset: bottomHalf},
 			want: geometry.Rect{X: 0, Y: -540, W: 1920, H: 540},
 		},
 		{
@@ -453,7 +461,7 @@ func TestResize_PresetAnchorIsADefault(t *testing.T) {
 	t.Parallel()
 
 	got := geometry.Resize(startFrame, singleDisplay, geometry.Request{
-		Preset: presetLeftHalf,
+		Preset: leftHalf,
 		Anchor: new(geometry.BottomRight),
 	})
 
@@ -864,7 +872,10 @@ func TestResize_ExplicitPositionMeasuresItsEdges(t *testing.T) {
 // anything a display can show.
 const tolerance = 1e-9
 
-func TestIsPreset(t *testing.T) {
+// TestParsePreset covers mimi#125: a preset name is only a preset once
+// ParsePreset has turned it into one, and an unknown name has no Preset to be
+// turned into — which is what stops one reaching Resize to be ignored there.
+func TestParsePreset(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -889,9 +900,41 @@ func TestIsPreset(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := geometry.IsPreset(testCase.name); got != testCase.want {
-				t.Fatalf("IsPreset(%q) = %v, want %v", testCase.name, got, testCase.want)
+			got, isPreset := geometry.ParsePreset(testCase.name)
+			if isPreset != testCase.want {
+				t.Fatalf(
+					"ParsePreset(%q) ok = %v, want %v",
+					testCase.name,
+					isPreset,
+					testCase.want,
+				)
+			}
+
+			if isPreset && got.String() != testCase.name {
+				t.Fatalf("ParsePreset(%q).String() = %q", testCase.name, got.String())
+			}
+
+			if !isPreset && got != (geometry.Preset{}) {
+				t.Fatalf("ParsePreset(%q) = %v, want the zero preset", testCase.name, got)
 			}
 		})
+	}
+}
+
+// TestPresetNames_ListsEveryPresetInTheDocumentedOrder pins both halves of the
+// list an unknown name is rejected with: which names are valid, and the order
+// the CLI's help and docs/CLI.md present them in, which the rejection message
+// is built from and so is user-visible.
+func TestPresetNames_ListsEveryPresetInTheDocumentedOrder(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		presetLeftHalf, presetRightHalf, presetTopHalf, presetBottomHalf,
+		presetTopLeft, presetTopRight, presetBottomLeft, presetBottomRight,
+		presetCenter, presetFill,
+	}
+
+	if got := geometry.PresetNames(); !slices.Equal(got, want) {
+		t.Fatalf("PresetNames() = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Description

This PR makes `mimi action resize_window` reject an unrecognised preset name on every route a command can arrive by, instead of only on the command line. Typing a name that is not a preset has always been an error at the command line, but that check stood in front of the layer that places the window, and that layer deliberately ignored a name it did not recognise — so a command that reached the daemon by any other route resized the window as though no preset had been given at all. The guarantee now lives in the value a preset travels as: a name that is not one of the ten cannot be held past the point where the command is built, so there is nothing left downstream to ignore.

Nothing changes for a valid preset. Each of the ten sizes and places a window exactly as it did, the command line accepts and rejects exactly what it did, and the rejection still lists all ten names in the same order. The one visible difference is off the command line, described below.

## Related Issues

Closes #125

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — ran the wider gate: `just fmt-check`, `just vet`, `just build` and `just test-all`, all green
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no document describes the behaviour that changed; the preset names, their effects and the command's help text are untouched
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command surface

`mimi action resize_window [preset]` takes the same ten preset names as before — `left-half`, `right-half`, `top-half`, `bottom-half`, `top-left`, `top-right`, `bottom-left`, `bottom-right`, `center`, `fill` — with the same effects and the same flags. An unknown name is rejected on the command line with the same message, byte for byte:

```
$ mimi action resize_window left-third
Error: [INVALID_INPUT] unknown preset "left-third" (valid: left-half, right-half, top-half, bottom-half, top-left, top-right, bottom-left, bottom-right, center, fill)
```

Existing configs, hooks and invocations keep working unchanged.

## Potentially breaking

Only for something speaking to the daemon's socket directly, which nothing outside mimi does today. A command sent to a running daemon with an unknown preset used to come back as a stray-argument error (`unexpected argument: left-third`); it now comes back with the message above. Anything matching on that error text would need updating; the CLI's own wording is unchanged, so a hotkey or script that shells out to `mimi` sees no difference.

## Additional Context

The valid preset names the rejection lists are now read from the one table that defines the presets, rather than restated next to it, so the list cannot drift from the presets that actually exist. The table changed from a lookup keyed by name to an ordered list, because the order the names are listed in is user-visible and now has one place it is decided.

The rule that decides whether a name is a preset also has one home now, which the command line, the direct execution path and the daemon's decode all call. That matters ahead of the typed socket work in #126: the parser that used to guarantee a valid preset upstream is deleted there, and this change lands the guarantee before that happens rather than after.
