### PR TITLE
refactor(cli,action): build every command through a constructor that validates

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -71,7 +71,7 @@ in that direction based on screen position.
 Only windows that are focusable (not minimized, not hidden) and on the
 current space are included.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			focusArgs, err := action.NewFocusWindowArgs(
+			focusCmd, err := action.NewFocusWindowCommand(
 				backward,
 				focusUp,
 				focusDown,
@@ -82,10 +82,7 @@ current space are included.`,
 				return err
 			}
 
-			return state.runAction(action.Command{
-				Name:        action.NameFocusWindow,
-				FocusWindow: focusArgs,
-			})
+			return state.runAction(focusCmd)
 		},
 	}
 
@@ -130,12 +127,12 @@ Examples:
   mimi action space prev     Cycle to the previous space (with wrap)`,
 		Args: validateSpaceArg(action.NameSpace),
 		RunE: func(_ *cobra.Command, args []string) error {
-			spaceArg, err := action.ParseSpaceArg(action.NameSpace, args)
+			spaceCmd, err := action.NewSpaceCommand(args)
 			if err != nil {
 				return err
 			}
 
-			return state.runAction(action.Command{Name: action.NameSpace, Space: spaceArg})
+			return state.runAction(spaceCmd)
 		},
 	}
 }
@@ -163,15 +160,12 @@ Examples:
   mimi action move_window_to_space prev     Move window to previous space (with wrap)`,
 		Args: validateSpaceArg(action.NameMoveWindowToSpace),
 		RunE: func(_ *cobra.Command, args []string) error {
-			spaceArg, err := action.ParseSpaceArg(action.NameMoveWindowToSpace, args)
+			moveCmd, err := action.NewMoveWindowToSpaceCommand(args)
 			if err != nil {
 				return err
 			}
 
-			return state.runAction(action.Command{
-				Name:              action.NameMoveWindowToSpace,
-				MoveWindowToSpace: spaceArg,
-			})
+			return state.runAction(moveCmd)
 		},
 	}
 }
@@ -221,25 +215,18 @@ Examples:
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			preset := ""
-
 			if len(args) > 0 {
-				// The rule lives in action.ParseResizePreset, which the conversion
-				// this payload feeds applies again — this is the fail-fast
-				// copy of the call, not a second copy of the rule.
 				preset = strings.TrimSpace(args[0])
-
-				_, err := action.ParseResizePreset(preset)
-				if err != nil {
-					return err
-				}
 			}
 
-			resizeArgs := resizeWindowArgsFromFlags(cobraCmd, preset)
+			resizeCmd, err := action.NewResizeWindowCommand(
+				resizeWindowArgsFromFlags(cobraCmd, preset),
+			)
+			if err != nil {
+				return err
+			}
 
-			return state.runAction(action.Command{
-				Name:         action.NameResizeWindow,
-				ResizeWindow: resizeArgs,
-			})
+			return state.runAction(resizeCmd)
 		},
 	}
 
@@ -300,7 +287,10 @@ func resizeWindowArgsFromFlags(cobraCmd *cobra.Command, preset string) action.Re
 // validateSpaceArg builds the Args validator for an action that takes one
 // space argument. Cobra keeps rejecting the argument before RunE runs — that
 // is what produces the usage output and the exit code — but the rule it
-// rejects with is action.ParseSpaceArg, the one place that rule lives.
+// rejects with is action.ParseSpaceArg, the one place that rule lives, and the
+// same rule the constructor in RunE calls. A malformed argument therefore
+// never gets as far as being built into a command, and reads the same either
+// way if it ever does.
 func validateSpaceArg(name action.Name) cobra.PositionalArgs {
 	return func(_ *cobra.Command, args []string) error {
 		_, err := action.ParseSpaceArg(name, args)

--- a/cmd/mimi/cmd/action_runner_test.go
+++ b/cmd/mimi/cmd/action_runner_test.go
@@ -34,16 +34,24 @@ func shortSocketDir(t *testing.T) string {
 	return dir
 }
 
-// stateWithSocketConfig writes a minimal config setting socket_file to
-// socketPath and returns a cliState pointed at it — the setup both routing
-// tests below share.
-func stateWithSocketConfig(t *testing.T, socketPath string) *cliState {
+// configWithSocket writes a minimal config setting socket_file to socketPath
+// and returns the path it wrote it to — how a test points a command tree at a
+// socket of its own rather than the default one.
+func configWithSocket(t *testing.T, socketPath string) string {
 	t.Helper()
 
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	writeConfigFile(t, configPath, fmt.Sprintf("[settings]\nsocket_file = %q\n", socketPath))
 
-	return &cliState{configPath: configPath}
+	return configPath
+}
+
+// stateWithSocketConfig returns a cliState pointed at a config whose
+// socket_file is socketPath — the setup both routing tests below share.
+func stateWithSocketConfig(t *testing.T, socketPath string) *cliState {
+	t.Helper()
+
+	return &cliState{configPath: configWithSocket(t, socketPath)}
 }
 
 // TestRunAction_RoutesToDaemonWhenListening pins the routing mimi#90 asks to

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -2,8 +2,13 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
+	"context"
+	"net"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -11,8 +16,19 @@ import (
 	"github.com/y3owk1n/mimi/internal/action"
 )
 
-// actionCommandName is the parent every action subcommand hangs off.
-const actionCommandName = "action"
+const (
+	// actionCommandName is the parent every action subcommand hangs off.
+	actionCommandName = "action"
+
+	// The two action subcommands whose flags these tests malform, spelled the
+	// way the CLI takes them.
+	focusWindowCommandName  = string(action.NameFocusWindow)
+	resizeWindowCommandName = string(action.NameResizeWindow)
+
+	// unknownPreset is a name that is not one of the ten presets, and never
+	// becomes one.
+	unknownPreset = "left-third"
+)
 
 // resizeFlags parses args against a fresh resize_window flag set and returns
 // the typed payload resizeWindowArgsFromFlags builds from it, without
@@ -132,11 +148,9 @@ func TestResizeWindowArgsFromFlags_CarriesThePresetAndTheOtherFlags(t *testing.T
 func TestResizeWindowCommand_RejectsAnUnknownPreset(t *testing.T) {
 	t.Parallel()
 
-	const unknownPreset = "left-third"
-
-	_, err := runCommand(t, actionCommandName, "resize_window", unknownPreset)
+	_, err := runCommand(t, actionCommandName, resizeWindowCommandName, unknownPreset)
 	if err == nil {
-		t.Fatalf("resize_window %s: expected an error", unknownPreset)
+		t.Fatalf("%s %s: expected an error", resizeWindowCommandName, unknownPreset)
 	}
 
 	_, wantErr := action.ParseResizePreset(unknownPreset)
@@ -146,15 +160,187 @@ func TestResizeWindowCommand_RejectsAnUnknownPreset(t *testing.T) {
 }
 
 // TestFocusWindowCommand_RejectsBackwardWithDirection checks the CLI surfaces
-// action.NewFocusWindowArgs' validation before ever reaching the desktop —
-// this fails during flag validation, not execution, so it is safe to run
-// through the real command tree.
+// action.NewFocusWindowCommand's validation before ever reaching the desktop —
+// this fails while the command is being built, not while it runs, so it is
+// safe to run through the real command tree.
 func TestFocusWindowCommand_RejectsBackwardWithDirection(t *testing.T) {
 	t.Parallel()
 
-	_, err := runCommand(t, actionCommandName, "focus_window", "--backward", "--up")
+	_, err := runCommand(t, actionCommandName, focusWindowCommandName, "--backward", "--up")
 	if err == nil {
 		t.Fatal("expected an error combining --backward with a direction flag")
+	}
+}
+
+// malformedAction is one command line that names an action and gives it
+// arguments the action must reject.
+type malformedAction struct {
+	name string
+	argv []string
+}
+
+// malformedActionArgv lists one command line per way an action's arguments can
+// be malformed — every case mimi#126 names, plus the two space arguments,
+// which the subcommand's own argument check rejects on the same rule the
+// constructor calls. None of them can reach the desktop.
+func malformedActionArgv() []malformedAction {
+	return []malformedAction{
+		{name: "negative width", argv: []string{resizeWindowCommandName, "--width", "-5"}},
+		{name: "negative height", argv: []string{resizeWindowCommandName, "--height", "-5"}},
+		{
+			name: "width-percent above 100",
+			argv: []string{resizeWindowCommandName, "--width-percent", "150"},
+		},
+		{
+			name: "negative height-percent",
+			argv: []string{resizeWindowCommandName, "--height-percent", "-1"},
+		},
+		{name: "unknown anchor", argv: []string{resizeWindowCommandName, "--anchor", "xx"}},
+		{name: "unknown preset", argv: []string{resizeWindowCommandName, unknownPreset}},
+		{
+			name: "a direction combined with --backward",
+			argv: []string{focusWindowCommandName, "--backward", "--up"},
+		},
+		{name: "space zero", argv: []string{string(action.NameSpace), "0"}},
+		{
+			name: "move_window_to_space nonsense",
+			argv: []string{string(action.NameMoveWindowToSpace), "nxt"},
+		},
+	}
+}
+
+// listeningDaemon starts a Unix listener that answers every request the way a
+// daemon would, and returns the number of connections it has accepted. A
+// command that validates its arguments before routing them never makes that
+// count move.
+func listeningDaemon(t *testing.T, socketPath string) *atomic.Int64 {
+	t.Helper()
+
+	lc := net.ListenConfig{}
+
+	listener, err := lc.Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("listening on fake daemon socket: %v", err)
+	}
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := &atomic.Int64{}
+
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+
+			accepted.Add(1)
+
+			_, _ = bufio.NewReader(conn).ReadBytes('\n')
+			_, _ = conn.Write([]byte("{\"ok\":true}\n"))
+			_ = conn.Close()
+		}
+	}()
+
+	return accepted
+}
+
+// actionArgv builds the command line that runs argv as an action subcommand
+// against the config at configPath.
+func actionArgv(configPath string, argv []string) []string {
+	return append([]string{"--config", configPath, actionCommandName}, argv...)
+}
+
+// TestActionCommands_RejectMalformedArgumentsWithoutOpeningASocket covers
+// mimi#126: every action builds its command through a constructor that
+// validates, so a malformed argument fails in the CLI's own process — with a
+// daemon listening on the configured socket and never contacted.
+//
+// Each case then routes a command over the same socket, so an accepted count
+// that stayed at zero is read as "nothing was sent" rather than as "nothing
+// could have been": the empty command name below is one no action carries, so
+// it never reaches the desktop whichever path takes it.
+func TestActionCommands_RejectMalformedArgumentsWithoutOpeningASocket(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range malformedActionArgv() {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			socketPath := filepath.Join(shortSocketDir(t), "mimi.sock")
+			accepted := listeningDaemon(t, socketPath)
+			configPath := configWithSocket(t, socketPath)
+
+			_, err := runCommand(t, actionArgv(configPath, testCase.argv)...)
+			if err == nil {
+				t.Fatalf("%v: expected an error", testCase.argv)
+			}
+
+			if accepted.Load() != 0 {
+				t.Fatalf(
+					"%v reached the daemon: %d connection(s) accepted",
+					testCase.argv,
+					accepted.Load(),
+				)
+			}
+
+			err = (&cliState{configPath: configPath}).runAction(action.Command{})
+			if err != nil {
+				t.Fatalf("routing a command over the same socket = %v, want nil", err)
+			}
+
+			if accepted.Load() != 1 {
+				t.Fatalf(
+					"the socket registers nothing at all: %d connection(s) accepted after routing one command",
+					accepted.Load(),
+				)
+			}
+		})
+	}
+}
+
+// TestActionCommands_RejectMalformedArgumentsIdenticallyWithAndWithoutADaemon
+// is the user-visible half of mimi#126: the same malformed argument used to
+// read one way when a daemon was listening and another way when it was not,
+// because only one of the two paths checked it. Validating as the command is
+// built leaves one sentence for both.
+func TestActionCommands_RejectMalformedArgumentsIdenticallyWithAndWithoutADaemon(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range malformedActionArgv() {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			liveSocket := filepath.Join(shortSocketDir(t), "mimi.sock")
+			listeningDaemon(t, liveSocket)
+
+			// Nothing ever listens here, so this run falls back to the direct
+			// path — the other side of the behavior difference.
+			deadSocket := filepath.Join(shortSocketDir(t), "mimi.sock")
+
+			_, withDaemon := runCommand(
+				t,
+				actionArgv(configWithSocket(t, liveSocket), testCase.argv)...)
+			if withDaemon == nil {
+				t.Fatalf("%v with a daemon listening: expected an error", testCase.argv)
+			}
+
+			_, withoutDaemon := runCommand(
+				t,
+				actionArgv(configWithSocket(t, deadSocket), testCase.argv)...)
+			if withoutDaemon == nil {
+				t.Fatalf("%v with no daemon: expected an error", testCase.argv)
+			}
+
+			if withDaemon.Error() != withoutDaemon.Error() {
+				t.Errorf(
+					"%v reads differently depending on the daemon:\n with: %s\n without: %s",
+					testCase.argv,
+					withDaemon,
+					withoutDaemon,
+				)
+			}
+		})
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,6 +58,8 @@ CLI actions pump the run loop briefly after posting events so gestures complete 
 
 When the daemon is running, `mimi action` first tries the Unix socket at `settings.socket_file`. The daemon executes the action on a dedicated OS thread and returns the result. If the socket is unavailable, the CLI falls back to direct execution.
 
+Each action builds its command through the constructor `internal/action` gives it (`NewFocusWindowCommand`, `NewSpaceCommand`, `NewMoveWindowToSpaceCommand`, `NewResizeWindowCommand`), and those constructors validate as they build. A malformed argument is therefore rejected before either path is chosen — no socket is opened, and the message reads the same whether or not a daemon is listening.
+
 ---
 
 ## Hook Daemon

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -29,6 +29,10 @@ const (
 	// one: the input every rejection case below is written against.
 	unknownPreset = "left-third"
 
+	// nonNumericArg names no space and no preset — the argument every
+	// "that is not a number or a keyword" case is written against.
+	nonNumericArg = "foo"
+
 	flagWidth         = "--width"
 	flagHeight        = "--height"
 	flagWidthPercent  = "--width-percent"
@@ -133,7 +137,7 @@ func TestParseSpaceArg_MalformedNamesTheAction(t *testing.T) {
 	}{
 		{name: "empty", args: []string{""}},
 		{name: "whitespace only", args: []string{"   "}},
-		{name: "non-numeric", args: []string{"foo"}},
+		{name: "non-numeric", args: []string{nonNumericArg}},
 		{name: "zero", args: []string{"0"}},
 		{name: "negative", args: []string{"-1"}},
 		{name: "no argument", args: nil},
@@ -186,7 +190,7 @@ func TestExecute_SpaceValidation(t *testing.T) {
 	}{
 		{name: "zero", arg: "0", code: derrors.CodeInvalidInput},
 		{name: "negative", arg: "-1", code: derrors.CodeInvalidInput},
-		{name: "non-numeric", arg: "foo", code: derrors.CodeInvalidInput},
+		{name: "non-numeric", arg: nonNumericArg, code: derrors.CodeInvalidInput},
 		{name: "empty", arg: "", code: derrors.CodeInvalidInput},
 	}
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -5,10 +5,22 @@ import (
 	"github.com/y3owk1n/mimi/internal/geometry"
 )
 
-// Command is a fully-typed action instruction, built once by the caller
-// instead of round-tripped through the string arguments the IPC wire format
-// carries. Only the field matching Name is read; the others sit at their
-// zero value.
+// Command is one fully-specified, validated instance of an action, built once
+// by the caller instead of round-tripped through the string arguments the IPC
+// wire format carries. Only the field matching Name is read; the others sit at
+// their zero value.
+//
+// Build one through the constructor its action carries —
+// NewFocusWindowCommand, NewSpaceCommand, NewMoveWindowToSpaceCommand or
+// NewResizeWindowCommand. Each validates as it builds, so a command's
+// arguments are checked once, in one implementation, at the moment the command
+// comes into existence: the direct path and the daemon path then reject the
+// same argument in the same words, and neither reaches a socket to do it.
+//
+// The fields stay exported, which makes an ill-formed command unconventional
+// to build rather than impossible. That is deliberate: these payloads cross
+// the daemon's socket as JSON, where an unexported field encodes to {} and
+// reports no error (see docs/adr/0001-typed-versioned-daemon-wire.md).
 //
 // ExecuteCommand is the direct-execution counterpart to Execute: Execute
 // exists because the IPC wire format is strings, and ExecuteCommand exists
@@ -29,24 +41,71 @@ type FocusWindowArgs struct {
 	Direction string
 }
 
-// NewFocusWindowArgs builds focus_window's typed payload directly from the
-// CLI's already-typed flags, without a string round trip. It applies the
-// same rule parseFocusWindowArgs enforces on the string path: at most one
-// direction, and never alongside --backward.
-func NewFocusWindowArgs(
+// NewFocusWindowCommand builds focus_window's command directly from the CLI's
+// already-typed flags, without a string round trip. It applies the same rule
+// parseFocusWindowArgs enforces on the string path: at most one direction, and
+// never alongside --backward.
+func NewFocusWindowCommand(
 	backward, focusUp, focusDown, focusLeft, focusRight bool,
-) (FocusWindowArgs, error) {
+) (Command, error) {
 	direction, err := focusDirectionOf(focusUp, focusDown, focusLeft, focusRight)
 	if err != nil {
-		return FocusWindowArgs{}, err
+		return Command{}, err
 	}
 
 	err = validateFocusWindowCombo(direction, backward)
 	if err != nil {
-		return FocusWindowArgs{}, err
+		return Command{}, err
 	}
 
-	return FocusWindowArgs{Backward: backward, Direction: direction}, nil
+	return Command{
+		Name:        NameFocusWindow,
+		FocusWindow: FocusWindowArgs{Backward: backward, Direction: direction},
+	}, nil
+}
+
+// NewSpaceCommand builds space's command from the one positional argument the
+// action takes, rejecting an argument that names no space. The rule is
+// ParseSpaceArg's, called rather than restated.
+func NewSpaceCommand(args []string) (Command, error) {
+	spaceArg, err := ParseSpaceArg(NameSpace, args)
+	if err != nil {
+		return Command{}, err
+	}
+
+	return Command{Name: NameSpace, Space: spaceArg}, nil
+}
+
+// NewMoveWindowToSpaceCommand builds move_window_to_space's command from the
+// one positional argument the action takes. It is NewSpaceCommand's
+// counterpart: the same rule, reported against this action's name, landing on
+// the field this action reads.
+func NewMoveWindowToSpaceCommand(args []string) (Command, error) {
+	spaceArg, err := ParseSpaceArg(NameMoveWindowToSpace, args)
+	if err != nil {
+		return Command{}, err
+	}
+
+	return Command{Name: NameMoveWindowToSpace, MoveWindowToSpace: spaceArg}, nil
+}
+
+// NewResizeWindowCommand builds resize_window's command from the CLI's raw
+// flags, rejecting arguments the geometry cannot be asked for.
+//
+// It validates by running ResizeRequestFromArgs and keeping only its
+// rejection: the conversion from raw arguments to a geometry request is the
+// rule, so a preset name, a size, a percentage or an anchor is checked here in
+// exactly the words every other path checks it in. The command keeps the raw
+// arguments rather than the request the conversion built, because those are
+// what the socket carries and the request is not something that survives the
+// trip.
+func NewResizeWindowCommand(args ResizeWindowArgs) (Command, error) {
+	_, err := ResizeRequestFromArgs(args)
+	if err != nil {
+		return Command{}, err
+	}
+
+	return Command{Name: NameResizeWindow, ResizeWindow: args}, nil
 }
 
 // focusDirectionOf turns the four direction flags into the one direction

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/y3owk1n/mimi/internal/geometry"
 )
 
-// TestNewFocusWindowArgs_BuildsTheTypedPayload pins the mapping from the
-// CLI's already-typed bools onto FocusWindowArgs, without a string round
-// trip.
-func TestNewFocusWindowArgs_BuildsTheTypedPayload(t *testing.T) {
+// TestNewFocusWindowCommand_BuildsTheTypedPayload pins the mapping from the
+// CLI's already-typed bools onto focus_window's command, without a string
+// round trip.
+func TestNewFocusWindowCommand_BuildsTheTypedPayload(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -32,7 +32,7 @@ func TestNewFocusWindowArgs_BuildsTheTypedPayload(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := action.NewFocusWindowArgs(
+			got, err := action.NewFocusWindowCommand(
 				testCase.backward,
 				testCase.up,
 				testCase.down,
@@ -40,22 +40,26 @@ func TestNewFocusWindowArgs_BuildsTheTypedPayload(t *testing.T) {
 				testCase.right,
 			)
 			if err != nil {
-				t.Fatalf("NewFocusWindowArgs() error = %v, want nil", err)
+				t.Fatalf("NewFocusWindowCommand() error = %v, want nil", err)
 			}
 
-			if got != testCase.want {
-				t.Fatalf("NewFocusWindowArgs() = %+v, want %+v", got, testCase.want)
+			if got.Name != action.NameFocusWindow {
+				t.Fatalf("Name = %q, want %q", got.Name, action.NameFocusWindow)
+			}
+
+			if got.FocusWindow != testCase.want {
+				t.Fatalf("FocusWindow = %+v, want %+v", got.FocusWindow, testCase.want)
 			}
 		})
 	}
 }
 
-func TestNewFocusWindowArgs_RejectsMoreThanOneDirection(t *testing.T) {
+func TestNewFocusWindowCommand_RejectsMoreThanOneDirection(t *testing.T) {
 	t.Parallel()
 
-	_, err := action.NewFocusWindowArgs(false, true, true, false, false)
+	_, err := action.NewFocusWindowCommand(false, true, true, false, false)
 	if err == nil {
-		t.Fatal("NewFocusWindowArgs(up, down) expected error")
+		t.Fatal("NewFocusWindowCommand(up, down) expected error")
 	}
 
 	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
@@ -63,12 +67,12 @@ func TestNewFocusWindowArgs_RejectsMoreThanOneDirection(t *testing.T) {
 	}
 }
 
-func TestNewFocusWindowArgs_RejectsBackwardWithDirection(t *testing.T) {
+func TestNewFocusWindowCommand_RejectsBackwardWithDirection(t *testing.T) {
 	t.Parallel()
 
-	_, err := action.NewFocusWindowArgs(true, true, false, false, false)
+	_, err := action.NewFocusWindowCommand(true, true, false, false, false)
 	if err == nil {
-		t.Fatal("NewFocusWindowArgs(backward, up) expected error")
+		t.Fatal("NewFocusWindowCommand(backward, up) expected error")
 	}
 
 	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
@@ -240,6 +244,207 @@ func TestResizeRequestFromArgs_InvalidAnchor(t *testing.T) {
 
 	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
 		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+}
+
+// TestNewSpaceCommands_ParseTheArgumentIntoTheirOwnField checks each space
+// constructor puts the parsed argument on the field its action reads, so the
+// name and the payload can no longer be paired up wrongly by hand.
+func TestNewSpaceCommands_ParseTheArgumentIntoTheirOwnField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  string
+		want action.SpaceArg
+	}{
+		{name: "absolute index", arg: "2", want: action.SpaceArg{Index: 2}},
+		{name: "next", arg: nextKeyword, want: action.SpaceArg{Direction: 1}},
+		{name: "prev", arg: prevKeyword, want: action.SpaceArg{Direction: -1}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			spaceCmd, err := action.NewSpaceCommand([]string{testCase.arg})
+			if err != nil {
+				t.Fatalf("NewSpaceCommand(%q) error = %v, want nil", testCase.arg, err)
+			}
+
+			if spaceCmd.Name != action.NameSpace || spaceCmd.Space != testCase.want {
+				t.Fatalf(
+					"NewSpaceCommand(%q) = %+v, want %s carrying %+v",
+					testCase.arg,
+					spaceCmd,
+					action.NameSpace,
+					testCase.want,
+				)
+			}
+
+			moveCmd, err := action.NewMoveWindowToSpaceCommand([]string{testCase.arg})
+			if err != nil {
+				t.Fatalf("NewMoveWindowToSpaceCommand(%q) error = %v, want nil", testCase.arg, err)
+			}
+
+			if moveCmd.Name != action.NameMoveWindowToSpace ||
+				moveCmd.MoveWindowToSpace != testCase.want {
+				t.Fatalf(
+					"NewMoveWindowToSpaceCommand(%q) = %+v, want %s carrying %+v",
+					testCase.arg,
+					moveCmd,
+					action.NameMoveWindowToSpace,
+					testCase.want,
+				)
+			}
+		})
+	}
+}
+
+// TestNewSpaceCommands_RejectAMalformedArgument checks both space constructors
+// reject with ParseSpaceArg — the one rule mimi#124 left in place — rather than
+// a second copy of it.
+func TestNewSpaceCommands_RejectAMalformedArgument(t *testing.T) {
+	t.Parallel()
+
+	malformed := [][]string{
+		nil,
+		{""},
+		{"0"},
+		{"-1"},
+		{nonNumericArg},
+		{"1", "2"},
+	}
+
+	builders := []struct {
+		actionName action.Name
+		build      func([]string) (action.Command, error)
+	}{
+		{actionName: action.NameSpace, build: action.NewSpaceCommand},
+		{actionName: action.NameMoveWindowToSpace, build: action.NewMoveWindowToSpaceCommand},
+	}
+
+	for _, builder := range builders {
+		actionName, build := builder.actionName, builder.build
+
+		t.Run(string(actionName), func(t *testing.T) {
+			t.Parallel()
+
+			for _, args := range malformed {
+				_, err := build(args)
+				if err == nil {
+					t.Fatalf("%s %v: expected an error", actionName, args)
+				}
+
+				if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+					t.Fatalf("%s %v: expected CodeInvalidInput, got %v", actionName, args, err)
+				}
+
+				_, wantErr := action.ParseSpaceArg(actionName, args)
+				if err.Error() != wantErr.Error() {
+					t.Errorf(
+						"%s %v rejected with its own wording:\n got: %s\nwant: %s",
+						actionName,
+						args,
+						err,
+						wantErr,
+					)
+				}
+			}
+		})
+	}
+}
+
+// TestNewResizeWindowCommand_RejectsWhatTheConversionRejects covers mimi#126:
+// resize_window's command is built through a constructor that validates as it
+// builds, and it validates by running the conversion — so every argument the
+// conversion rejects is rejected at construction, in the conversion's own
+// words, before the command exists to be sent anywhere.
+func TestNewResizeWindowCommand_RejectsWhatTheConversionRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args action.ResizeWindowArgs
+	}{
+		{
+			name: "negative width",
+			args: action.ResizeWindowArgs{Width: -5, WidthSet: true},
+		},
+		{
+			name: "negative height",
+			args: action.ResizeWindowArgs{Height: -5, HeightSet: true},
+		},
+		{
+			name: "width-percent above 100",
+			args: action.ResizeWindowArgs{WidthPercent: 150, WidthPercentSet: true},
+		},
+		{
+			name: "negative height-percent",
+			args: action.ResizeWindowArgs{HeightPercent: -1, HeightPercentSet: true},
+		},
+		{
+			name: "unknown anchor",
+			args: action.ResizeWindowArgs{Anchor: "xx", AnchorSet: true},
+		},
+		{
+			name: "unknown preset",
+			args: action.ResizeWindowArgs{Preset: unknownPreset},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := action.NewResizeWindowCommand(testCase.args)
+			if err == nil {
+				t.Fatalf("NewResizeWindowCommand(%+v) expected an error", testCase.args)
+			}
+
+			if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Fatalf("expected CodeInvalidInput, got %v", err)
+			}
+
+			_, wantErr := action.ResizeRequestFromArgs(testCase.args)
+			if err.Error() != wantErr.Error() {
+				t.Errorf(
+					"rejected with its own wording:\n got: %s\nwant: %s",
+					err,
+					wantErr,
+				)
+			}
+		})
+	}
+}
+
+// TestNewResizeWindowCommand_CarriesTheRawArgumentsUnchanged pins the other
+// half: a valid command keeps the raw flags it was built from, rather than the
+// geometry request the conversion made of them. Those raw flags are what the
+// socket carries (see docs/adr/0001-typed-versioned-daemon-wire.md); the
+// conversion runs here for its rejections, not for its result.
+func TestNewResizeWindowCommand_CarriesTheRawArgumentsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	args := action.ResizeWindowArgs{
+		Preset: presetLeftHalf,
+		Width:  800, WidthSet: true,
+		Height: 600, HeightSet: true,
+		Anchor: "cc", AnchorSet: true,
+		NoMargin: true,
+	}
+
+	cmd, err := action.NewResizeWindowCommand(args)
+	if err != nil {
+		t.Fatalf("NewResizeWindowCommand(%+v) error = %v, want nil", args, err)
+	}
+
+	if cmd.Name != action.NameResizeWindow {
+		t.Fatalf("Name = %q, want %q", cmd.Name, action.NameResizeWindow)
+	}
+
+	if cmd.ResizeWindow != args {
+		t.Fatalf("ResizeWindow = %+v, want %+v", cmd.ResizeWindow, args)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR reworks how `mimi action` builds a command so that a bad argument is caught in the CLI's own process, before anything is routed anywhere. Every action now assembles its command through a constructor that validates as it builds, and the CLI has no other way in.

Previously the check a malformed flag met depended on whether the daemon happened to be running. `mimi action resize_window --width -5` failed locally with one sentence when nothing was listening, and opened the socket, sent the bad value and reported the daemon's differently-worded answer when something was. Now it fails immediately with the same sentence either way, and no socket is opened to find out. The same is true of a negative height, a percentage outside 0-100, an unknown anchor, an unknown preset, a space argument that names no space, and a direction flag combined with `--backward`.

There is a deliberate limit: the payloads keep exported fields, so a command can still be assembled by hand without passing through a constructor — that is unconventional now, not impossible. Hiding the fields was rejected in `docs/adr/0001-typed-versioned-daemon-wire.md`, because these payloads are about to cross a JSON wire where an unexported field encodes to `{}` and reports no error.

## Related Issues

Closes #126

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — ran `just test-all`, plus `just fmt-check` and `just vet`
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — `docs/ARCHITECTURE.md` now states where argument rules are applied
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

No config key, command, subcommand, flag, hook name or `mimi_*` variable changes; every invocation that worked before works unchanged. What changes for a user is when and how an already-invalid invocation fails: earlier, and with one wording rather than two. Nothing that used to succeed now fails.

Typed `refactor` rather than `fix` in line with the rest of this sequence (#124, #125) and the issue's own title, even though the behaviour difference is visible from the outside.

The rules themselves were not touched or copied. The resize constructor validates by running the existing conversion from raw arguments to a geometry request and keeping only its rejection — that conversion is the single implementation of those rules, and adding a second one beside it is the defect this sequence exists to remove. The space constructors call the same argument parser the subcommands' argument check already used.

Two tests carry the user-visible claim: one runs every malformed invocation against a tree pointed at a socket a stand-in daemon is listening on and asserts the daemon is never contacted, and the other runs each invocation twice — with a daemon listening and without — and asserts the two error messages are identical.
