### PR TITLE
fix(action,cli): reject --margin and --no-margin given together

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -201,7 +201,8 @@ Custom flags allow precise control using an anchor system:
   margin on internal (split) edges so adjacent windows share a
   single gap. A window too small to give up its margins is sized
   exactly as asked for instead, with no margins on either axis.
-  Use --margin or --no-margin to override.
+  Use --margin or --no-margin to override — one or the other,
+  never both.
 
 Examples:
   mimi action resize_window left-half

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -163,6 +163,41 @@ func TestResizeWindowCommand_RejectsAnUnknownPreset(t *testing.T) {
 	}
 }
 
+// TestResizeWindowCommand_RejectsBothMarginFlags covers mimi#138 at the CLI:
+// the conflicting pair is refused with the conversion's own wording rather
+// than a second copy of the rule living in this layer — which is what makes
+// the sentence identical to the one the same pair gets over the socket. No
+// cobra flag group stands in front of it, deliberately: that would be the
+// second copy.
+//
+// This fails while the command is being built, not while it runs, so it is safe
+// to run through the real command tree.
+func TestResizeWindowCommand_RejectsBothMarginFlags(t *testing.T) {
+	t.Parallel()
+
+	_, err := runCommand(
+		t,
+		actionCommandName,
+		resizeWindowCommandName,
+		"--margin",
+		"--no-margin",
+	)
+	if err == nil {
+		t.Fatal("expected an error combining --margin with --no-margin")
+	}
+
+	_, wantErr := action.ResizeRequestFromArgs(
+		action.ResizeWindowArgs{UseMargin: true, NoMargin: true},
+	)
+	if wantErr == nil {
+		t.Fatal("ResizeRequestFromArgs(--margin --no-margin): expected an error")
+	}
+
+	if err.Error() != wantErr.Error() {
+		t.Errorf("rejected with its own wording:\n got: %s\nwant: %s", err, wantErr)
+	}
+}
+
 // TestResizeWindowCommand_ReportsThePositionalArgumentAndTheFlagsInOneOrder is
 // the evidence mimi#133 asks for: what a command line with more than one thing
 // wrong is rejected for, now that resize_window's preset is validated in the
@@ -454,6 +489,12 @@ func malformedActionArgv() []malformedAction {
 			// than quietly resizing nothing.
 			name: "whitespace-only preset",
 			argv: []string{resizeWindowCommandName, whitespaceOnlyArg},
+		},
+		{
+			// mimi#138: the conflicting margin pair, refused by the rule the
+			// constructor runs rather than by anything in this layer.
+			name: "both margin flags at once",
+			argv: []string{resizeWindowCommandName, "--margin", "--no-margin"},
 		},
 		{
 			name: "a direction combined with --backward",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -117,6 +117,8 @@ bl  bc  br       (bottom-left, bottom-center, bottom-right)
 | `--margin`    | Enable tiled margins (overrides system setting) |
 | `--no-margin` | Disable tiled margins                           |
 
+Give one or neither: omitting both defers to the system tiled-window-margins setting, and giving both is rejected rather than resolved by picking one of them.
+
 **Examples:**
 
 ```bash

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -332,17 +332,41 @@ func ResizeRequestFromArgs(args ResizeWindowArgs) (geometry.Request, error) {
 		req.Anchor = &anchor
 	}
 
-	if args.UseMargin {
-		useMargins := true
-		req.UseMargins = &useMargins
+	useMargins, err := marginPreferenceOf(args.UseMargin, args.NoMargin)
+	if err != nil {
+		return geometry.Request{}, err
 	}
 
-	if args.NoMargin {
-		useMargins := false
-		req.UseMargins = &useMargins
-	}
+	req.UseMargins = useMargins
 
 	return req, nil
+}
+
+// marginPreferenceOf turns resize_window's two margin flags into the margin
+// preference they express: forced on, forced off, or — for the pair nobody
+// gave — none at all, the nil that defers to the system tiled-window-margins
+// setting.
+//
+// Asking for both at once expresses no preference either, but it is a
+// contradiction rather than a silence, so it is refused (mimi#138). The
+// conversion used to apply one flag and then the other, which made the
+// assignment written second in the code the answer regardless of what was
+// asked for.
+func marginPreferenceOf(useMargin, noMargin bool) (*bool, error) {
+	if useMargin && noMargin {
+		return nil, derrors.New(
+			derrors.CodeInvalidInput,
+			"--margin cannot be combined with --no-margin",
+		)
+	}
+
+	if !useMargin && !noMargin {
+		return nil, nil //nolint:nilnil // intentional: signals "no preference"
+	}
+
+	useMargins := useMargin
+
+	return &useMargins, nil
 }
 
 // ExecuteCommand runs cmd against the desktop mimi is running on.

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -360,6 +360,12 @@ func TestNewResizeWindowCommand_RejectsWhatTheConversionRejects(t *testing.T) {
 			name: "unknown preset",
 			args: action.ResizeWindowArgs{Preset: unknownPreset},
 		},
+		{
+			// mimi#138: the pair asks for opposite things, so the conversion
+			// refuses it and the constructor inherits that.
+			name: "both margin flags at once",
+			args: action.ResizeWindowArgs{UseMargin: true, NoMargin: true},
+		},
 	}
 
 	for _, testCase := range tests {
@@ -569,6 +575,16 @@ func TestExecuteCommand_RejectsAPayloadNoConstructorWouldBuild(t *testing.T) {
 			cmd: action.Command{
 				Name:         action.NameResizeWindow,
 				ResizeWindow: action.ResizeWindowArgs{Width: -5, WidthSet: true},
+			},
+		},
+		{
+			// mimi#138: the conflicting pair reaching the daemon off the
+			// socket, with nothing having looked at it — the CLI is not the
+			// only place the rule runs.
+			name: "resize_window asking for margins and for no margins",
+			cmd: action.Command{
+				Name:         action.NameResizeWindow,
+				ResizeWindow: action.ResizeWindowArgs{UseMargin: true, NoMargin: true},
 			},
 		},
 	}

--- a/internal/action/resize_test.go
+++ b/internal/action/resize_test.go
@@ -1,6 +1,7 @@
 package action_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/action"
@@ -93,6 +94,31 @@ func TestResizeRequestFromArgs_MapsArgumentsOntoTheGeometryRequest(t *testing.T)
 
 			assertRequest(t, got, testCase.want)
 		})
+	}
+}
+
+// TestResizeRequestFromArgs_RejectsBothMarginFlagsAtOnce covers mimi#138,
+// against the conversion because that is what every path runs — the
+// constructor for its rejection, and the daemon after decoding a command off
+// the socket. marginPreferenceOf is where the rule and its history live.
+func TestResizeRequestFromArgs_RejectsBothMarginFlagsAtOnce(t *testing.T) {
+	t.Parallel()
+
+	args := action.ResizeWindowArgs{UseMargin: true, NoMargin: true}
+
+	_, err := action.ResizeRequestFromArgs(args)
+	if err == nil {
+		t.Fatal("ResizeRequestFromArgs(--margin --no-margin) error = nil, want an error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("expected CodeInvalidInput, got %v", err)
+	}
+
+	for _, flag := range []string{"--margin", "--no-margin"} {
+		if !strings.Contains(err.Error(), flag) {
+			t.Errorf("%q does not name %s", err, flag)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes `resize_window` quietly accepting a contradictory margin instruction. Asking for margins and for no margins in the same invocation used to be resolved by whichever preference was applied last while the arguments were turned into a geometry request — in practice the window was always sized without margins, whatever the user asked for first.

Both flags together are now refused, with a message naming the conflict, and refused wherever the command comes from: typed at the CLI it fails before anything is sent, and arriving at the running daemon over its socket it fails before the desktop is touched. Nothing else moves — either flag on its own behaves exactly as it did, and giving neither still defers to the system tiled-window-margins setting.

## Command surface

`mimi action resize_window` keeps both flags; what changes is that they may no longer be combined.

| Invocation                    | Before                       | After                                          |
| ----------------------------- | ---------------------------- | ---------------------------------------------- |
| `--margin`                    | margins forced on            | unchanged                                       |
| `--no-margin`                 | margins forced off           | unchanged                                       |
| neither                       | follows the system setting   | unchanged                                       |
| `--margin --no-margin`        | accepted, behaved as `--no-margin` | rejected: `--margin cannot be combined with --no-margin` |

```bash
mimi action resize_window fill --margin --no-margin
# Error: --margin cannot be combined with --no-margin
```

## Potentially breaking

A command line that gives both flags is now an error instead of resizing the window. Anyone who has `--margin --no-margin` in a hotkey, a hook command, or a script was getting the no-margin behaviour by accident; they should drop `--margin` to keep it, or drop `--no-margin` to get the margins they were asking for. Nothing else about `resize_window` changes, and no config key or hook variable is affected.

## Related Issues

Closes #138

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — plus `just fmt-check`, `just vet` and `just test-all`, the full set CI runs
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A — no systray or graphical output changes; the new behaviour is the one-line error quoted above.

## Additional Context

The rule lives in the conversion from resize arguments to a geometry request, which is the single implementation every path runs — the CLI runs it as it builds the command, and the daemon runs it again after decoding one off the socket, because the socket is a trust boundary. That placement follows `docs/adr/0001-typed-versioned-daemon-wire.md`, which exists to keep argument rules from having a second implementation.

Cobra's mutually-exclusive flag marking was deliberately not added alongside it. It would only cover the direct path, and its wording would differ from the one a command over the socket is rejected with — a second copy of the rule for a slightly different sentence. Five tests fail without this change: at the conversion, at the CLI-side construction, at the daemon-side execution of a payload no CLI would build, and twice through the real command tree, where the rejection is checked to read identically with and without a daemon listening.

`docs/CLI.md` and the `resize_window` help text now state that the two flags cannot be combined.
