### PR TITLE
fix(action,cli): trim a resize preset name in the rule, not at the CLI

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	"github.com/y3owk1n/mimi/internal/action"
@@ -214,9 +212,13 @@ Examples:
   mimi action resize_window center --width-percent 80 --height-percent 90`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			// The preset name is forwarded exactly as it was given. This used
+			// to trim it, which is why a padded name named a preset here and
+			// was rejected on every other path (mimi#132); the trim now lives
+			// in action.ParseResizePreset, which every path runs.
 			preset := ""
 			if len(args) > 0 {
-				preset = strings.TrimSpace(args[0])
+				preset = args[0]
 			}
 
 			resizeCmd, err := action.NewResizeWindowCommand(

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -198,6 +198,19 @@ func malformedActionArgv() []malformedAction {
 		{name: "unknown anchor", argv: []string{resizeWindowCommandName, "--anchor", "xx"}},
 		{name: "unknown preset", argv: []string{resizeWindowCommandName, unknownPreset}},
 		{
+			// mimi#132: a padded name is trimmed by action.ParseResizePreset, so
+			// this is rejected for the name it carries and not for its padding.
+			name: "padded unknown preset",
+			argv: []string{resizeWindowCommandName, " " + unknownPreset + " "},
+		},
+		{
+			// mimi#132: whitespace is not part of a preset name, so an argument
+			// made of nothing else names no preset — and says so here rather
+			// than quietly resizing nothing.
+			name: "whitespace-only preset",
+			argv: []string{resizeWindowCommandName, "   "},
+		},
+		{
 			name: "a direction combined with --backward",
 			argv: []string{focusWindowCommandName, "--backward", "--up"},
 		},

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -166,12 +166,22 @@ func (e *Executor) resolveSpaceArg(name Name, parsed SpaceArg) (int, error) {
 // daemon runs again on a command it decoded — so an unknown name is rejected
 // in the same words wherever it arrives from.
 //
+// Surrounding whitespace is not part of the name and is trimmed here, the way
+// ParseSpaceArg trims a space argument, so " left-half " names the same preset
+// wherever it arrives from — a shell that padded it, a hook that built the
+// argument, or a command the daemon decoded off the socket. The CLI used to
+// trim instead, which is what made a padded name work on the direct path and
+// be rejected on every other one (mimi#132); this is now the only place it
+// happens.
+//
 // The rejection lists the ten valid names, read from the geometry's own table
 // rather than restated here, since mistyping one is the likely way to get
-// here. The empty name is not a preset either: a command that names no preset
-// never asks for one.
+// here, and quotes the name as it was given rather than as it was trimmed, so
+// padding the user did type is visible in it. A name that is empty, or is
+// nothing but whitespace, is not a preset either: a command that names no
+// preset never asks for one.
 func ParseResizePreset(name string) (geometry.Preset, error) {
-	preset, ok := geometry.ParsePreset(name)
+	preset, ok := geometry.ParsePreset(strings.TrimSpace(name))
 	if !ok {
 		return geometry.Preset{}, derrors.Newf(
 			derrors.CodeInvalidInput,

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -1,6 +1,7 @@
 package action_test
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -32,6 +33,10 @@ const (
 	// nonNumericArg names no space and no preset — the argument every
 	// "that is not a number or a keyword" case is written against.
 	nonNumericArg = "foo"
+
+	// whitespaceOnlyArg is made of nothing but whitespace, which is part of
+	// no argument's spelling: it names no space, and names no preset either.
+	whitespaceOnlyArg = "   "
 )
 
 // TestParseSpaceArg_AcceptedForms covers the accepted half of the one space
@@ -87,7 +92,7 @@ func TestParseSpaceArg_MalformedNamesTheAction(t *testing.T) {
 		args []string
 	}{
 		{name: "empty", args: []string{""}},
-		{name: "whitespace only", args: []string{"   "}},
+		{name: "whitespace only", args: []string{whitespaceOnlyArg}},
 		{name: "non-numeric", args: []string{nonNumericArg}},
 		{name: "zero", args: []string{"0"}},
 		{name: "negative", args: []string{"-1"}},
@@ -171,23 +176,53 @@ func assertListsEveryPreset(t *testing.T, err error) {
 // TestResizePreset covers mimi#125: one rule decides whether a name is a
 // preset, and it hands back the preset itself rather than a boolean beside it,
 // so a caller cannot carry an unrecognized name past the check.
+//
+// Each preset is run as it is written and with padding around it, because
+// mimi#132 makes surrounding whitespace this rule's business rather than the
+// CLI's: both spellings name the same preset, whoever asks.
 func TestResizePreset(t *testing.T) {
 	t.Parallel()
 
 	for _, name := range everyPreset() {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+		spellings := map[string]string{
+			"as written": name,
+			"padded":     "  " + name + "\t",
+		}
 
-			got, err := action.ParseResizePreset(name)
-			if err != nil {
-				t.Fatalf("ParseResizePreset(%q) error = %v", name, err)
-			}
+		for label, given := range spellings {
+			t.Run(name+"/"+label, func(t *testing.T) {
+				t.Parallel()
 
-			if got != presetFor(t, name) {
-				t.Fatalf("ParseResizePreset(%q) = %q, want %q", name, got, name)
-			}
-		})
+				got, err := action.ParseResizePreset(given)
+				if err != nil {
+					t.Fatalf("ParseResizePreset(%q) error = %v", given, err)
+				}
+
+				if got != presetFor(t, name) {
+					t.Fatalf("ParseResizePreset(%q) = %q, want %q", given, got, name)
+				}
+			})
+		}
 	}
+
+	t.Run("whitespace only", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := action.ParseResizePreset(whitespaceOnlyArg)
+		if err == nil {
+			t.Fatalf("ParseResizePreset(%q) expected error", whitespaceOnlyArg)
+		}
+
+		if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+			t.Fatalf("expected CodeInvalidInput, got %v", err)
+		}
+
+		// The rejection quotes the argument as it was given, so it never
+		// reports an empty name for something the user did type.
+		if !strings.Contains(err.Error(), strconv.Quote(whitespaceOnlyArg)) {
+			t.Errorf("rejection does not quote %q as given: %v", whitespaceOnlyArg, err)
+		}
+	})
 
 	t.Run("unknown", func(t *testing.T) {
 		t.Parallel()

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -242,6 +242,10 @@ func ResizeRequestFromArgs(args ResizeWindowArgs) (geometry.Request, error) {
 	// The preset is checked first, as the positional argument it is, so a
 	// command carrying both a mistyped preset and a bad flag is rejected for
 	// the preset on this path too.
+	//
+	// The empty string is the argument nobody gave — what a command with no
+	// positional argument carries. Anything else is a name, whitespace
+	// included, and what it names is ParseResizePreset's decision alone.
 	var preset geometry.Preset
 
 	if args.Preset != "" {

--- a/internal/action/resize_test.go
+++ b/internal/action/resize_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/geometry"
 )
 
@@ -92,6 +93,41 @@ func TestResizeRequestFromArgs_MapsArgumentsOntoTheGeometryRequest(t *testing.T)
 
 			assertRequest(t, got, testCase.want)
 		})
+	}
+}
+
+// TestResizeRequestFromArgs_TrimsAPaddedPresetName covers mimi#132 where it
+// matters most: this conversion is what the daemon runs on a command it
+// decoded off the socket, with no CLI in front of it to trim the name first. A
+// padded preset therefore has to name its preset here, or the same argument
+// means one thing on the direct path and nothing on the daemon path.
+func TestResizeRequestFromArgs_TrimsAPaddedPresetName(t *testing.T) {
+	t.Parallel()
+
+	args := action.ResizeWindowArgs{Preset: " \t" + presetLeftHalf + " "}
+
+	got, err := action.ResizeRequestFromArgs(args)
+	if err != nil {
+		t.Fatalf("ResizeRequestFromArgs(%+v) error = %v", args, err)
+	}
+
+	assertRequest(t, got, geometry.Request{Preset: presetFor(t, presetLeftHalf)})
+}
+
+// TestResizeRequestFromArgs_RejectsAPresetNameThatIsOnlyWhitespace pins the
+// other half of that rule: whitespace is not part of a preset name, so an
+// argument made of nothing else names no preset and is rejected — on every
+// path, rather than quietly meaning "no preset" on the one that trimmed.
+func TestResizeRequestFromArgs_RejectsAPresetNameThatIsOnlyWhitespace(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.ResizeRequestFromArgs(action.ResizeWindowArgs{Preset: whitespaceOnlyArg})
+	if err == nil {
+		t.Fatal("ResizeRequestFromArgs(whitespace preset) error = nil, want an error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes a resize preset name that carries stray whitespace being accepted
on one path and rejected on the others. Typing `mimi action resize_window
" left-half "` worked, because the CLI quietly trimmed the argument before
checking it; the identical command sent to a running daemon, or built anywhere
else, came back as an unknown preset. Trimming now happens where a preset name
is read, so every path agrees: a padded name resizes the window, whichever door
it arrives through, and every preset name that worked before still works
unchanged.

One consequence is worth calling out: an argument made of nothing but
whitespace now fails with the same "unknown preset" message everywhere, where
the CLI used to trim it away and treat the command as naming no preset at all.
Whitespace is not part of a preset name, so an argument made only of whitespace
names nothing — and it says so instead of quietly resizing to the flags around
it. The rejection quotes the argument exactly as it was given, so padding the
user typed is visible in the message.

## Related Issues

Closes #132

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — also `just fmt-check`, `just vet` and `just test-all`
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no document described the old trimming behaviour, and the preset names and CLI help are unchanged
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command surface

`mimi action resize_window [preset]` is the only surface touched, and its ten
preset names are unchanged. What changes is which spellings of them are
accepted, on every path rather than only at the CLI:

| Argument | Before (CLI) | Before (daemon) | Now (every path) |
| --- | --- | --- | --- |
| `left-half` | resizes | resizes | resizes |
| `" left-half "` | resizes | rejected as unknown | resizes |
| `" "` (whitespace only) | treated as no preset | rejected as unknown | rejected as unknown |
| `""` / no argument | no preset | no preset | no preset |

## Potentially breaking

Potentially breaking for one input only: a script or hotkey passing
`resize_window` an argument made entirely of whitespace — plausible from an
unquoted or empty shell variable — used to run as though no preset had been
given, applying whatever `--width`/`--height` flags accompanied it. It now
fails with an unknown-preset error instead. Passing no positional argument at
all, or an empty string, is unaffected and still means "no preset". Anything
padded around a real preset name keeps working and now works everywhere.

## Additional Context

The alternative was to keep the CLI's trim and declare a padded name invalid
everywhere else. This went the other way — the rule trims — for consistency
with the space actions, whose one rule already trims so that ` 2 ` and `next `
name a space on every path. Trimming inside the rule also means every future
caller inherits it rather than having to remember to trim first.

The trim exists in exactly one place, and the tests pin the behaviour where it
matters: at the conversion the daemon runs on a command it decoded off the
socket, with no CLI in front of it to trim anything, as well as at the rule
itself and through the CLI's own command tree.
