### PR TITLE
refactor(cli): send the protocol-mismatch warning through the command's error stream

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -68,7 +68,7 @@ in that direction based on screen position.
 
 Only windows that are focusable (not minimized, not hidden) and on the
 current space are included.`,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			focusCmd, err := action.NewFocusWindowCommand(
 				backward,
 				focusUp,
@@ -80,7 +80,7 @@ current space are included.`,
 				return err
 			}
 
-			return state.runAction(focusCmd)
+			return state.runAction(cobraCmd, focusCmd)
 		},
 	}
 
@@ -124,13 +124,13 @@ Examples:
   mimi action space next     Cycle to the next space (with wrap)
   mimi action space prev     Cycle to the previous space (with wrap)`,
 		Args: validateSpaceArg(action.NameSpace),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			spaceCmd, err := action.NewSpaceCommand(args)
 			if err != nil {
 				return err
 			}
 
-			return state.runAction(spaceCmd)
+			return state.runAction(cobraCmd, spaceCmd)
 		},
 	}
 }
@@ -157,13 +157,13 @@ Examples:
   mimi action move_window_to_space next     Move window to next space (with wrap)
   mimi action move_window_to_space prev     Move window to previous space (with wrap)`,
 		Args: validateSpaceArg(action.NameMoveWindowToSpace),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			moveCmd, err := action.NewMoveWindowToSpaceCommand(args)
 			if err != nil {
 				return err
 			}
 
-			return state.runAction(moveCmd)
+			return state.runAction(cobraCmd, moveCmd)
 		},
 	}
 }
@@ -223,7 +223,7 @@ Examples:
 				return err
 			}
 
-			return state.runAction(resizeCmd)
+			return state.runAction(cobraCmd, resizeCmd)
 		},
 	}
 

--- a/cmd/mimi/cmd/action_runner.go
+++ b/cmd/mimi/cmd/action_runner.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/ipc"
@@ -13,7 +15,12 @@ import (
 // paths run that same value: the daemon path puts it on the socket as JSON,
 // and the direct path runs it where it stands. Neither re-parses a string the
 // other already held typed.
-func (s *cliState) runAction(cmd action.Command) error {
+//
+// cobraCmd is the command being run, carried in for the one thing this needs
+// from it: the error stream any warning below goes out on. Warnings never
+// share the command's stdout — an action's own output has to stay exactly what
+// it was with no daemon in the picture at all.
+func (s *cliState) runAction(cobraCmd *cobra.Command, cmd action.Command) error {
 	socketPath := ipc.ResolveSocketPath(s.configPath)
 
 	err := ipc.TryExecute(socketPath, cmd)
@@ -34,7 +41,7 @@ func (s *cliState) runAction(cmd action.Command) error {
 	// would then last until the next reboot with nothing ever mentioning it.
 	if derrors.IsCode(err, derrors.CodeProtocolMismatch) {
 		_, _ = fmt.Fprintf(
-			s.warnWriter(),
+			cobraCmd.ErrOrStderr(),
 			"mimi: the daemon speaks a different request protocol than this CLI (%s) — restart the daemon so it runs this build ('mimi stop && mimi start', or 'mimi services restart' when installed as a service). This action ran on the direct path instead.\n",
 			derrors.Message(err),
 		)

--- a/cmd/mimi/cmd/action_runner_test.go
+++ b/cmd/mimi/cmd/action_runner_test.go
@@ -6,11 +6,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
@@ -56,6 +59,16 @@ func stateWithSocketConfig(t *testing.T, socketPath string) *cliState {
 	return &cliState{configPath: configWithSocket(t, socketPath)}
 }
 
+// discardErrCommand is the cobra command runAction is handed by a test that
+// does not read its warnings. Its error stream goes nowhere, so a warning the
+// test does not expect cannot reach the test binary's own stderr.
+func discardErrCommand() *cobra.Command {
+	cobraCmd := &cobra.Command{}
+	cobraCmd.SetErr(io.Discard)
+
+	return cobraCmd
+}
+
 // TestRunAction_RoutesToDaemonWhenListening pins the routing mimi#90 asks to
 // be documented and tested: since PR #88, runAction resolves socket_file
 // from the (now always-resolved) config path and finds a daemon listening on
@@ -73,7 +86,7 @@ func TestRunAction_RoutesToDaemonWhenListening(t *testing.T) {
 	// The fake daemon never inspects what was asked of it for this test.
 	serveOneResponse(t, socketPath, `{"ok":true}`)
 
-	err := state.runAction(action.Command{})
+	err := state.runAction(discardErrCommand(), action.Command{})
 	if err != nil {
 		t.Fatalf(
 			"runAction with a daemon listening on the configured socket = %v, want nil (it should have routed there instead of falling back to direct execution, which always errors on an empty action name)",
@@ -95,6 +108,11 @@ func TestRunAction_RoutesToDaemonWhenListening(t *testing.T) {
 // asserted on its parts rather than its wording — the cause, the fix, and the
 // path the action actually ran on — so it can be reworded without a test
 // change but cannot lose one of the three.
+//
+// It is read off the real tree's error stream, set on the root and inherited
+// by the leaf the warning is written from (mimi#140), which is how a caller
+// redirecting a command's error output captures this warning along with every
+// other message the command tree writes.
 func TestRunAction_FallsBackToDirectWhenTheDaemonSpeaksAnotherProtocol(t *testing.T) {
 	t.Parallel()
 
@@ -103,14 +121,20 @@ func TestRunAction_FallsBackToDirectWhenTheDaemonSpeaksAnotherProtocol(t *testin
 
 	var warnings bytes.Buffer
 
-	state.warnOut = &warnings
+	root := newRootCmd()
+	root.SetErr(&warnings)
+
+	leaf, _, err := root.Find([]string{"action", "space"})
+	if err != nil {
+		t.Fatalf("finding the action space command: %v", err)
+	}
 
 	serveOneResponse(t, socketPath, fmt.Sprintf(
 		`{"ok":false,"code":%q,"message":"daemon speaks request protocol version 1, client sent 2"}`,
 		derrors.CodeProtocolMismatch,
 	))
 
-	err := state.runAction(action.Command{})
+	err = state.runAction(leaf, action.Command{})
 	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
 		t.Fatalf(
 			"runAction against a mismatched daemon = %v, want CodeInvalidInput from the direct path it should have fallen back to",
@@ -169,7 +193,7 @@ func TestRunAction_FallsBackToDirectWhenNoDaemonListening(t *testing.T) {
 	socketPath := filepath.Join(shortSocketDir(t), "mimi.sock")
 	state := stateWithSocketConfig(t, socketPath)
 
-	err := state.runAction(action.Command{})
+	err := state.runAction(discardErrCommand(), action.Command{})
 	if err == nil {
 		t.Fatal(
 			"expected runAction to fall back to direct execution and fail on the empty action name",

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -542,7 +542,8 @@ func TestActionCommands_RejectMalformedArgumentsWithoutOpeningASocket(t *testing
 				)
 			}
 
-			err = (&cliState{configPath: configPath}).runAction(action.Command{})
+			err = (&cliState{configPath: configPath}).
+				runAction(discardErrCommand(), action.Command{})
 			if err != nil {
 				t.Fatalf("routing a command over the same socket = %v, want nil", err)
 			}

--- a/cmd/mimi/cmd/configpath.go
+++ b/cmd/mimi/cmd/configpath.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"io"
-	"os"
-
 	"github.com/y3owk1n/mimi/internal/config"
 )
 
@@ -12,21 +9,6 @@ import (
 // path before any command runs.
 type cliState struct {
 	configPath string
-	// warnOut is where warnings that are not the command's own output go.
-	// Nil means os.Stderr, which is what every real command tree leaves it
-	// at; a test sets it to read what a user would have been told.
-	warnOut io.Writer
-}
-
-// warnWriter returns the stream warnings go to. Warnings never share the
-// command's stdout: an action's own output has to stay exactly what it was
-// with no daemon in the picture at all.
-func (s *cliState) warnWriter() io.Writer {
-	if s.warnOut != nil {
-		return s.warnOut
-	}
-
-	return os.Stderr
 }
 
 // resolveConfigPath replaces an empty --config with the default config path.


### PR DESCRIPTION
## Description

This PR reworks the channel the CLI warns on when it finds a daemon speaking a
different request protocol than the CLI itself — the message that names the
mismatch, tells you to restart the daemon, and says the action ran on the direct
path instead. That warning used to go out on a stream of its own that nothing
else in the CLI wrote to, so redirecting a command's error output captured every
other message the command tree produces except this one.

It now goes out on the running command's error stream, the same channel the rest
of the CLI uses, so redirecting error output captures it along with everything
else. In normal use it still lands on stderr, and nothing else moves: the
warning's wording, the fallback to the direct path, the action's own output and
its exit code are all unchanged.

The deliberate limitation is in the test, not the behaviour: the warning's
channel is pinned one layer below a full command run, because reaching that
warning through a real command run would perform the action on the desktop.

## Related Issues

Closes #140

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — `just fmt-check`, `just vet`, `just build` and
      `just test-all` were run too, all green
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no document describes which
      stream this warning goes out on
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Nothing a user types changes: no command, flag, config key or hook variable is
touched, and the warning's text is byte-identical. The only observable
difference is that a caller who redirects a command's error output now receives
this warning there rather than always on the process's stderr.

The stream of its own was never the preferred design. It shipped that way
because a concurrent change owned the file holding the four call sites, and
routing the warning properly meant editing it. Both changes have since merged,
so the warning now takes the ordinary channel.

The test that pins the warning reads it off the command tree's error stream set
on the root and inherited by the leaf, rather than off a field, which is what
makes the redirect a tested property. It still asserts the warning's three parts
— cause, fix, and the path the action ran on — rather than its exact wording. It
stops short of driving a full command run because the warning is only reached
when the action then runs on the direct path, which on a real run would move a
window or switch a space; the package has no seam for standing a fake desktop in
front of that.
