### PR TITLE
fix(ipc,cli): detect a daemon on an older wire protocol and say so

### DIFF
--- a/cmd/mimi/cmd/action_runner.go
+++ b/cmd/mimi/cmd/action_runner.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/ipc"
@@ -20,6 +22,23 @@ func (s *cliState) runAction(cmd action.Command) error {
 	}
 
 	if derrors.IsCode(err, derrors.CodeDaemonUnavailable) {
+		return action.ExecuteCommand(cmd)
+	}
+
+	// A daemon left running across an upgrade speaks a different request
+	// envelope than this build, and says so under a code of its own. The
+	// command still runs — on the direct path, exactly as it does when no
+	// daemon is listening — because hard-erroring here would break every
+	// hotkey until someone restarts the daemon, for a condition the direct
+	// path handles fine. Falling back silently was rejected too: the skew
+	// would then last until the next reboot with nothing ever mentioning it.
+	if derrors.IsCode(err, derrors.CodeProtocolMismatch) {
+		_, _ = fmt.Fprintf(
+			s.warnWriter(),
+			"mimi: the daemon speaks a different request protocol than this CLI (%s) — restart the daemon so it runs this build ('mimi stop && mimi start', or 'mimi services restart' when installed as a service). This action ran on the direct path instead.\n",
+			derrors.Message(err),
+		)
+
 		return action.ExecuteCommand(cmd)
 	}
 

--- a/cmd/mimi/cmd/action_runner_test.go
+++ b/cmd/mimi/cmd/action_runner_test.go
@@ -3,11 +3,13 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/action"
@@ -68,6 +70,71 @@ func TestRunAction_RoutesToDaemonWhenListening(t *testing.T) {
 	socketPath := filepath.Join(shortSocketDir(t), "mimi.sock")
 	state := stateWithSocketConfig(t, socketPath)
 
+	// The fake daemon never inspects what was asked of it for this test.
+	serveOneResponse(t, socketPath, `{"ok":true}`)
+
+	err := state.runAction(action.Command{})
+	if err != nil {
+		t.Fatalf(
+			"runAction with a daemon listening on the configured socket = %v, want nil (it should have routed there instead of falling back to direct execution, which always errors on an empty action name)",
+			err,
+		)
+	}
+}
+
+// TestRunAction_FallsBackToDirectWhenTheDaemonSpeaksAnotherProtocol is the CLI
+// half of mimi#128: a daemon left running across an upgrade rejects the
+// request with CodeProtocolMismatch, and the CLI treats that the way it
+// already treats an absent daemon — it runs the command on the direct path —
+// except that it also says so, because a mismatch that nobody is told about
+// persists until the next reboot.
+//
+// The fallback is observable the same way the no-daemon case is: the empty
+// action name only ever fails with CodeInvalidInput on the direct path, and
+// the fake daemon below answers nothing but the mismatch. The warning is
+// asserted on its parts rather than its wording — the cause, the fix, and the
+// path the action actually ran on — so it can be reworded without a test
+// change but cannot lose one of the three.
+func TestRunAction_FallsBackToDirectWhenTheDaemonSpeaksAnotherProtocol(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(shortSocketDir(t), "mimi.sock")
+	state := stateWithSocketConfig(t, socketPath)
+
+	var warnings bytes.Buffer
+
+	state.warnOut = &warnings
+
+	serveOneResponse(t, socketPath, fmt.Sprintf(
+		`{"ok":false,"code":%q,"message":"daemon speaks request protocol version 1, client sent 2"}`,
+		derrors.CodeProtocolMismatch,
+	))
+
+	err := state.runAction(action.Command{})
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf(
+			"runAction against a mismatched daemon = %v, want CodeInvalidInput from the direct path it should have fallen back to",
+			err,
+		)
+	}
+
+	warning := warnings.String()
+	if warning == "" {
+		t.Fatal("the fallback was silent; expected a warning naming the mismatch")
+	}
+
+	for _, want := range []string{"protocol", "restart", "direct"} {
+		if !strings.Contains(strings.ToLower(warning), want) {
+			t.Errorf("warning %q does not mention %q", warning, want)
+		}
+	}
+}
+
+// serveOneResponse stands a fake daemon on socketPath that answers a single
+// request with response, then hangs up.
+func serveOneResponse(t *testing.T, socketPath, response string) {
+	t.Helper()
+
 	lc := net.ListenConfig{}
 
 	listener, err := lc.Listen(context.Background(), "unix", socketPath)
@@ -84,19 +151,9 @@ func TestRunAction_RoutesToDaemonWhenListening(t *testing.T) {
 		}
 		defer func() { _ = conn.Close() }()
 
-		// Drain the request line, then answer ok — the fake daemon never
-		// needs to inspect what was asked of it for this test.
 		_, _ = bufio.NewReader(conn).ReadBytes('\n')
-		_, _ = conn.Write([]byte("{\"ok\":true}\n"))
+		_, _ = conn.Write([]byte(response + "\n"))
 	}()
-
-	err = state.runAction(action.Command{})
-	if err != nil {
-		t.Fatalf(
-			"runAction with a daemon listening on the configured socket = %v, want nil (it should have routed there instead of falling back to direct execution, which always errors on an empty action name)",
-			err,
-		)
-	}
 }
 
 // TestRunAction_FallsBackToDirectWhenNoDaemonListening is

--- a/cmd/mimi/cmd/configpath.go
+++ b/cmd/mimi/cmd/configpath.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"io"
+	"os"
+
 	"github.com/y3owk1n/mimi/internal/config"
 )
 
@@ -9,6 +12,21 @@ import (
 // path before any command runs.
 type cliState struct {
 	configPath string
+	// warnOut is where warnings that are not the command's own output go.
+	// Nil means os.Stderr, which is what every real command tree leaves it
+	// at; a test sets it to read what a user would have been told.
+	warnOut io.Writer
+}
+
+// warnWriter returns the stream warnings go to. Warnings never share the
+// command's stdout: an action's own output has to stay exactly what it was
+// with no daemon in the picture at all.
+func (s *cliState) warnWriter() io.Writer {
+	if s.warnOut != nil {
+		return s.warnOut
+	}
+
+	return os.Stderr
 }
 
 // resolveConfigPath replaces an empty --config with the default config path.

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -110,7 +110,7 @@ return derrors.New(derrors.CodeInternal, "something went wrong")
 return derrors.Wrapf(err, derrors.CodeConfigIOFailed, "reading config")
 ```
 
-Available error codes: `CodeAccessibilityDenied`, `CodeAccessibilityFailed`, `CodeInvalidConfig`, `CodeInvalidInput`, `CodeActionFailed`, `CodeContextCanceled`, `CodeTimeout`, `CodeInternal`, `CodeLoggingFailed`, `CodeConfigIOFailed`, `CodeSerializationFailed`, `CodeBridgeFailed`, `CodeDaemonUnavailable`, `CodeIPCFailed`, `CodeServiceFailed`, `CodeNotSupported`.
+Available error codes: `CodeAccessibilityDenied`, `CodeAccessibilityFailed`, `CodeInvalidConfig`, `CodeInvalidInput`, `CodeActionFailed`, `CodeContextCanceled`, `CodeTimeout`, `CodeInternal`, `CodeLoggingFailed`, `CodeConfigIOFailed`, `CodeSerializationFailed`, `CodeBridgeFailed`, `CodeDaemonUnavailable`, `CodeIPCFailed`, `CodeProtocolMismatch`, `CodeServiceFailed`, `CodeNotSupported`.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,6 +23,19 @@ It matters when:
   restarted (it's restart-only — see [Reloading](CONFIGURATION.md#reloading)),
   the CLI is checking a socket the daemon isn't on, actions fall back to
   direct execution silently, and nothing errors.
+- **mimi was upgraded and the daemon not restarted.** The daemon path carries
+  a versioned request, and the daemon accepts only the version its own build
+  speaks. A daemon running a different build therefore rejects the request,
+  and `mimi action` runs the command on the direct path instead, printing one
+  line to stderr naming the mismatch and the fix. The action itself still does
+  what it was asked and exits as it always did, so this is a warning, not a
+  failure. Skew is rejected whichever build is ahead — a daemon newer than the
+  `mimi` binary on your `PATH` refuses that binary's requests just the same.
+  A daemon older than the version check itself has no way to recognise a
+  request it cannot read, and may instead fail the action outright with a
+  complaint about its arguments. Either way the fix is the same: restart the
+  daemon so it runs the same build as the CLI — `mimi stop && mimi start`, or
+  `mimi services restart` when it is installed as a launchd service.
 - **You're timing something.** The daemon path is a socket round trip to an
   already-running process; the direct path pays process startup cost instead
   but skips the socket. An action that behaves differently under load, or

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -53,6 +53,14 @@ const (
 	// CodeIPCFailed indicates a failure in IPC communication.
 	CodeIPCFailed Code = "IPC_FAILED"
 
+	// CodeProtocolMismatch indicates the daemon and the CLI do not speak the
+	// same version of the request envelope carried over the socket — mimi was
+	// upgraded and the daemon not restarted. It is deliberately distinct from
+	// CodeDaemonUnavailable: the CLI falls back to the direct path for both,
+	// but only this one is worth warning about, and telling them apart by
+	// message text would break the first time the message is reworded.
+	CodeProtocolMismatch Code = "PROTOCOL_MISMATCH"
+
 	// CodeServiceFailed indicates a failure managing the launchd service:
 	// rendering or writing its plist, or a launchctl invocation.
 	CodeServiceFailed Code = "SERVICE_FAILED"

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -11,11 +11,11 @@ import (
 
 // ProtocolVersion is the version of the request envelope this build speaks.
 //
-// It is carried on every request but not yet checked by the daemon; enforcing
-// it, and the fallback a mismatch triggers, is mimi#128. Bump it whenever the
-// encoded shape of a request changes in a way an older daemon would read
-// wrongly — a renamed or removed field, or a field whose meaning changed.
-// TestRequest_EncodesTheGoldenBytes is what makes such a change visible.
+// It is carried on every request and compared for strict equality by the
+// daemon. Bump it whenever the encoded shape of a request changes in a way an
+// older daemon would read wrongly — a renamed or removed field, or a field
+// whose meaning changed. TestRequest_EncodesTheGoldenBytes is what makes such
+// a change visible.
 const ProtocolVersion = 1
 
 // Request is the envelope one command travels in over the daemon's Unix
@@ -66,6 +66,25 @@ func readRequest(r *bufio.Reader) (Request, error) {
 			err,
 			derrors.CodeSerializationFailed,
 			"decoding IPC request",
+		)
+	}
+
+	// A request on another version of the envelope decodes without complaint —
+	// unknown fields are ignored and absent ones take their zero value — so
+	// this comparison, not the decoder, is what catches a CLI and a daemon
+	// built either side of a wire change. It lives here rather than at the
+	// caller so no request can be acted on without having passed it.
+	//
+	// Strict equality in both directions: skew breaks a newer daemon reading
+	// an older client's request just as badly as the reverse, and a version
+	// absent altogether decodes to zero and fails the same comparison, which
+	// is the right answer for any CLI built before the typed wire.
+	if req.Version != ProtocolVersion {
+		return Request{}, derrors.Newf(
+			derrors.CodeProtocolMismatch,
+			"daemon speaks request protocol version %d, client sent %d",
+			ProtocolVersion,
+			req.Version,
 		)
 	}
 

--- a/internal/ipc/protocol_version_test.go
+++ b/internal/ipc/protocol_version_test.go
@@ -1,0 +1,136 @@
+package ipc //nolint:testpackage // drives the unexported request encoding directly
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// TestServer_RejectsARequestOnAnotherProtocolVersion pins the daemon half of
+// mimi#128: a request whose envelope this build does not speak is refused
+// before its command reaches the action runner, and refused under a code of
+// its own so the CLI can tell it apart from an absent daemon.
+//
+// The raw request lines below are what a CLI built either side of the typed
+// wire puts on the socket, which is why they are written as bytes rather than
+// through writeRequest — writeRequest can only ever produce this build's
+// version. The absent-version case is the dangerous one the change exists for:
+// it decodes to a zero version and an empty command, which the action runner
+// would otherwise happily act on.
+func TestServer_RejectsARequestOnAnotherProtocolVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		wantCode derrors.Code
+		wantRun  bool
+	}{
+		{
+			name: "a version this build does not speak",
+			line: fmt.Sprintf(
+				`{"version":%d,"command":{"name":"space","space":{"index":2,"direction":0}}}`,
+				ProtocolVersion+1,
+			),
+			wantCode: derrors.CodeProtocolMismatch,
+		},
+		{
+			name:     "no version at all, as a CLI built before the typed wire sends",
+			line:     `{"action":"space","args":["2"]}`,
+			wantCode: derrors.CodeProtocolMismatch,
+		},
+		{
+			name: "this build's own version",
+			line: fmt.Sprintf(
+				`{"version":%d,"command":{"name":"space","space":{"index":2,"direction":0}}}`,
+				ProtocolVersion,
+			),
+			wantRun: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			ran := make(chan struct{}, 1)
+
+			socketPath := filepath.Join(shortSocketDir(t), "mimi.sock")
+			server := NewServer(socketPath)
+			server.execute = func(_ action.Command) error {
+				ran <- struct{}{}
+
+				return nil
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			runDone := make(chan error, 1)
+			go func() { runDone <- server.Run(ctx) }()
+
+			waitForSocket(t, socketPath)
+
+			resp := sendRawRequest(t, socketPath, testCase.line)
+
+			cancel()
+			<-runDone
+			server.Shutdown()
+
+			if testCase.wantRun {
+				if !resp.OK {
+					t.Fatalf("response = %+v, want ok for a matching protocol version", resp)
+				}
+			} else {
+				if resp.OK {
+					t.Fatalf("response = %+v, want a rejection", resp)
+				}
+
+				if resp.Code != string(testCase.wantCode) {
+					t.Errorf("response code = %q, want %q", resp.Code, testCase.wantCode)
+				}
+			}
+
+			select {
+			case <-ran:
+				if !testCase.wantRun {
+					t.Error("the command reached the action runner despite the version mismatch")
+				}
+			default:
+				if testCase.wantRun {
+					t.Error("the command never reached the action runner")
+				}
+			}
+		})
+	}
+}
+
+// sendRawRequest writes one request line to the daemon's socket verbatim and
+// returns the response it answers with.
+func sendRawRequest(t *testing.T, socketPath, line string) Response {
+	t.Helper()
+
+	dialer := net.Dialer{Timeout: 2 * time.Second}
+
+	conn, err := dialer.DialContext(t.Context(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("dialing the daemon socket: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	_, err = conn.Write([]byte(line + "\n"))
+	if err != nil {
+		t.Fatalf("writing the request line: %v", err)
+	}
+
+	resp, err := readResponse(bufio.NewReader(conn))
+	if err != nil {
+		t.Fatalf("reading the response: %v", err)
+	}
+
+	return resp
+}

--- a/internal/ipc/wire_test.go
+++ b/internal/ipc/wire_test.go
@@ -138,8 +138,8 @@ func TestRequest_RoundTripsEveryAction(t *testing.T) {
 // trip cannot make: a renamed field round-trips perfectly against itself and
 // still breaks every daemon that has not restarted. The bytes below are what a
 // running daemon of this protocol version reads, so changing them is a
-// protocol change — bump ProtocolVersion with it (mimi#128 makes the daemon
-// act on that).
+// protocol change — bump ProtocolVersion with it, and a daemon still running
+// the old build will reject this build's requests rather than misread them.
 //
 // One command per action, each built the way the CLI builds it. Within a
 // payload that is encoded at all, every field is, whether or not it carries a


### PR DESCRIPTION
## Description

This PR fixes mimi going quiet when you upgrade it and leave the old daemon running. Until now the daemon accepted whatever arrived on its socket, so a CLI and a daemon from different builds could disagree about what a request means with nothing said about it — in the worst case the daemon acted on a command it had misread rather than refusing it.

The daemon now accepts only requests from a build that speaks the same wire as it does, and refuses the rest. `mimi action` recognises that refusal, runs the action itself instead — exactly what it already does when no daemon is listening — and prints one line to stderr naming the mismatch, the fix, and the fact that the action ran without the daemon. The action still does what you asked and still exits with the code it always did, so this is a warning, not a failure; hard-erroring would have broken every hotkey until someone restarted the daemon, for a condition that works fine without one.

One deliberate limitation: a daemon older than this check has no way to recognise a request it cannot read, so on that one upgrade the action can still fail outright with a complaint about its arguments rather than falling back. The fix is the same either way — restart the daemon — and `docs/TROUBLESHOOTING.md` now says so, next to the `socket_file` mismatch it sits beside.

## Related Issues

Closes #128

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — plus `just fmt-check`, `just vet` and `just test-all`
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## User-facing surface

No config key, command, subcommand, flag, hook name or `mimi_*` variable changes. The only new user-visible output is one stderr line from `mimi action` when the daemon is from a different build:

```
mimi: the daemon speaks a different request protocol than this CLI (…) — restart the daemon so it runs this build ('mimi stop && mimi start', or 'mimi services restart' when installed as a service). This action ran on the direct path instead.
```

Existing configs, hook scripts and invocations are unaffected. Scripts that parse `mimi action`'s stderr are the one thing that could notice, since a line can now appear there where none did; stdout and the exit code are untouched.

## Additional Context

The check is keyed on a dedicated protocol integer, not the build version string — that string is `dev` in every local build, so a check keyed on it would be inert exactly where it gets tested. Equality is strict in both directions: skew breaks a newer daemon reading an older client's request just as badly as the reverse, and a request carrying no version at all decodes to zero and fails the same comparison, which is the right answer for any CLI built before the typed wire.

The rejection carries a new error code rather than reusing the "daemon unavailable" one, so the CLI can tell a mismatch apart from an absent daemon and warn only about the former, without sniffing message text. The code is added to the documented list in `docs/CODING_STANDARDS.md` in the same commit. Rationale for the versioned wire is in `docs/adr/0001-typed-versioned-daemon-wire.md`; per that ADR the socket payload is deliberately not documented as a public protocol, so `docs/ARCHITECTURE.md` is untouched.

Tests cover a mismatched version, an absent version, and a matching version against a real daemon on a real socket, and the CLI's fallback-and-warn against a daemon that answers with the mismatch.
