### PR TITLE
docs(architecture): name both conditions that fall back to direct execution

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ it is what checks that the real desktop behaves the way the fake pretends to.
 
 CLI actions pump the run loop briefly after posting events so gestures complete before the process exits.
 
-When the daemon is running, `mimi action` first tries the Unix socket at `settings.socket_file`. The daemon executes the action on a dedicated OS thread and returns the result. If the socket is unavailable, the CLI falls back to direct execution.
+When the daemon is running, `mimi action` first tries the Unix socket at `settings.socket_file`. The daemon executes the action on a dedicated OS thread and returns the result. If the socket is unavailable, the CLI falls back to direct execution. It falls back the same way when a daemon is listening but rejects the request because it accepts only the version its own build speaks, printing a warning naming the mismatch and the fix — the action still does what it was asked.
 
 Each action builds its command through the constructor `internal/action` gives it (`NewFocusWindowCommand`, `NewSpaceCommand`, `NewMoveWindowToSpaceCommand`, `NewResizeWindowCommand`), and those constructors validate as they build. A malformed argument is therefore rejected before either path is chosen — no socket is opened, and the message reads the same whether or not a daemon is listening.
 


### PR DESCRIPTION
## Description

This PR fixes the architecture overview, which described only one of the two
conditions under which `mimi action` stops using a running daemon. It said the
CLI falls back to running the action itself when the socket is unavailable —
still true, but since the daemon path gained a version check there is a second
case: a daemon that is listening but only accepts the version its own build
speaks rejects the action, and the CLI runs it directly instead, printing a
warning that names the mismatch and the fix.

One clause covers it. The overview keeps describing *when* the fallback
happens, not what travels over the socket; the wording follows the
protocol-mismatch entry in `docs/TROUBLESHOOTING.md` so the two documents read
the same way.

## Related Issues

Closes #139

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — ran `just test-all`, `just fmt-check` and `just vet` as well, all green
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, documentation only, no behaviour changed
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The behaviour was verified against the code before writing it down: the CLI
falls back both when no daemon is listening and when the daemon rejects a
version it does not speak, and it warns only in the second case. The sentence
is deliberately narrow about that second case — a daemon old enough to predate
the version check cannot report a mismatch at all, and that case does not fall
back, which `docs/TROUBLESHOOTING.md` already covers for users.

No config keys, commands, flags, or hook variables change.
