### PR TITLE
refactor(cli,action): validate the resize preset where the space argument is validated

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -210,19 +210,14 @@ Examples:
   mimi action resize_window --width 1024 --height 768 --x 0 --y 0 --anchor tl
   mimi action resize_window fill --no-margin
   mimi action resize_window center --width-percent 80 --height-percent 90`,
-		Args: cobra.MaximumNArgs(1),
+		Args: validateResizePresetArg,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// The preset name is forwarded exactly as it was given. This used
 			// to trim it, which is why a padded name named a preset here and
 			// was rejected on every other path (mimi#132); the trim now lives
 			// in action.ParseResizePreset, which every path runs.
-			preset := ""
-			if len(args) > 0 {
-				preset = args[0]
-			}
-
 			resizeCmd, err := action.NewResizeWindowCommand(
-				resizeWindowArgsFromFlags(cobraCmd, preset),
+				resizeWindowArgsFromFlags(cobraCmd, presetArg(args)),
 			)
 			if err != nil {
 				return err
@@ -284,6 +279,52 @@ func resizeWindowArgsFromFlags(cobraCmd *cobra.Command, preset string) action.Re
 		UseMargin:        useMargin,
 		NoMargin:         noMargin,
 	}
+}
+
+// presetArg is resize_window's optional positional argument, or "" for the
+// argument nobody gave — the spelling action.ParseResizePresetArg reads it in.
+func presetArg(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	return args[0]
+}
+
+// validateResizePresetArg is resize_window's Args validator, which puts its
+// positional argument in the same layer the space actions validate theirs in
+// (mimi#133). Cobra rejects the argument before RunE runs — that is what
+// produces the usage output and the exit code — and the rule it rejects with is
+// action.ParseResizePresetArg, the one place that rule lives, and the same rule
+// ResizeRequestFromArgs calls for a command that reached the daemon path
+// without passing here.
+//
+// Arity stays cobra's, checked before the preset, so an extra positional
+// argument still reads as the arity mistake it is rather than as a mistyped
+// preset. That is where this differs in shape from validateSpaceArg, whose
+// rule counts the arguments itself.
+//
+// Nothing a user sees moves by validating here: the usage output, the exit
+// code and which of several mistakes gets reported are the same as when the
+// preset was checked in the command body. Cobra parses flags before it
+// validates arguments, so a flag it cannot parse at all was already reported
+// ahead of the preset; a flag whose value parses but breaks a rule is still
+// reported after it, since the preset is rejected here before RunE reads a
+// flag at all, and action.ResizeRequestFromArgs checks the preset first for the
+// daemon path. What does move is invisible: the persistent pre-run that
+// resolves the config path no longer runs for a bad preset, and it only assigns
+// a field.
+// TestResizeWindowCommand_ReportsThePositionalArgumentAndTheFlagsInOneOrder
+// pins the orderings.
+func validateResizePresetArg(cobraCmd *cobra.Command, args []string) error {
+	err := cobra.MaximumNArgs(1)(cobraCmd, args)
+	if err != nil {
+		return err
+	}
+
+	_, err = action.ParseResizePresetArg(presetArg(args))
+
+	return err
 }
 
 // validateSpaceArg builds the Args validator for an action that takes one

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -28,6 +28,10 @@ const (
 	// unknownPreset is a name that is not one of the ten presets, and never
 	// becomes one.
 	unknownPreset = "left-third"
+
+	// whitespaceOnlyArg is a positional argument made of nothing but
+	// whitespace, which names neither a preset nor a space.
+	whitespaceOnlyArg = "   "
 )
 
 // resizeFlags parses args against a fresh resize_window flag set and returns
@@ -159,6 +163,247 @@ func TestResizeWindowCommand_RejectsAnUnknownPreset(t *testing.T) {
 	}
 }
 
+// TestResizeWindowCommand_ReportsThePositionalArgumentAndTheFlagsInOneOrder is
+// the evidence mimi#133 asks for: what a command line with more than one thing
+// wrong is rejected for, now that resize_window's preset is validated in the
+// Args layer rather than in the command body.
+//
+// The order does not depend on that layer, which is why moving the check was
+// free — every case below reports the same thing as it did when the preset was
+// checked in the body. Cobra parses flags before it validates arguments, so a
+// flag it cannot parse at all is reported ahead of the preset either way — the
+// same order "space 0 --nope" has always had, and the case below runs both
+// styles to show it. A flag whose value parses but breaks a rule is reported
+// after the preset: the Args layer now rejects the preset before RunE reads a
+// flag at all, and action.ResizeRequestFromArgs checks the preset first for the
+// daemon path, so both agree. An extra positional argument is reported as
+// arity, ahead of both.
+func TestResizeWindowCommand_ReportsThePositionalArgumentAndTheFlagsInOneOrder(t *testing.T) {
+	t.Parallel()
+
+	_, presetErr := action.ParseResizePreset(unknownPreset)
+	if presetErr == nil {
+		t.Fatalf("ParseResizePreset(%q): expected an error", unknownPreset)
+	}
+
+	testCases := []struct {
+		name    string
+		argv    []string
+		wantErr string
+	}{
+		{
+			name:    "an unparsable flag value beats the preset",
+			argv:    []string{resizeWindowCommandName, unknownPreset, "--height", "abc"},
+			wantErr: `invalid argument "abc" for "--height" flag: strconv.ParseInt: parsing "abc": invalid syntax`,
+		},
+		{
+			name:    "an unknown flag beats the preset",
+			argv:    []string{resizeWindowCommandName, unknownPreset, "--nope"},
+			wantErr: "unknown flag: --nope",
+		},
+		{
+			name:    "an unknown flag beats a space argument too",
+			argv:    []string{string(action.NameSpace), "0", "--nope"},
+			wantErr: "unknown flag: --nope",
+		},
+		{
+			name:    "the preset beats an unknown anchor",
+			argv:    []string{resizeWindowCommandName, unknownPreset, "--anchor", "xx"},
+			wantErr: presetErr.Error(),
+		},
+		{
+			name:    "the preset beats a width-percent above 100",
+			argv:    []string{resizeWindowCommandName, unknownPreset, "--width-percent", "150"},
+			wantErr: presetErr.Error(),
+		},
+		{
+			name:    "arity beats the preset",
+			argv:    []string{resizeWindowCommandName, unknownPreset, "extra"},
+			wantErr: "accepts at most 1 arg(s), received 2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := runCommand(t, append([]string{actionCommandName}, testCase.argv...)...)
+			if err == nil {
+				t.Fatalf("%v: expected an error", testCase.argv)
+			}
+
+			if err.Error() != testCase.wantErr {
+				t.Errorf(
+					"%v rejected for the wrong thing:\n got: %s\nwant: %s",
+					testCase.argv,
+					err,
+					testCase.wantErr,
+				)
+			}
+
+			if !strings.Contains(out, "Usage:") {
+				t.Errorf("%v printed no usage, got: %s", testCase.argv, out)
+			}
+		})
+	}
+}
+
+// stubbedRun runs argv against a fresh command tree whose leaf at path has had
+// its body replaced with a stub, and reports what the tree printed, whether the
+// stub ran, and how the run ended. Stubbing the body is what lets a test drive
+// the real tree without the action reaching the desktop.
+func stubbedRun(t *testing.T, path, argv []string) (string, bool, error) {
+	t.Helper()
+
+	var out bytes.Buffer
+
+	ran := false
+	root := newRootCmd()
+
+	target, _, err := root.Find(path)
+	if err != nil {
+		t.Fatalf("finding %v: %v", path, err)
+	}
+
+	target.RunE = func(_ *cobra.Command, _ []string) error {
+		ran = true
+
+		return nil
+	}
+
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(argv)
+
+	err = root.Execute()
+
+	return out.String(), ran, err
+}
+
+// assertRejectedBeforeRunE checks the tree rejected argv in the Args layer:
+// with wantErr's own wording, printing usage, and with the command body never
+// running. That layer is what produces the usage output and the exit code, so
+// both actions that validate a positional argument there are pinned through
+// here.
+func assertRejectedBeforeRunE(t *testing.T, path, argv []string, wantErr error) {
+	t.Helper()
+
+	out, ran, err := stubbedRun(t, path, argv)
+	if err == nil {
+		t.Fatalf("%v: expected an error", argv)
+	}
+
+	if err.Error() != wantErr.Error() {
+		t.Errorf(
+			"%v failed with something other than the rule:\n got: %s\nwant: %s",
+			argv,
+			err,
+			wantErr,
+		)
+	}
+
+	if ran {
+		t.Errorf("%v reached RunE", argv)
+	}
+
+	if !strings.Contains(out, "Usage:") {
+		t.Errorf("%v printed no usage, got: %s", argv, out)
+	}
+}
+
+// TestResizeWindowArgValidation_RejectsBeforeRunE is resize_window's half of
+// mimi#133: its positional argument is now checked in the same layer the space
+// actions check theirs in, so an unknown preset never reaches the command body.
+// The tree fails with action.ParseResizePreset's own wording and prints its
+// usage, exactly as it did when the check sat in the body.
+func TestResizeWindowArgValidation_RejectsBeforeRunE(t *testing.T) {
+	t.Parallel()
+
+	for _, preset := range []string{unknownPreset, " " + unknownPreset + " ", whitespaceOnlyArg} {
+		t.Run(preset, func(t *testing.T) {
+			t.Parallel()
+
+			_, wantErr := action.ParseResizePreset(preset)
+			if wantErr == nil {
+				t.Fatalf("ParseResizePreset(%q): expected an error", preset)
+			}
+
+			assertRejectedBeforeRunE(
+				t,
+				[]string{actionCommandName, resizeWindowCommandName},
+				[]string{actionCommandName, resizeWindowCommandName, preset},
+				wantErr,
+			)
+		})
+	}
+}
+
+// TestResizeWindowArgValidation_AcceptsWhatItAlwaysAccepted is the other half
+// of mimi#133's promise: checking the preset in the Args layer rejects nothing
+// the command body used to let through.
+//
+// The empty argument is the case that needs saying. resize_window's positional
+// argument is optional, so "" is the argument nobody gave rather than a preset
+// named "" — a distinction only action.ParseResizePresetArg's empty-string
+// branch keeps, and one the Args layer would otherwise turn into a rejection
+// for an input that has always been accepted. The command body is stubbed out,
+// so nothing here reaches the desktop.
+func TestResizeWindowArgValidation_AcceptsWhatItAlwaysAccepted(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "no argument", args: nil},
+		{name: "the empty argument", args: []string{""}},
+		{name: "a preset", args: []string{"left-half"}},
+		{name: "a padded preset", args: []string{" left-half "}},
+		{name: "a preset beside its flags", args: []string{"center", "--x", "10"}},
+		{name: "flags with no preset", args: []string{"--margin"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := []string{actionCommandName, resizeWindowCommandName}
+
+			_, ran, err := stubbedRun(t, path, append(path, testCase.args...))
+			if err != nil {
+				t.Fatalf("%v rejected: %v", testCase.args, err)
+			}
+
+			if !ran {
+				t.Errorf("%v never reached RunE", testCase.args)
+			}
+		})
+	}
+}
+
+// TestResizeWindowArgValidation_HelpStillWinsOverABadPreset pins the one thing
+// asking for help must keep doing: cobra answers --help before it validates
+// arguments, so a command line that also carries an unknown preset prints the
+// help text and succeeds rather than being rejected for the preset.
+func TestResizeWindowArgValidation_HelpStillWinsOverABadPreset(t *testing.T) {
+	t.Parallel()
+
+	path := []string{actionCommandName, resizeWindowCommandName}
+
+	out, ran, err := stubbedRun(t, path, append(path, unknownPreset, "--help"))
+	if err != nil {
+		t.Fatalf("--help beside %q failed: %v", unknownPreset, err)
+	}
+
+	if ran {
+		t.Error("--help reached RunE")
+	}
+
+	if !strings.Contains(out, "Usage:") {
+		t.Errorf("--help printed no usage, got: %s", out)
+	}
+}
+
 // TestFocusWindowCommand_RejectsBackwardWithDirection checks the CLI surfaces
 // action.NewFocusWindowCommand's validation before ever reaching the desktop —
 // this fails while the command is being built, not while it runs, so it is
@@ -208,7 +453,7 @@ func malformedActionArgv() []malformedAction {
 			// made of nothing else names no preset — and says so here rather
 			// than quietly resizing nothing.
 			name: "whitespace-only preset",
-			argv: []string{resizeWindowCommandName, "   "},
+			argv: []string{resizeWindowCommandName, whitespaceOnlyArg},
 		},
 		{
 			name: "a direction combined with --backward",
@@ -391,7 +636,7 @@ func malformedSpaceArgs() []struct {
 		args []string
 	}{
 		{name: "empty", args: []string{""}},
-		{name: "whitespace only", args: []string{"   "}},
+		{name: "whitespace only", args: []string{whitespaceOnlyArg}},
 		{name: "non-numeric", args: []string{"foo"}},
 		{name: "zero", args: []string{"0"}},
 		{name: "negative", args: []string{"-1"}},
@@ -510,55 +755,17 @@ func TestSpaceArgValidation_RejectsBeforeRunE(t *testing.T) {
 				t.Run(testCase.name, func(t *testing.T) {
 					t.Parallel()
 
-					var out bytes.Buffer
-
-					ran := false
-					root := newRootCmd()
-					path := []string{actionCommandName, string(name)}
-
-					target, _, err := root.Find(path)
-					if err != nil {
-						t.Fatalf("finding command: %v", err)
-					}
-
-					target.RunE = func(_ *cobra.Command, _ []string) error {
-						ran = true
-
-						return nil
-					}
-
-					root.SetOut(&out)
-					root.SetErr(&out)
-					root.SetArgs(spaceArgv(name, testCase.args))
-
-					err = root.Execute()
-					if err == nil {
-						t.Fatalf("%s %v: expected an error", name, testCase.args)
-					}
-
 					_, wantErr := action.ParseSpaceArg(name, testCase.args)
-					if err.Error() != wantErr.Error() {
-						t.Errorf(
-							"%s %v failed with something other than the rule:\n got: %s\nwant: %s",
-							name,
-							testCase.args,
-							err,
-							wantErr,
-						)
+					if wantErr == nil {
+						t.Fatalf("ParseSpaceArg(%s, %v): expected an error", name, testCase.args)
 					}
 
-					if ran {
-						t.Errorf("%s %v reached RunE", name, testCase.args)
-					}
-
-					if !strings.Contains(out.String(), "Usage:") {
-						t.Errorf(
-							"%s %v printed no usage, got: %s",
-							name,
-							testCase.args,
-							out.String(),
-						)
-					}
+					assertRejectedBeforeRunE(
+						t,
+						[]string{actionCommandName, string(name)},
+						spaceArgv(name, testCase.args),
+						wantErr,
+					)
 				})
 			}
 		})

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -194,6 +194,27 @@ func ParseResizePreset(name string) (geometry.Preset, error) {
 	return preset, nil
 }
 
+// ParseResizePresetArg parses resize_window's one positional argument into the
+// preset it names, and is the only implementation of that argument's rule.
+//
+// The empty string is the argument nobody gave — resize_window's positional
+// argument is optional, and a command that names no preset asks for none, so
+// the zero preset comes back with no error. Anything else is a name,
+// whitespace included, and what it names is ParseResizePreset's decision
+// alone.
+//
+// Both layers that reject a bad preset call this rather than restating it: the
+// CLI's Args layer, which stops the argument before the command body runs, and
+// ResizeRequestFromArgs, which checks it again for a command that arrived over
+// the daemon path with nothing having looked at it.
+func ParseResizePresetArg(name string) (geometry.Preset, error) {
+	if name == "" {
+		return geometry.Preset{}, nil
+	}
+
+	return ParseResizePreset(name)
+}
+
 // dimensionOf folds one axis's two size flags into the dimension they
 // describe. An absolute size wins over a percentage, and a zero of either
 // means the flag was never given, so the window keeps the size it has.

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -239,3 +239,49 @@ func TestResizePreset(t *testing.T) {
 		assertListsEveryPreset(t, err)
 	})
 }
+
+// TestParseResizePresetArg covers the one thing resize_window's positional
+// argument adds to the preset rule: it is optional, so the empty string is the
+// argument nobody gave and names no preset without that being an error.
+// Everything else is ParseResizePreset's decision, which is why an unknown name
+// still reads in its words — the CLI's Args layer and ResizeRequestFromArgs
+// both reject through here (mimi#133).
+func TestParseResizePresetArg(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no argument names no preset", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := action.ParseResizePresetArg("")
+		if err != nil {
+			t.Fatalf(`ParseResizePresetArg("") error = %v`, err)
+		}
+
+		if (got != geometry.Preset{}) {
+			t.Fatalf(`ParseResizePresetArg("") = %v, want the zero preset`, got)
+		}
+	})
+
+	t.Run("a name is the preset rule's decision", func(t *testing.T) {
+		t.Parallel()
+
+		for _, name := range append(everyPreset(), unknownPreset, whitespaceOnlyArg) {
+			got, gotErr := action.ParseResizePresetArg(name)
+			want, wantErr := action.ParseResizePreset(name)
+
+			switch {
+			case (gotErr == nil) != (wantErr == nil):
+				t.Errorf("ParseResizePresetArg(%q) error = %v, want %v", name, gotErr, wantErr)
+			case gotErr != nil && gotErr.Error() != wantErr.Error():
+				t.Errorf(
+					"ParseResizePresetArg(%q) rejected in other words:\n got: %s\nwant: %s",
+					name,
+					gotErr,
+					wantErr,
+				)
+			case gotErr == nil && got != want:
+				t.Errorf("ParseResizePresetArg(%q) = %v, want %v", name, got, want)
+			}
+		}
+	})
+}

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -241,20 +241,16 @@ type ResizeWindowArgs struct {
 func ResizeRequestFromArgs(args ResizeWindowArgs) (geometry.Request, error) {
 	// The preset is checked first, as the positional argument it is, so a
 	// command carrying both a mistyped preset and a bad flag is rejected for
-	// the preset on this path too.
+	// the preset on this path too. That is what makes the daemon path agree
+	// with the CLI's, where the preset is rejected in the Args layer before a
+	// flag is ever read.
 	//
-	// The empty string is the argument nobody gave — what a command with no
-	// positional argument carries. Anything else is a name, whitespace
-	// included, and what it names is ParseResizePreset's decision alone.
-	var preset geometry.Preset
-
-	if args.Preset != "" {
-		named, err := ParseResizePreset(args.Preset)
-		if err != nil {
-			return geometry.Request{}, err
-		}
-
-		preset = named
+	// ParseResizePresetArg is that layer's rule as well as this one's, called
+	// rather than restated, so the empty argument means the same thing here as
+	// it does there.
+	preset, err := ParseResizePresetArg(args.Preset)
+	if err != nil {
+		return geometry.Request{}, err
 	}
 
 	if args.WidthSet && args.Width < 0 {


### PR DESCRIPTION
## Description

This PR reworks where `mimi action resize_window` checks its preset argument. It used to be checked inside the command body, while `space` and `move_window_to_space` check theirs in the layer above, so the two positional-argument styles rejected at different points for the same job. The preset is now checked in that same layer, through one shared rule rather than a second copy of it.

Nothing a user sees changes. For a command line with more than one thing wrong, the same mistake is reported as before: an unparsable or unknown flag still beats the preset, a flag whose value breaks a rule still loses to it, too many positional arguments are still reported as that, and `--help` still wins over everything. Usage output and the exit code are unchanged for every input that was already rejected, and no input that was accepted before is rejected now — including `mimi action resize_window ""`, which still means "no preset".

## Related Issues

Closes #133

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, nothing documented changes: the command, its flags, its output and its exit code are untouched
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The issue left open whether this move was worth making, since checking the preset earlier could have reordered the messages when more than one input is wrong at once — and said that if it did, the right outcome was a comment explaining why the two styles differ rather than a change. The deciding evidence was a test written before touching anything: it pins what an invalid preset presented alongside an invalid flag is actually reported for, and it passes unchanged against the code from before this branch as well as after. That is what made the move free rather than a trade.

The order does not depend on the layer, for three reasons. Flags are parsed before positional arguments are validated, so a flag that cannot be parsed at all was already reported ahead of the preset. A flag whose value parses but breaks a range or spelling rule was, and still is, reported after the preset — now because the preset is rejected before any flag is read, and on the daemon path because the conversion from arguments to a geometry request checks the preset first. And the arity check runs before the preset check, so `resize_window one two` still reads as an arity mistake.

One deliberate limitation: the preset is still re-checked in the command body, because that check is also the daemon path's, where nothing has passed through the CLI's argument layer. That is the arrangement `docs/adr/0001-typed-versioned-daemon-wire.md` asks for — one rule, called from both ends — not a duplicate.

`just fmt-check` and `just test-all` were run in addition to the gate above.
