### PR TITLE
feat(daemon,config): report the restart-only settings a reload could not apply

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -20,19 +20,46 @@ subset of `[settings]` listed below; a bad config (e.g. an invalid `title`
 regex) leaves the previous, working config in place and logs the failure
 rather than applying it partially.
 
-**Restart-only** — these fields are read once at daemon startup and are not
-picked up by a reload; changing them requires restarting the daemon
-(`mimi daemon stop && mimi daemon start`, or equivalent):
+**Reloadable** — picked up by every reload:
 
-- `[systray]` (both `enabled` and `show_workspace_number`)
+- `settings.hook_timeout_secs`
+- `settings.hook_shell`
+- `settings.resize_debounce_ms`
+- `[hooks]` (every hook kind)
+
+**Restart-only** — read once at daemon startup and never re-read, so changing
+one takes effect only after the daemon is restarted (`mimi daemon stop &&
+mimi daemon start`, or equivalent):
+
 - `settings.log_file`
 - `settings.log_level`
+- `settings.log_format`
+- `settings.max_hook_workers`
 - `settings.pid_file`
 - `settings.socket_file`
+- `systray.enabled`
+- `systray.show_workspace_number`
 
-Everything else in `[settings]` (`log_format`, `hook_timeout_secs`,
-`hook_shell`, `max_hook_workers`, `resize_debounce_ms`) and all of `[hooks]`
-take effect on the next reload.
+A reload that changes a restart-only setting still applies everything
+reloadable, and then logs a warning naming the settings that need the restart,
+for example:
+
+```text
+config reloaded; restart required for changed restart-only settings
+  trigger=sighup restart_only=["settings.log_level","settings.max_hook_workers"]
+```
+
+A reload that changes only reloadable settings logs the plain
+`config reloaded` line, with no restart notice.
+
+The comparison is against the config the daemon started with, not the previous
+edit, so the notice keeps appearing on every reload for as long as the file and
+the running daemon disagree — and stops on its own if you put the old value
+back.
+
+These two lists are not maintained by hand: each config field is classified on
+the type itself, and a test fails if this document and that classification
+disagree.
 
 ---
 
@@ -42,10 +69,10 @@ take effect on the next reload.
 [settings]
 log_file = "~/.local/share/mimi/mimi.log"   # optional; omit for console-only — restart-only
 log_level = "info"                           # debug | info | warn | error — restart-only
-log_format = "text"                          # text | json — console output only
+log_format = "text"                          # text | json — console output only — restart-only
 hook_timeout_secs = 10
 hook_shell = "/bin/sh"
-max_hook_workers = 4
+max_hook_workers = 4                         # restart-only
 pid_file = "~/.local/share/mimi/mimi.pid"    # restart-only
 socket_file = "~/.local/share/mimi/mimi.sock" # restart-only
 resize_debounce_ms = 250                     # on_window_resize debounce window

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,10 +9,14 @@ import (
 )
 
 // Config holds the full mimi configuration.
+//
+// The reload tags classify each part of the file as reloadable or
+// restart-only; see reloadability.go for what they mean and who reads them.
+// A section tagged per-field is classified one field at a time instead.
 type Config struct {
-	Settings SettingsConfig `json:"settings" toml:"settings"`
-	Hooks    HooksConfig    `json:"hooks"    toml:"hooks"`
-	Systray  SystrayConfig  `json:"systray"  toml:"systray"`
+	Settings SettingsConfig `json:"settings" reload:"per-field"  toml:"settings"`
+	Hooks    HooksConfig    `json:"hooks"    reload:"reloadable" toml:"hooks"`
+	Systray  SystrayConfig  `json:"systray"  reload:"per-field"  toml:"systray"`
 
 	// UnknownHookKeys lists the keys found under [hooks] that name no hook
 	// kind, sorted. Loading records them rather than reporting them so each
@@ -24,22 +28,30 @@ type Config struct {
 }
 
 // SettingsConfig holds the [settings] section of the config.
+//
+// Every field carries a reload tag: the logger, the pid file and the socket
+// are opened once at startup, and the hook worker limit sizes a channel the
+// executor never resizes, so changing any of them takes a restart. The three
+// the reload path re-reads are tagged reloadable.
 type SettingsConfig struct {
-	LogFile          string `json:"logFile"          toml:"log_file"`
-	LogLevel         string `json:"logLevel"         toml:"log_level"`
-	LogFormat        string `json:"logFormat"        toml:"log_format"`
-	HookTimeoutSecs  int    `json:"hookTimeoutSecs"  toml:"hook_timeout_secs"`
-	HookShell        string `json:"hookShell"        toml:"hook_shell"`
-	MaxHookWorkers   int    `json:"maxHookWorkers"   toml:"max_hook_workers"`
-	PIDFile          string `json:"pidFile"          toml:"pid_file"`
-	SocketFile       string `json:"socketFile"       toml:"socket_file"`
-	ResizeDebounceMS int    `json:"resizeDebounceMs" toml:"resize_debounce_ms"`
+	LogFile          string `json:"logFile"          reload:"restart-only" toml:"log_file"`
+	LogLevel         string `json:"logLevel"         reload:"restart-only" toml:"log_level"`
+	LogFormat        string `json:"logFormat"        reload:"restart-only" toml:"log_format"`
+	HookTimeoutSecs  int    `json:"hookTimeoutSecs"  reload:"reloadable"   toml:"hook_timeout_secs"`
+	HookShell        string `json:"hookShell"        reload:"reloadable"   toml:"hook_shell"`
+	MaxHookWorkers   int    `json:"maxHookWorkers"   reload:"restart-only" toml:"max_hook_workers"`
+	PIDFile          string `json:"pidFile"          reload:"restart-only" toml:"pid_file"`
+	SocketFile       string `json:"socketFile"       reload:"restart-only" toml:"socket_file"`
+	ResizeDebounceMS int    `json:"resizeDebounceMs" reload:"reloadable"   toml:"resize_debounce_ms"`
 }
 
 // SystrayConfig holds the [systray] section of the config.
+//
+// The systray is built before the daemon's reload path exists and is never
+// rebuilt, so both fields are restart-only.
 type SystrayConfig struct {
-	Enabled             bool `json:"enabled"             toml:"enabled"`
-	ShowWorkspaceNumber bool `json:"showWorkspaceNumber" toml:"show_workspace_number"`
+	Enabled             bool `json:"enabled"             reload:"restart-only" toml:"enabled"`
+	ShowWorkspaceNumber bool `json:"showWorkspaceNumber" reload:"restart-only" toml:"show_workspace_number"`
 }
 
 // HooksConfig holds all hook entries grouped by event kind.

--- a/internal/config/nil_logger_test.go
+++ b/internal/config/nil_logger_test.go
@@ -1,4 +1,4 @@
-//nolint:testpackage // exercises reload, an unexported method, to reach the logger call
+//nolint:testpackage // exercises notifyChange, an unexported method, to reach the logger call
 package config
 
 import (
@@ -27,12 +27,12 @@ func TestNewWatcher_NilLogger(t *testing.T) {
 			construct: func(t *testing.T) {
 				t.Helper()
 
-				// A path that cannot be loaded drives reload down its
-				// Warnw branch, which is the cheapest route to a log call.
+				// notifyChange logs before it calls onChange, and it never
+				// reads the file, so the path need not exist.
 				missing := filepath.Join(t.TempDir(), "does-not-exist.toml")
 
-				w := NewWatcher(missing, func(*Config) {}, nil)
-				w.reload()
+				w := NewWatcher(missing, func() {}, nil)
+				w.notifyChange()
 			},
 		},
 	}

--- a/internal/config/reload_docs_test.go
+++ b/internal/config/reload_docs_test.go
@@ -1,0 +1,122 @@
+package config //nolint:testpackage // pins the classification against the documented lists
+
+// docs/CONFIGURATION.md tells users which settings a reload picks up and which
+// need a restart. That list is the only one most people will ever read, and
+// the previous, hand-maintained version of it was wrong within a day of being
+// written — it promised that log_format and max_hook_workers take effect on
+// reload when the logger is built once at CLI start and the hook worker limit
+// sizes a channel the executor never resizes.
+//
+// The compiler cannot check Markdown, so this test reads the document as a
+// fixture — the same trick docs_test.go uses on the hook kind tables — and
+// pins both lists against the reload tags on the config type.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// reloadLabels maps the bold label that introduces each list in the Reloading
+// section of docs/CONFIGURATION.md onto the classification it documents.
+var reloadLabels = map[string]reloadability{
+	"Restart-only": restartOnly,
+	"Reloadable":   reloadable,
+}
+
+var (
+	reloadSecRe   = regexp.MustCompile(`(?ms)^## Reloading$.*?^## `)
+	reloadLabelRe = regexp.MustCompile(`(?m)^\*\*([A-Za-z-]+)\*\*`)
+	reloadItemRe  = regexp.MustCompile("(?m)^- `([^`]+)`")
+)
+
+// documentedReloadability parses the Reloading section of
+// docs/CONFIGURATION.md into a map of config key -> the classification whose
+// list it appeared under.
+//
+// A whole section is written the way a user writes it in TOML — `[hooks]` —
+// while the classification names it `hooks`, so the brackets are stripped
+// here rather than making the document read like something nobody types.
+func documentedReloadability(t *testing.T) map[string]reloadability {
+	t.Helper()
+
+	// go test runs with the package directory as the working directory.
+	data, err := os.ReadFile("../../docs/CONFIGURATION.md")
+	if err != nil {
+		t.Fatalf("reading docs/CONFIGURATION.md: %v", err)
+	}
+
+	section := reloadSecRe.FindString(string(data))
+	if section == "" {
+		t.Fatal("docs/CONFIGURATION.md: found no '## Reloading' section; this parser is stale")
+	}
+
+	documented := make(map[string]reloadability)
+
+	labels := reloadLabelRe.FindAllStringSubmatchIndex(section, -1)
+	if len(labels) == 0 {
+		t.Fatal(
+			"docs/CONFIGURATION.md: the Reloading section has no bold lists; this parser is stale",
+		)
+	}
+
+	for idx, label := range labels {
+		reloadability, wanted := reloadLabels[section[label[2]:label[3]]]
+		if !wanted {
+			continue
+		}
+
+		end := len(section)
+		if idx+1 < len(labels) {
+			end = labels[idx+1][0]
+		}
+
+		for _, item := range reloadItemRe.FindAllStringSubmatch(section[label[1]:end], -1) {
+			key := strings.Trim(item[1], "[]")
+
+			if previous, dup := documented[key]; dup {
+				t.Errorf("%s is listed twice (as %v and %v)", key, previous, reloadability)
+			}
+
+			documented[key] = reloadability
+		}
+	}
+
+	return documented
+}
+
+func TestReloadability_MatchesTheDocumentedLists(t *testing.T) {
+	t.Parallel()
+
+	documented := documentedReloadability(t)
+
+	if len(documented) == 0 {
+		t.Fatal("parsed no settings out of docs/CONFIGURATION.md; this parser is stale")
+	}
+
+	classified := make(map[string]reloadability, len(settingFields))
+
+	for _, field := range settingFields {
+		classified[field.Key] = field.kind
+
+		switch documentedReloadability, listed := documented[field.Key]; {
+		case !listed:
+			t.Errorf(
+				"%s is a config field but docs/CONFIGURATION.md lists it under neither reload list",
+				field.Key,
+			)
+		case documentedReloadability != field.kind:
+			t.Errorf(
+				"docs/CONFIGURATION.md documents %s as %v, but the config type classifies it as %v",
+				field.Key, documentedReloadability, field.kind,
+			)
+		}
+	}
+
+	for key := range documented {
+		if _, ok := classified[key]; !ok {
+			t.Errorf("docs/CONFIGURATION.md lists %s, which is not a config field", key)
+		}
+	}
+}

--- a/internal/config/reloadability.go
+++ b/internal/config/reloadability.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"reflect"
+	"slices"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// reloadability says whether changing a config field takes effect when a
+// running daemon reloads, or only once it is restarted.
+type reloadability string
+
+const (
+	// reloadable marks a field the daemon's reload path re-reads, so a change
+	// to it takes effect on the next reload.
+	reloadable reloadability = "reloadable"
+	// restartOnly marks a restart-only setting: the daemon reads it once at
+	// startup and never again, so a change to it takes effect only after the
+	// daemon is restarted.
+	restartOnly reloadability = "restart-only"
+)
+
+// reloadTagPerField is the reload tag a section carries when its fields are
+// classified one at a time rather than together — [settings] and [systray],
+// where some fields reload and some do not. It is a tag value rather than the
+// absence of a tag so that every part of the config file says outright how it
+// is classified, and a section nobody thought about is an error rather than a
+// silent recursion.
+const reloadTagPerField = "per-field"
+
+// reloadTagKey is the struct tag that classifies a config field.
+//
+// The classification lives on the config type itself so that it is written
+// where the field is, instead of in a list kept somewhere else: the
+// hand-maintained list in docs/CONFIGURATION.md was wrong within a day of
+// being written, promising that log_format and max_hook_workers take effect
+// on reload when neither does.
+//
+// The tag records what the daemon's reload path re-reads. Widening that path
+// — teaching internal/daemon's reloader.Apply to re-read a field it ignores
+// today — means moving that field's tag to reloadable in the same change.
+const reloadTagKey = "reload"
+
+// settingField is one classified part of the config file.
+type settingField struct {
+	// Key is the dotted TOML path a user would write: "settings.log_level"
+	// for a leaf field, or a bare section name ("hooks") for a section
+	// classified as a whole.
+	Key string
+	// kind says whether a change to this field is picked up by a
+	// reload or needs a restart.
+	kind reloadability
+	// index locates the field inside a Config value, for FieldByIndex. A
+	// section classified as a whole indexes the section itself.
+	index []int
+}
+
+// settingFields is every classified part of the config file, in the order
+// Config declares them — which is the order changed settings are reported in,
+// and the order docs/CONFIGURATION.md lists them.
+var settingFields = mustClassifyConfig()
+
+// mustClassifyConfig derives the classification from the Config type.
+//
+// A config field with no reload tag is a programming error, and package init
+// is the first moment it can be caught: Go cannot check struct-field
+// exhaustiveness at compile time. Panicking here fails every test binary and
+// the daemon's own startup rather than letting an unclassified field be
+// silently left out of what a reload reports.
+func mustClassifyConfig() []settingField {
+	fields, err := classifyFields(reflect.TypeFor[Config](), "", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return fields
+}
+
+// classifyFields walks structType and returns one settingField per part of
+// the config file it declares, prefixing keys with prefix and field indices
+// with index so nested sections report their full path.
+func classifyFields(structType reflect.Type, prefix string, index []int) ([]settingField, error) {
+	var fields []settingField
+
+	for field := range structType.Fields() {
+		key, inFile := field.Tag.Lookup("toml")
+		if !inFile || key == "-" {
+			// Not part of the config file, so there is nothing for a user to
+			// change and nothing to classify. UnknownHookKeys is the one such
+			// field today.
+			continue
+		}
+
+		if prefix != "" {
+			key = prefix + "." + key
+		}
+
+		fieldIndex := append(slices.Clip(index), field.Index...)
+
+		tag, classified := field.Tag.Lookup(reloadTagKey)
+
+		switch {
+		case !classified:
+			return nil, derrors.Newf(
+				derrors.CodeInternal,
+				"config field %q carries no %q tag: classify it as %q, %q, or %q",
+				key, reloadTagKey, reloadable, restartOnly, reloadTagPerField,
+			)
+		case tag == reloadTagPerField:
+			if field.Type.Kind() != reflect.Struct {
+				return nil, derrors.Newf(
+					derrors.CodeInternal,
+					"config field %q is tagged %q but is not a section",
+					key, reloadTagPerField,
+				)
+			}
+
+			nested, err := classifyFields(field.Type, key, fieldIndex)
+			if err != nil {
+				return nil, err
+			}
+
+			fields = append(fields, nested...)
+		default:
+			kind, err := parseReloadability(key, tag)
+			if err != nil {
+				return nil, err
+			}
+
+			fields = append(fields, settingField{Key: key, kind: kind, index: fieldIndex})
+		}
+	}
+
+	return fields, nil
+}
+
+func parseReloadability(key, tag string) (reloadability, error) {
+	switch kind := reloadability(tag); kind {
+	case reloadable, restartOnly:
+		return kind, nil
+	default:
+		return "", derrors.Newf(
+			derrors.CodeInternal,
+			"config field %q has %s tag %q: want %q, %q, or %q",
+			key, reloadTagKey, tag, reloadable, restartOnly, reloadTagPerField,
+		)
+	}
+}
+
+// RestartOnlyChanges names the restart-only settings whose values differ
+// between running and next, as dotted TOML keys in declaration order.
+//
+// running is the config the daemon actually started with, not the last one it
+// reloaded: a restart-only setting only ever takes effect at startup, so the
+// question worth answering is "does this differ from what the daemon is
+// running", and it stays answered the same way however many reloads happened
+// in between. Changing log_level and then putting it back reports nothing,
+// because nothing is out of step any more.
+func RestartOnlyChanges(running, next *Config) []string {
+	if running == nil || next == nil {
+		return nil
+	}
+
+	runningValue := reflect.ValueOf(*running)
+	nextValue := reflect.ValueOf(*next)
+
+	var changed []string
+
+	for _, field := range settingFields {
+		if field.kind != restartOnly {
+			continue
+		}
+
+		runningField := runningValue.FieldByIndex(field.index).Interface()
+		if !reflect.DeepEqual(runningField, nextValue.FieldByIndex(field.index).Interface()) {
+			changed = append(changed, field.Key)
+		}
+	}
+
+	return changed
+}

--- a/internal/config/reloadability_test.go
+++ b/internal/config/reloadability_test.go
@@ -1,0 +1,166 @@
+package config //nolint:testpackage // exercises the unexported classification walk
+
+import (
+	"reflect"
+	"testing"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// runningConfig is the config a reload is compared against: every field set to
+// a value distinguishable from the zero value, so a test that changes one
+// field changes it to something the comparison can actually see.
+func runningConfig() *Config {
+	return &Config{
+		Settings: SettingsConfig{
+			LogFile:          "/tmp/mimi.log",
+			LogLevel:         "info",
+			LogFormat:        "text",
+			HookTimeoutSecs:  10,
+			HookShell:        "/bin/sh",
+			MaxHookWorkers:   4,
+			PIDFile:          "/tmp/mimi.pid",
+			SocketFile:       "/tmp/mimi.sock",
+			ResizeDebounceMS: 250,
+		},
+		Systray: SystrayConfig{Enabled: true, ShowWorkspaceNumber: true},
+	}
+}
+
+// TestClassifyFields_RejectsAnUnclassifiedField pins the guard that stands in
+// for a compile-time check: a config field nobody classified must stop the
+// package rather than be quietly reported as reloadable. The real Config type
+// goes through the same walk at package init, so the failure a new field
+// produces is this error, raised as a panic before any test runs.
+func TestClassifyFields_RejectsAnUnclassifiedField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		structType reflect.Type
+	}{
+		{
+			name: "a leaf field with no reload tag",
+			structType: reflect.TypeOf(struct {
+				Classified   string `reload:"reloadable" toml:"classified"`
+				Unclassified string `toml:"unclassified"`
+			}{}),
+		},
+		{
+			name: "a reload tag that names no classification",
+			structType: reflect.TypeOf(struct {
+				Nonsense string `reload:"sometimes" toml:"nonsense"`
+			}{}),
+		},
+		{
+			name: "a section with no reload tag",
+			structType: reflect.TypeOf(struct {
+				Section struct {
+					Classified string `reload:"reloadable" toml:"classified"`
+				} `toml:"section"`
+			}{}),
+		},
+		{
+			name: "a leaf inside a per-field section",
+			structType: reflect.TypeOf(struct {
+				Section struct {
+					Unclassified string `toml:"unclassified"`
+				} `reload:"per-field" toml:"section"`
+			}{}),
+		},
+		{
+			name: "a leaf tagged as a section",
+			structType: reflect.TypeOf(struct {
+				NotASection string `reload:"per-field" toml:"not_a_section"`
+			}{}),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := classifyFields(testCase.structType, "", nil)
+			if err == nil {
+				t.Fatal("expected an error for an unclassified config field, got nil")
+			}
+
+			if !derrors.IsCode(err, derrors.CodeInternal) {
+				t.Errorf("expected CodeInternal, got %v", derrors.GetCode(err))
+			}
+		})
+	}
+}
+
+func TestRestartOnlyChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		change func(*Config)
+		want   []string
+	}{
+		{
+			name:   "an unchanged config needs no restart",
+			change: func(*Config) {},
+			want:   nil,
+		},
+		{
+			name:   "a reloadable setting needs no restart",
+			change: func(c *Config) { c.Settings.HookShell = "/bin/bash" },
+			want:   nil,
+		},
+		{
+			name:   "reloadable hooks need no restart",
+			change: func(c *Config) { c.Hooks.WindowFocus = []HookEntry{{Run: "echo hi"}} },
+			want:   nil,
+		},
+		{
+			name:   "a changed log level is restart-only",
+			change: func(c *Config) { c.Settings.LogLevel = "debug" },
+			want:   []string{"settings.log_level"},
+		},
+		{
+			name:   "a changed log format is restart-only",
+			change: func(c *Config) { c.Settings.LogFormat = "json" },
+			want:   []string{"settings.log_format"},
+		},
+		{
+			name:   "a changed hook worker limit is restart-only",
+			change: func(c *Config) { c.Settings.MaxHookWorkers = 8 },
+			want:   []string{"settings.max_hook_workers"},
+		},
+		{
+			name:   "a changed systray field is restart-only",
+			change: func(c *Config) { c.Systray.ShowWorkspaceNumber = false },
+			want:   []string{"systray.show_workspace_number"},
+		},
+		{
+			name: "several restart-only changes are all named, in declaration order",
+			change: func(c *Config) {
+				c.Systray.Enabled = false
+				c.Settings.SocketFile = "/tmp/other.sock"
+				c.Settings.LogFile = "/tmp/other.log"
+			},
+			want: []string{
+				"settings.log_file",
+				"settings.socket_file",
+				"systray.enabled",
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			next := runningConfig()
+			testCase.change(next)
+
+			got := RestartOnlyChanges(runningConfig(), next)
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Errorf("RestartOnlyChanges() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -13,15 +13,23 @@ import (
 
 const debounceDelay = 300 * time.Millisecond
 
-// Watcher monitors a config file and triggers a callback on changes.
+// Watcher monitors a config file and calls a callback once the writes to it
+// have settled.
+//
+// It reports that the file changed and nothing more: it does not read the
+// file, so it can neither parse it nor fail to. The daemon's reloadConfig is
+// the one place that loads a config, applies it, and logs how that went, so
+// a file that will not parse and a file that will not apply are reported the
+// same way, by the same line — which they were not while this watcher parsed
+// the file itself and logged its own failure.
 type Watcher struct {
 	path     string
-	onChange func(*Config)
+	onChange func()
 	logger   *zap.SugaredLogger
 }
 
 // NewWatcher creates a new config file watcher.
-func NewWatcher(path string, onChange func(*Config), logger *zap.SugaredLogger) *Watcher {
+func NewWatcher(path string, onChange func(), logger *zap.SugaredLogger) *Watcher {
 	if logger == nil {
 		logger = zap.NewNop().Sugar()
 	}
@@ -74,10 +82,10 @@ func (w *Watcher) Run(ctx context.Context) error {
 					if debounce.Stop() {
 						debounce.Reset(debounceDelay)
 					} else {
-						debounce = time.AfterFunc(debounceDelay, w.reload)
+						debounce = time.AfterFunc(debounceDelay, w.notifyChange)
 					}
 				} else {
-					debounce = time.AfterFunc(debounceDelay, w.reload)
+					debounce = time.AfterFunc(debounceDelay, w.notifyChange)
 				}
 			}
 		case err, ok := <-fileWatcher.Errors:
@@ -90,24 +98,15 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 }
 
-// reload parses the watched file and, on success, hands it to onChange.
+// notifyChange tells onChange the watched file has changed.
 //
-// It does not log a success line: onChange is where the hook registry
-// actually reloads and where a bad hook (an invalid regex, for example) is
-// caught, so only the caller can know whether the reload as a whole
-// succeeded. The daemon's applyReload is that caller, and it logs the one
-// authoritative "config reloaded" / "config reload failed" line for every
-// trigger. Logging a debug line here — rather than nothing — still records
-// that the file parsed, which is useful when a later onChange failure needs
-// to be told apart from a parse failure.
-func (w *Watcher) reload() {
-	cfg, err := Load(w.path)
-	if err != nil {
-		w.logger.Warnw("config reload failed", "err", err)
-
-		return
-	}
-
-	w.logger.Debug("config file parsed")
-	w.onChange(cfg)
+// It logs at debug and claims nothing about the reload: onChange is where the
+// file is loaded, where the hook registry reloads, and where a bad hook (an
+// invalid regex, for example) is caught, so only it can know how the reload
+// went. The debug line still records that the watcher fired, which is what
+// tells "my editor's save was never noticed" apart from "it was noticed and
+// the config was rejected".
+func (w *Watcher) notifyChange() {
+	w.logger.Debug("config file changed")
+	w.onChange()
 }

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -1,4 +1,4 @@
-//nolint:testpackage // tests reload, an unexported method exercising Watcher's private log/dispatch ordering
+//nolint:testpackage // tests notifyChange, an unexported method exercising Watcher's private log/dispatch ordering
 package config
 
 import (
@@ -11,15 +11,13 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-const watcherTestMarker = "watcher-test-marker.log"
-
 // newTestWatcher writes contents to a config file in dir and returns a
-// Watcher over it, wired to onChange, plus the log entries reload will
+// Watcher over it, wired to onChange, plus the log entries notifyChange will
 // produce on it.
 func newTestWatcher(
 	t *testing.T,
 	dir, contents string,
-	onChange func(*Config),
+	onChange func(),
 ) (*Watcher, *observer.ObservedLogs) {
 	t.Helper()
 
@@ -36,87 +34,56 @@ func newTestWatcher(
 	return NewWatcher(path, onChange, logger), logs
 }
 
-// TestWatcher_Reload_OnSuccess_DoesNotClaimReloadSucceeded pins the fix for
-// #107: a successful config.Load must not log an Info "config reloaded" line,
-// because that claims more than has happened at that point — onChange (the
-// hook registry reload) hasn't run yet, and it is the one that can still
-// fail. The daemon's applyReload is the sole place that logs the outcome of
-// a reload; the watcher only logs that it parsed the file.
-func TestWatcher_Reload_OnSuccess_DoesNotClaimReloadSucceeded(t *testing.T) {
+// TestWatcher_NotifyChange_ReportsTheChangeAndNothingMore pins the fix for
+// #107 and the split it grew into: the watcher says the file changed, and
+// claims nothing about the reload. It does not read the file, so a config
+// that will not parse reaches the daemon's one reload path — which loads it,
+// applies it, and logs the single authoritative outcome line — instead of
+// being reported here, in a second voice that cannot name the trigger.
+func TestWatcher_NotifyChange_ReportsTheChangeAndNothingMore(t *testing.T) {
 	t.Parallel()
 
-	var gotCfg *Config
-
-	onChange := func(cfg *Config) { gotCfg = cfg }
-
-	dir := t.TempDir()
-	watcher, logs := newTestWatcher(
-		t,
-		dir,
-		"[settings]\nlog_file = \""+watcherTestMarker+"\"\n",
-		onChange,
-	)
-	watcher.reload()
-
-	if gotCfg == nil {
-		t.Fatal("onChange was not called")
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "a config that parses", contents: "[settings]\nlog_level = \"info\"\n"},
+		{name: "a config that does not parse", contents: "not valid toml [[["},
 	}
 
-	if gotCfg.Settings.LogFile != watcherTestMarker {
-		t.Errorf("onChange got LogFile = %q, want %q", gotCfg.Settings.LogFile, watcherTestMarker)
-	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-	entries := logs.All()
-	if len(entries) != 1 {
-		t.Fatalf("got %d log entries, want 1: %+v", len(entries), entries)
-	}
+			called := 0
 
-	entry := entries[0]
+			onChange := func() { called++ }
 
-	if entry.Message != "config file parsed" {
-		t.Errorf("log message = %q, want %q", entry.Message, "config file parsed")
-	}
+			watcher, logs := newTestWatcher(t, t.TempDir(), testCase.contents, onChange)
+			watcher.notifyChange()
 
-	if entry.Level != zapcore.DebugLevel {
-		t.Errorf(
-			"watcher logged %q at %v, want Debug; the daemon's applyReload owns the Info-level success/failure line",
-			entry.Message,
-			entry.Level,
-		)
-	}
-}
+			if called != 1 {
+				t.Fatalf("onChange was called %d times, want 1", called)
+			}
 
-// TestWatcher_Reload_OnFailure_LogsWarnAndSkipsOnChange pins the existing
-// (and unchanged) failure path: a bad config file must not invoke onChange,
-// and must log exactly one Warn line so it isn't followed by anything that
-// looks like a success.
-func TestWatcher_Reload_OnFailure_LogsWarnAndSkipsOnChange(t *testing.T) {
-	t.Parallel()
+			entries := logs.All()
+			if len(entries) != 1 {
+				t.Fatalf("got %d log entries, want 1: %+v", len(entries), entries)
+			}
 
-	called := false
+			entry := entries[0]
 
-	onChange := func(*Config) { called = true }
+			if entry.Message != "config file changed" {
+				t.Errorf("log message = %q, want %q", entry.Message, "config file changed")
+			}
 
-	dir := t.TempDir()
-	watcher, logs := newTestWatcher(t, dir, "not valid toml [[[", onChange)
-	watcher.reload()
-
-	if called {
-		t.Error("onChange was called despite a failed Load")
-	}
-
-	entries := logs.All()
-	if len(entries) != 1 {
-		t.Fatalf("got %d log entries, want 1: %+v", len(entries), entries)
-	}
-
-	entry := entries[0]
-
-	if entry.Level != zapcore.WarnLevel {
-		t.Errorf("log level = %v, want Warn", entry.Level)
-	}
-
-	if entry.Message != "config reload failed" {
-		t.Errorf("log message = %q, want %q", entry.Message, "config reload failed")
+			if entry.Level != zapcore.DebugLevel {
+				t.Errorf(
+					"watcher logged %q at %v, want Debug; the daemon's reloadConfig owns the reload outcome line",
+					entry.Message,
+					entry.Level,
+				)
+			}
+		})
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -117,10 +117,16 @@ func runCore(
 	go pipeline.executor.Run(ctx, pipeline.hookSub)
 	go logging.WriteEventLog(ctx, pipeline.logSub, cfg.Settings.LogFile, logger)
 
-	cfgReloader := newReloader(pipeline.reg, pipeline.executor, pipeline.axTracker, pipeline.router)
+	cfgReloader := newReloader(
+		cfg,
+		pipeline.reg,
+		pipeline.executor,
+		pipeline.axTracker,
+		pipeline.router,
+	)
 
-	onChange := func(newCfg *config.Config) {
-		applyReload(cfgReloader, newCfg, reloadTriggerFsnotify, logger)
+	onChange := func() {
+		reloadConfig(configPath, cfgReloader, reloadTriggerFsnotify, logger)
 	}
 
 	watcher := config.NewWatcher(configPath, onChange, logger)
@@ -250,7 +256,7 @@ func setupEventPipeline(
 }
 
 // reloadTrigger names which route into the daemon fired a reload. It closes
-// the set of triggers that can call applyReload — fsnotify and SIGHUP today
+// the set of triggers that can call reloadConfig — fsnotify and SIGHUP today
 // — over a bare string so a new call site can't drift in an ad hoc label.
 type reloadTrigger string
 
@@ -259,26 +265,59 @@ const (
 	reloadTriggerSighup   reloadTrigger = "sighup"
 )
 
-// applyReload runs cfgReloader.Apply against newCfg and logs the outcome. fsnotify's
-// onChange and the SIGHUP handler both funnel through this one function, so
-// a bad config is reported identically regardless of which trigger noticed
-// it — previously the fsnotify path logged and stopped on a hook-reload
-// error while the SIGHUP path discarded it and logged success anyway.
-func applyReload(
+// The three things a reload can report. They are constants so that the tests
+// that pin which outcome a given config produces name the outcome rather than
+// repeating its wording.
+const (
+	reloadFailedMessage          = "config reload failed"
+	reloadedMessage              = "config reloaded"
+	reloadRestartRequiredMessage = "config reloaded; restart required for changed restart-only settings"
+)
+
+// reloadConfig loads the config at configPath, applies it, and logs the
+// outcome. It is the one place all three of those happen: fsnotify's onChange
+// and the SIGHUP handler both call it, so a config that will not parse and a
+// config that will not apply are reported the same way, by the same line,
+// naming the trigger that noticed — previously the watcher logged parse
+// failures itself, without a trigger, while apply failures were logged here.
+//
+// A reload that changes a restart-only setting is not a plain success: the
+// daemon has applied everything it can and is still running the old value for
+// the rest, so it says so and names them. The names are mimi's own; the
+// values the user gave them stay out of the log.
+func reloadConfig(
+	configPath string,
 	cfgReloader *reloader,
-	newCfg *config.Config,
 	trigger reloadTrigger,
 	logger *zap.SugaredLogger,
 ) {
-	err := cfgReloader.Apply(newCfg)
+	newCfg, err := config.Load(configPath)
+
+	var restartOnly []string
+
+	if err == nil {
+		restartOnly, err = cfgReloader.Apply(newCfg)
+	}
+
 	if err != nil {
-		logger.Warnw("config reload failed", "trigger", trigger, "err", err)
+		logger.Warnw(reloadFailedMessage, "trigger", trigger, "err", err)
 
 		return
 	}
 
 	warnUnknownHookKeys(newCfg, logger)
-	logger.Infow("config reloaded", "trigger", trigger)
+
+	if len(restartOnly) > 0 {
+		logger.Warnw(
+			reloadRestartRequiredMessage,
+			"trigger", trigger,
+			"restart_only", restartOnly,
+		)
+
+		return
+	}
+
+	logger.Infow(reloadedMessage, "trigger", trigger)
 }
 
 // warnUnknownHookKeys notes that the config asked for hook kinds mimi does not
@@ -323,7 +362,7 @@ func runSignalLoop(
 			return
 		case sig := <-sigCh:
 			if sig == syscall.SIGHUP {
-				reloadConfig(configPath, cfgReloader, logger)
+				reloadConfig(configPath, cfgReloader, reloadTriggerSighup, logger)
 
 				continue
 			}
@@ -334,17 +373,6 @@ func runSignalLoop(
 			return
 		}
 	}
-}
-
-func reloadConfig(configPath string, cfgReloader *reloader, logger *zap.SugaredLogger) {
-	newCfg, err := config.Load(configPath)
-	if err != nil {
-		logger.Warnw("config reload failed", "trigger", reloadTriggerSighup, "err", err)
-
-		return
-	}
-
-	applyReload(cfgReloader, newCfg, reloadTriggerSighup, logger)
 }
 
 func shutdown(cancel context.CancelFunc, pipeline *eventPipeline, logger *zap.SugaredLogger) {

--- a/internal/daemon/reload_report_test.go
+++ b/internal/daemon/reload_report_test.go
@@ -1,0 +1,200 @@
+//nolint:testpackage // tests reloadConfig, the daemon's unexported reload reporting
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/y3owk1n/mimi/internal/config"
+)
+
+// reloadReportMarker is a value only a user's config file would contain. It
+// stands in for every user payload AGENTS.md keeps out of the log: the log
+// may name settings.log_file, never what the user put in it.
+const reloadReportMarker = "/tmp/mimi-user-payload-marker.log"
+
+// The TOML keys the reload tests expect to be named back to them, spelled the
+// way config.RestartOnlyChanges reports them.
+const (
+	keyLogFile        = "settings.log_file"
+	keyLogLevel       = "settings.log_level"
+	keyMaxHookWorkers = "settings.max_hook_workers"
+)
+
+const reloadReportBaseConfig = `[settings]
+log_level = "info"
+hook_shell = "/bin/sh"
+
+[hooks]
+on_window_focus = ["echo old"]
+`
+
+// newTestReloadConfig writes contents to a config file and builds a reloader
+// running that config, returning the path, the reloader, the logger a reload
+// reports through, and the entries it produces.
+func newTestReloadConfig(
+	t *testing.T,
+	contents string,
+) (string, *reloader, *zap.SugaredLogger, *observer.ObservedLogs) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+
+	writeReloadTestConfig(t, path, contents)
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("failed to load the starting config: %v", err)
+	}
+
+	cfgReloader, _, _ := newTestReloader(t, cfg)
+
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	return path, cfgReloader, zap.New(core).Sugar(), logs
+}
+
+func writeReloadTestConfig(t *testing.T, path, contents string) {
+	t.Helper()
+
+	err := os.WriteFile(path, []byte(contents), 0o600)
+	if err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+}
+
+// entryText renders a log entry the way a reader sees it — message and
+// fields together — so an assertion about what does or does not reach the log
+// covers both.
+func entryText(entry observer.LoggedEntry) string {
+	var text strings.Builder
+
+	text.WriteString(entry.Message)
+
+	for _, field := range entry.Context {
+		// A zap field carries its value in String or in Interface depending
+		// on its type; both go in, so no value can hide from an assertion.
+		fmt.Fprintf(&text, " %s=%v=%v", field.Key, field.String, field.Interface)
+	}
+
+	return text.String()
+}
+
+func TestReloadConfig_ReportsTheOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contents    string
+		wantLevel   zapcore.Level
+		wantMessage string
+		wantInEntry []string
+	}{
+		{
+			name:        "a config that does not parse",
+			contents:    "not valid toml [[[",
+			wantLevel:   zapcore.WarnLevel,
+			wantMessage: reloadFailedMessage,
+		},
+		{
+			name:        "a config that parses but cannot be applied",
+			contents:    "[[hooks.on_window_focus]]\nrun = \"echo new\"\ntitle = \"[\"\n",
+			wantLevel:   zapcore.WarnLevel,
+			wantMessage: reloadFailedMessage,
+		},
+		{
+			name:        "only reloadable settings changed",
+			contents:    "[settings]\nlog_level = \"info\"\nhook_shell = \"/bin/bash\"\n",
+			wantLevel:   zapcore.InfoLevel,
+			wantMessage: reloadedMessage,
+		},
+		{
+			name:        "a restart-only setting changed",
+			contents:    "[settings]\nlog_level = \"debug\"\n",
+			wantLevel:   zapcore.WarnLevel,
+			wantMessage: reloadRestartRequiredMessage,
+			wantInEntry: []string{keyLogLevel},
+		},
+		{
+			name:        "several restart-only settings changed",
+			contents:    "[settings]\nlog_level = \"debug\"\nmax_hook_workers = 8\n",
+			wantLevel:   zapcore.WarnLevel,
+			wantMessage: reloadRestartRequiredMessage,
+			wantInEntry: []string{keyLogLevel, keyMaxHookWorkers},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, cfgReloader, logger, logs := newTestReloadConfig(t, reloadReportBaseConfig)
+
+			writeReloadTestConfig(t, path, testCase.contents)
+
+			reloadConfig(path, cfgReloader, reloadTriggerSighup, logger)
+
+			entries := logs.All()
+			if len(entries) != 1 {
+				t.Fatalf("got %d log entries, want 1: %+v", len(entries), entries)
+			}
+
+			entry := entries[0]
+
+			if entry.Message != testCase.wantMessage {
+				t.Errorf("log message = %q, want %q", entry.Message, testCase.wantMessage)
+			}
+
+			if entry.Level != testCase.wantLevel {
+				t.Errorf("log level = %v, want %v", entry.Level, testCase.wantLevel)
+			}
+
+			text := entryText(entry)
+
+			if !strings.Contains(text, string(reloadTriggerSighup)) {
+				t.Errorf("log entry %q does not name the trigger that fired the reload", text)
+			}
+
+			for _, want := range testCase.wantInEntry {
+				if !strings.Contains(text, want) {
+					t.Errorf("log entry %q does not name %q", text, want)
+				}
+			}
+		})
+	}
+}
+
+// TestReloadConfig_KeepsUserConfigValuesOutOfTheLog pins AGENTS.md's rule on
+// the one line this change adds: naming a restart-only setting means naming
+// the setting, never the value the user gave it.
+func TestReloadConfig_KeepsUserConfigValuesOutOfTheLog(t *testing.T) {
+	t.Parallel()
+
+	path, cfgReloader, logger, logs := newTestReloadConfig(t, reloadReportBaseConfig)
+
+	writeReloadTestConfig(t, path, "[settings]\nlog_file = \""+reloadReportMarker+"\"\n")
+
+	reloadConfig(path, cfgReloader, reloadTriggerFsnotify, logger)
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("got %d log entries, want 1: %+v", len(entries), entries)
+	}
+
+	text := entryText(entries[0])
+
+	if !strings.Contains(text, keyLogFile) {
+		t.Errorf("log entry %q does not name the restart-only setting that changed", text)
+	}
+
+	if strings.Contains(text, reloadReportMarker) {
+		t.Errorf("log entry %q carries the user's config value", text)
+	}
+}

--- a/internal/daemon/reloader.go
+++ b/internal/daemon/reloader.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"sync"
 	"time"
 
 	"github.com/y3owk1n/mimi/internal/config"
@@ -19,26 +20,46 @@ import (
 // invalid config's stale hooks in place with no signal to the user.
 //
 // reloader itself never logs — Apply reports outcomes purely through its
-// return value, and the caller (applyReload, in daemon.go) is the single
-// place that turns that into a log line, so every trigger logs identically.
+// return values, and the caller (reloadConfig, in daemon.go) is the single
+// place that turns those into a log line, so every trigger logs identically.
 type reloader struct {
+	// mu serializes Apply. Two goroutines can ask for a reload at the same
+	// moment — the config file watcher and the signal loop — and holding the
+	// lock for the whole of Apply is what stops a simultaneous file save and
+	// SIGHUP from interleaving into hooks from one config and executor
+	// settings from another. See docs/adr/0002-reload-is-signal-mediated.md.
+	mu sync.Mutex
+
+	// running is the config the daemon started with, and is never replaced.
+	// Its restart-only settings are the values actually in effect for this
+	// process's lifetime, whatever a later config says, so they are what a
+	// reload compares against to decide whether to ask for a restart.
+	running *config.Config
+
 	reg       *hooks.Registry
 	executor  *hooks.Executor
 	axTracker *observe.AXTracker
 	router    *observe.Router
 }
 
-// newReloader bundles the dependencies a reload touches — the hook
-// registry, its executor, the AX tracker, and the router's debounce window —
-// so callers pass them once at construction instead of threading the same
-// four pointers by hand through every reload call site.
+// newReloader bundles the dependencies a reload touches — the config the
+// daemon started with, the hook registry, its executor, the AX tracker, and
+// the router's debounce window — so callers pass them once at construction
+// instead of threading the same pointers by hand through every reload call
+// site.
+//
+// running is the config the daemon is about to run and must not be nil; with
+// no config to compare against, Apply has nothing to say about restart-only
+// settings and reports none.
 func newReloader(
+	running *config.Config,
 	reg *hooks.Registry,
 	executor *hooks.Executor,
 	axTracker *observe.AXTracker,
 	router *observe.Router,
 ) *reloader {
 	return &reloader{
+		running:   running,
 		reg:       reg,
 		executor:  executor,
 		axTracker: axTracker,
@@ -53,18 +74,28 @@ func newReloader(
 // failure means a bad config leaves every dependency exactly as it was
 // rather than reloading some values but not others.
 //
-// Settings outside [hooks] and the fields read here — systray, log_file,
-// log_level, pid_file, socket_file — are restart-only: Apply never touches
-// them, and nothing else in the daemon reads a fresh value for them after
-// startup.
-func (rl *reloader) Apply(cfg *config.Config) error {
+// Everything Apply does not touch — the logger, the pid file, the socket, the
+// systray, the hook worker limit — is restart-only, because nothing else in
+// the daemon reads a fresh value for it after startup either. Apply returns
+// the restart-only settings cfg changes, by TOML key, so the caller can say
+// so instead of reporting a reload that quietly did nothing. Those keys are
+// derived from the config type (config.RestartOnlyChanges); widening what
+// Apply re-reads means retagging that field as reloadable in the same change.
+//
+// Apply is serialized: the whole of it runs under rl.mu, so a file save and a
+// SIGHUP arriving together apply one config after the other rather than
+// interleaving.
+func (rl *reloader) Apply(cfg *config.Config) ([]string, error) {
 	if cfg == nil {
-		return derrors.New(derrors.CodeInvalidInput, "nil config")
+		return nil, derrors.New(derrors.CodeInvalidInput, "nil config")
 	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
 
 	err := rl.reg.Reload(cfg)
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeInvalidConfig, "reloading hooks")
+		return nil, derrors.Wrapf(err, derrors.CodeInvalidConfig, "reloading hooks")
 	}
 
 	rl.executor.UpdateSettings(&cfg.Settings)
@@ -74,5 +105,5 @@ func (rl *reloader) Apply(cfg *config.Config) error {
 	perm := permissions.Check()
 	rl.axTracker.Update(perm.Accessibility && hasWindowEvents(cfg))
 
-	return nil
+	return config.RestartOnlyChanges(rl.running, cfg), nil
 }

--- a/internal/daemon/reloader_test.go
+++ b/internal/daemon/reloader_test.go
@@ -50,9 +50,191 @@ func newTestReloader(
 	)
 	executor := hooks.NewExecutor(reg, &initialCfg.Settings, logger)
 
-	cfgReloader := newReloader(reg, executor, axTracker, router)
+	cfgReloader := newReloader(initialCfg, reg, executor, axTracker, router)
 
 	return cfgReloader, reg, bus
+}
+
+// TestReloader_Apply_ReportsRestartOnlySettingsThatChanged pins what a
+// trigger learns from a reload: the restart-only settings the new config
+// changes, so the caller can say a restart is needed instead of reporting a
+// success that changed nothing.
+func TestReloader_Apply_ReportsRestartOnlySettingsThatChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		change func(*config.Config)
+		want   []string
+	}{
+		{
+			name:   "only reloadable settings changed",
+			change: func(c *config.Config) { c.Settings.HookShell = "/bin/bash" },
+			want:   nil,
+		},
+		{
+			name: "restart-only settings changed",
+			change: func(c *config.Config) {
+				c.Settings.LogLevel = "debug"
+				c.Settings.MaxHookWorkers = 8
+			},
+			want: []string{keyLogLevel, keyMaxHookWorkers},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			oldCfg := &config.Config{Settings: baseSettings()}
+			oldCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunOld}}
+
+			cfgReloader, _, _ := newTestReloader(t, oldCfg)
+
+			newCfg := &config.Config{Settings: baseSettings()}
+			newCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunNew}}
+			testCase.change(newCfg)
+
+			restartOnly, err := cfgReloader.Apply(newCfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(restartOnly, testCase.want) {
+				t.Errorf("Apply() restart-only settings = %v, want %v", restartOnly, testCase.want)
+			}
+		})
+	}
+}
+
+// TestReloader_Apply_ComparesAgainstTheConfigTheDaemonIsRunning pins which
+// config a restart-only change is measured against: the one the daemon
+// started with, not the one it reloaded last. A restart-only setting only
+// ever takes effect at startup, so putting the old value back leaves nothing
+// out of step and must stop asking for a restart — which it would not do if
+// each reload became the next reload's baseline.
+func TestReloader_Apply_ComparesAgainstTheConfigTheDaemonIsRunning(t *testing.T) {
+	t.Parallel()
+
+	oldCfg := &config.Config{Settings: baseSettings()}
+	oldCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunOld}}
+
+	cfgReloader, _, _ := newTestReloader(t, oldCfg)
+
+	changedCfg := &config.Config{Settings: baseSettings()}
+	changedCfg.Settings.LogLevel = "debug"
+
+	restartOnly, err := cfgReloader.Apply(changedCfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(restartOnly, []string{keyLogLevel}) {
+		t.Fatalf("Apply() restart-only settings = %v, want %v", restartOnly, []string{keyLogLevel})
+	}
+
+	revertedCfg := &config.Config{Settings: baseSettings()}
+
+	restartOnly, err = cfgReloader.Apply(revertedCfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if restartOnly != nil {
+		t.Errorf(
+			"putting a restart-only setting back to the running value still asks for a restart: %v",
+			restartOnly,
+		)
+	}
+}
+
+// TestReloader_Apply_WaitsForAReloadAlreadyInProgress pins the serialization
+// ADR 0002 calls for. The config file watcher and the signal loop are separate
+// goroutines, so a file save and a SIGHUP can arrive together; without a lock
+// held across the whole of Apply the two interleave into hooks from one config
+// and executor settings from another.
+//
+// Holding the reloader's own lock is how the test stands in for "a reload is
+// in progress": a second Apply must make no change at all until the first has
+// finished, and must then apply its config whole. Reaching for the lock is
+// white-box, but the lock is the mechanism the ADR decided on, and the
+// alternative — racing two reloads and hoping to catch a tear — passes just as
+// happily with no lock at all.
+//
+// What this proves is that none of Apply's writes happen before the lock is
+// taken, and that a blocked reload lands whole once it is released. That the
+// lock is also still held at Apply's last write is not observable from here;
+// it is visible in Apply's `defer rl.mu.Unlock()`.
+func TestReloader_Apply_WaitsForAReloadAlreadyInProgress(t *testing.T) {
+	t.Parallel()
+
+	const (
+		debounceOld = 100
+		debounceNew = 900
+		// How long a blocked Apply is given to wrongly make progress. Only a
+		// lower bound on the test's patience: it never waits this long unless
+		// the serialization is broken.
+		blockedFor = 100 * time.Millisecond
+	)
+
+	oldCfg := &config.Config{Settings: baseSettings()}
+	oldCfg.Settings.ResizeDebounceMS = debounceOld
+	oldCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunOld}}
+
+	cfgReloader, reg, bus := newTestReloader(t, oldCfg)
+
+	newCfg := &config.Config{Settings: baseSettings()}
+	newCfg.Settings.ResizeDebounceMS = debounceNew
+	newCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunNew}}
+
+	logger := zap.NewNop().Sugar()
+
+	applied := make(chan struct{})
+
+	// Stand in for a reload that is mid-flight, then start a second one.
+	cfgReloader.mu.Lock()
+
+	go func() {
+		defer close(applied)
+
+		_, err := cfgReloader.Apply(newCfg)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	select {
+	case <-applied:
+		t.Fatal("a second reload ran while one was already in progress")
+	case <-time.After(blockedFor):
+	}
+
+	got := reg.HooksFor(events.WindowFocus)
+	if len(got) != 1 || got[0].Entry.Run != reloaderHookRunOld {
+		t.Errorf("a reload in progress was overwritten by a second one, got %+v", got)
+	}
+
+	cfgReloader.mu.Unlock()
+	<-applied
+
+	// Whole, not partial: the hooks and the debounce window both come from
+	// the config the second reload applied.
+	got = reg.HooksFor(events.WindowFocus)
+	if len(got) != 1 || got[0].Entry.Run != reloaderHookRunNew {
+		t.Errorf("expected the registry to hold the second reload's hook, got %+v", got)
+	}
+
+	wantRouter := observe.NewRouterWithDebounce(
+		bus,
+		cfgReloader.axTracker,
+		logger,
+		debounceNew*time.Millisecond,
+	)
+	if !reflect.DeepEqual(wantRouter, cfgReloader.router) {
+		t.Error(
+			"the second reload applied its hooks but not its debounce window; the reload tore",
+		)
+	}
 }
 
 func TestReloader_Apply_ValidConfigReloadsHooksAndDependencies(t *testing.T) {
@@ -65,7 +247,7 @@ func TestReloader_Apply_ValidConfigReloadsHooksAndDependencies(t *testing.T) {
 	newCfg.Settings.ResizeDebounceMS = 750
 	newCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunNew}}
 
-	err := cfgReloader.Apply(newCfg)
+	_, err := cfgReloader.Apply(newCfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -126,9 +308,16 @@ func TestReloader_Apply_InvalidHookRegexLeavesPreviousStateUntouched(t *testing.
 		{Run: reloaderHookRunNew, Title: reloaderInvalidRegex},
 	}
 
-	err := cfgReloader.Apply(newCfg)
+	restartOnly, err := cfgReloader.Apply(newCfg)
 	if err == nil {
 		t.Fatal("expected an error for an invalid hook regex, got nil")
+	}
+
+	if restartOnly != nil {
+		t.Errorf(
+			"a failed reload reported %v as needing a restart; nothing was applied, so nothing does",
+			restartOnly,
+		)
 	}
 
 	if !derrors.IsCode(err, derrors.CodeInvalidConfig) {


### PR DESCRIPTION
## Description

This PR makes a reload tell you what it actually applied. Until now the daemon
logged a plain `config reloaded` after every config that parsed, including a
config that changed only settings the running daemon never re-reads — so
changing the log level, reloading, and seeing success gave you no way to learn
that nothing had happened. A reload now warns instead, and names the settings
that need a daemon restart; a reload that changes only reloadable settings still
logs the plain success line, unchanged.

The documentation was wrong in the same way, listing `log_format` and
`max_hook_workers` among the settings a reload picks up when neither is ever
re-read. Both lists are now derived from the configuration itself rather than
kept by hand, and a test fails if the documented lists and the real behaviour
ever drift apart again.

Two other things change with it. Loading a config, applying it, and reporting
the outcome now happen in one place, so a file that will not parse and a file
that will not apply are reported by the same log line, naming the trigger that
noticed; the file watcher only reports that the file changed. And applying a
config now holds a lock for its whole duration, so a file save and a `SIGHUP`
arriving at the same moment can no longer leave the daemon running hooks from
one config and executor settings from another.

## Related Issues

Closes #144

## Config keys affected

No key is added, renamed, or removed, and every existing config file keeps
working unchanged. What changes is which keys are documented as reloadable, and
what a reload says about them:

| Key | Before | Now |
| --- | --- | --- |
| `settings.hook_timeout_secs` | reloadable | reloadable (unchanged) |
| `settings.hook_shell` | reloadable | reloadable (unchanged) |
| `settings.resize_debounce_ms` | reloadable | reloadable (unchanged) |
| `[hooks]` (every hook kind) | reloadable | reloadable (unchanged) |
| `settings.log_format` | documented as reloadable | **restart-only** — the documentation was wrong; it never reloaded |
| `settings.max_hook_workers` | documented as reloadable | **restart-only** — the documentation was wrong; it never reloaded |
| `settings.log_file` | restart-only | restart-only (unchanged) |
| `settings.log_level` | restart-only | restart-only (unchanged) |
| `settings.pid_file` | restart-only | restart-only (unchanged) |
| `settings.socket_file` | restart-only | restart-only (unchanged) |
| `systray.enabled` | restart-only | restart-only (unchanged) |
| `systray.show_workspace_number` | restart-only | restart-only (unchanged) |

Change any of the restart-only keys and reload, and the daemon log now says:

```text
config reloaded; restart required for changed restart-only settings
  trigger=sighup restart_only=["settings.log_level","settings.max_hook_workers"]
```

Setting names reach the log; the values you gave them do not. The comparison is
against the config the daemon started with, so the notice keeps appearing on
every reload for as long as the file and the running daemon disagree, and stops
on its own if you put the old value back.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The restart-only set is derived from the config type: every field of the config
carries a tag saying whether a reload picks it up, and a field added without one
stops the package at initialisation, failing every test binary and the daemon's
own startup. Go cannot check that at compile time — there is no exhaustiveness
check over struct fields — so initialisation is the earliest honest moment. On
top of that, a test parses the two lists out of `docs/CONFIGURATION.md` and
fails if they disagree with the classification, the same trick the hook kind
tables already use.

The reload lock is pinned by a test that holds it and asserts a second reload
makes no change until it is released. Racing two reloads and hoping to observe a
torn one was tried first, and passed just as happily with no lock at all.

`mimi config reload` and the systray menu item still report a requested reload
rather than a result — they signal the daemon and do not wait, per
`docs/adr/0002-reload-is-signal-mediated.md`. The restart notice is in the
daemon log only.
