### PR TITLE
fix(systray): report a requested reload, not a completed one

### DIFF
--- a/internal/systray/component.go
+++ b/internal/systray/component.go
@@ -12,7 +12,7 @@ import (
 type Component struct {
 	version             string
 	configPath          string
-	reload              func(context.Context, string) error
+	requestReload       func(context.Context, string) error
 	quit                func()
 	logger              *zap.SugaredLogger
 	showWorkspaceNumber bool
@@ -33,7 +33,7 @@ type Component struct {
 func NewComponent(
 	version string,
 	configPath string,
-	reload func(context.Context, string) error,
+	requestReload func(context.Context, string) error,
 	quit func(),
 	showWorkspaceNumber bool,
 	logger *zap.SugaredLogger,
@@ -47,7 +47,7 @@ func NewComponent(
 	return &Component{
 		version:             version,
 		configPath:          configPath,
-		reload:              reload,
+		requestReload:       requestReload,
 		quit:                quit,
 		showWorkspaceNumber: showWorkspaceNumber,
 		logger:              logger,
@@ -154,13 +154,18 @@ func (c *Component) openURL(url string, label string) {
 	}()
 }
 
+// handleReloadConfig asks the daemon to reload its config. The menu item is a
+// reload trigger and nothing more: it signals and returns, so it learns whether
+// the ask was delivered but never whether the config was applied. It therefore
+// reports a requested reload, the same thing `mimi config reload` prints. See
+// docs/adr/0002-reload-is-signal-mediated.md.
 func (c *Component) handleReloadConfig() {
-	err := c.reload(c.ctx, c.configPath)
+	err := c.requestReload(c.ctx, c.configPath)
 	if err != nil {
-		c.logger.Warnw("failed to reload config from systray", "err", err)
+		c.logger.Warnw("failed to request config reload from systray", "err", err)
 
 		return
 	}
 
-	c.logger.Info("configuration reloaded from systray")
+	c.logger.Info("config reload requested from systray")
 }

--- a/internal/systray/nil_logger_test.go
+++ b/internal/systray/nil_logger_test.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 )
 
-// errReloadFailed drives handleReloadConfig down its Warnw branch.
+// errReloadFailed drives handleReloadConfig down its Warnw branch. Shared with
+// reload_test.go, which pins what that branch logs.
 var errReloadFailed = errors.New("reload failed")
 
 // TestNewComponent_NilLogger pins the contract stated in AGENTS.md and

--- a/internal/systray/reload_test.go
+++ b/internal/systray/reload_test.go
@@ -1,0 +1,79 @@
+//nolint:testpackage // exercises handleReloadConfig, an unexported method, to reach its log calls
+package systray
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestComponent_HandleReloadConfig_ReportsTheRequestNotTheOutcome pins what the
+// systray's reload menu item is allowed to say. As a reload trigger it only asks the
+// daemon to reload — it signals and returns, and never learns whether the new
+// config was applied (docs/adr/0002-reload-is-signal-mediated.md). So a
+// delivered ask reports a *requested* reload, matching what `mimi config
+// reload` prints for the same reason; claiming the configuration was reloaded
+// put a success line in the log next to the daemon's own failure line for the
+// same click, on an invalid config.
+//
+// Failing to ask at all is a different thing entirely, and stays a warning.
+func TestComponent_HandleReloadConfig_ReportsTheRequestNotTheOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// requestReload stands in for the closure that signals the daemon.
+		requestReload func(context.Context, string) error
+		wantLevel     zapcore.Level
+		wantMessage   string
+	}{
+		{
+			name:          "asking for a reload succeeds",
+			requestReload: func(context.Context, string) error { return nil },
+			wantLevel:     zapcore.InfoLevel,
+			wantMessage:   "config reload requested from systray",
+		},
+		{
+			name:          "asking for a reload fails",
+			requestReload: func(context.Context, string) error { return errReloadFailed },
+			wantLevel:     zapcore.WarnLevel,
+			wantMessage:   "failed to request config reload from systray",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			core, logs := observer.New(zapcore.DebugLevel)
+
+			component := NewComponent(
+				"v0",
+				"config.toml",
+				testCase.requestReload,
+				func() {},
+				false,
+				zap.New(core).Sugar(),
+			)
+			defer component.Close()
+
+			component.handleReloadConfig()
+
+			entries := logs.All()
+			if len(entries) != 1 {
+				t.Fatalf("handleReloadConfig() logged %d entries, want 1", len(entries))
+			}
+
+			if entries[0].Level != testCase.wantLevel {
+				t.Errorf("logged at %v, want %v", entries[0].Level, testCase.wantLevel)
+			}
+
+			if entries[0].Message != testCase.wantMessage {
+				t.Errorf("logged %q, want %q", entries[0].Message, testCase.wantMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the tray's Reload Config item claiming a reload succeeded when all it did was ask for one. Clicking it signals the running daemon and returns immediately, so it never finds out whether the new config was applied — yet it logged that the configuration had been reloaded. On an invalid config that produced two contradictory lines in the same log for the same click: the daemon reporting that the reload failed and the previous config was kept, and the tray reporting success right after it.

The menu item now reports that a reload was *requested*, which is all it knows and exactly what `mimi config reload` already prints for the same reason. Failing to deliver the signal at all is still reported as a failure, because that is something the tray genuinely observes.

Deliberate limitation: the tray still cannot tell you whether the config was actually applied. Reading the daemon's log remains the way to find that out.

## Related Issues

Closes #145

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no doc quotes these log lines and no config key, command, flag or hook variable changes
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

No screenshot: the menu is pixel-for-pixel unchanged — the item is still labelled "Reload Config" — and the whole change is the line the daemon logs when you click it. A screenshot would show nothing the quoted lines don't.

Before, clicking the item on a config that fails to load:

```
WARN  config reload failed   {"trigger": "sighup", "err": "..."}
INFO  configuration reloaded from systray
```

After, same click:

```
WARN  config reload failed   {"trigger": "sighup", "err": "..."}
INFO  config reload requested from systray
```

And when the signal cannot be delivered at all, still a warning, now naming what actually failed:

```
WARN  failed to request config reload from systray   {"err": "..."}
```

## Additional Context

`docs/adr/0002-reload-is-signal-mediated.md` records why the tray is not given a way to learn the outcome: every reload trigger asks and learns nothing, and the two routes that once each applied a config by hand are what drifted apart in the first place. Surfacing a real reload result to the user is #146, deliberately designed as a tray feature fed by the daemon's own outcome rather than a second route into reloading.

Beyond the wording, the callback the tray holds is renamed to say it requests a reload rather than performs one, so the next reader of that struct does not have to rediscover the distinction. It is a rename inside the tray package only; the daemon side is untouched.

The daemon's own reload log lines shown above are quoted from the current daemon behaviour and are not changed here.
