### PR TITLE
fix(space,native): restore space switching on macOS 27

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -7,6 +7,25 @@
 3. **Check space index** — spaces are 1-based in Mission Control order (`mimi action space 1` is the first space)
 4. **Close Mission Control** — actions refuse to run while Mission Control is open
 
+### Space switching on macOS 27 and later
+
+macOS 27 changed how the Dock reads a synthetic swipe: the gesture fields on the
+posted `CGEvent` are no longer enough on their own, and the event must also carry
+a serialized IOHID payload. mimi picks the encoding from the running OS version,
+so no configuration is needed.
+
+If space switching misbehaves near that boundary, override the choice with
+`MIMI_FORCE_DOCK_SWIPE_AUGMENTATION` — `1` forces the macOS 27 encoding, `0`
+forces the pre-27 one:
+
+```bash
+MIMI_FORCE_DOCK_SWIPE_AUGMENTATION=1 mimi action space next
+```
+
+The variable is read once per process, so a daemon has to be restarted for a
+change to take effect. Failures to build the payload are logged with a
+`Mimi: dock swipe augmentation failed` prefix.
+
 ## `mimi action` runs but seems to ignore the running daemon
 
 `mimi action …` routes over the daemon's Unix socket (`settings.socket_file`)

--- a/internal/native/dockswipe.h
+++ b/internal/native/dockswipe.h
@@ -1,0 +1,35 @@
+//
+//  dockswipe.h
+//  Mimi
+//
+//  Copyright © 2025 Mimi. All rights reserved.
+//
+
+#ifndef MIMI_DOCKSWIPE_H
+#define MIMI_DOCKSWIPE_H
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <stdbool.h>
+
+// macOS 27 stopped reconstructing a dock swipe from the gesture fields set on
+// a synthetic CGEvent. The Dock now reads a serialized IOHID queue payload
+// carried in the event's data representation, so a synthetic swipe that only
+// sets the gesture fields is silently ignored. These helpers gate and build
+// that payload; everything here is undocumented and may break on any update.
+
+/// Whether the running macOS requires synthetic dock swipes to carry a
+/// serialized IOHID payload. True on macOS 27 and later.
+///
+/// The answer depends on the running OS, not the SDK the binary was built
+/// against, and is cached after the first call. Setting
+/// `MIMI_FORCE_DOCK_SWIPE_AUGMENTATION` to `1` or `0` overrides the version
+/// check, which is the only way to exercise either path on a single machine.
+bool MimiDockSwipeRequiresAugmentation(void);
+
+/// Copy `event` with a serialized IOHID queue payload appended, built from the
+/// gesture fields already set on it.
+/// @param event Dock-control gesture event to augment
+/// @return Retained CGEventRef (caller must CFRelease), or NULL on failure
+CGEventRef MimiDockSwipeAugment(CGEventRef event);
+
+#endif  // MIMI_DOCKSWIPE_H

--- a/internal/native/dockswipe.m
+++ b/internal/native/dockswipe.m
@@ -1,0 +1,274 @@
+//
+//  dockswipe.m
+//  Mimi
+//
+//  Copyright © 2025 Mimi. All rights reserved.
+//
+
+#import "dockswipe.h"
+
+#import "mimi_log.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <mach/mach_time.h>
+#import <stdint.h>
+#import <stdlib.h>
+#import <string.h>
+#import <sys/sysctl.h>
+
+#pragma mark - IOHID Queue Layout
+
+// Layout of the IOHID event records the Dock expects to find serialized inside
+// a synthetic dock-swipe CGEvent on macOS 27+. Reverse-engineered from
+// IOHIDFamily; packed because the Dock parses the bytes positionally.
+#pragma pack(push, 1)
+
+typedef struct {
+	uint32_t size;
+	uint32_t type;
+	uint32_t options;
+	uint8_t depth;
+	uint8_t reserved[3];
+} MimiIOHIDEventBase;
+
+typedef struct {
+	MimiIOHIDEventBase base;
+	int32_t positionX;
+	int32_t positionY;
+	int32_t positionZ;
+	uint32_t swipeMask;
+	uint16_t gestureMotion;
+	uint16_t gestureFlavor;
+	int32_t swipeProgress;
+} MimiIOHIDFluidTouchGestureData;
+
+typedef struct {
+	MimiIOHIDEventBase base;
+	int32_t velocityX;
+	int32_t velocityY;
+	int32_t velocityZ;
+} MimiIOHIDVelocityEventData;
+
+typedef struct {
+	uint64_t timestamp;
+	uint64_t senderID;
+	uint32_t options;
+	uint32_t attributeLength;
+	uint32_t eventCount;
+} MimiIOHIDSystemQueueElementHeader;
+
+#pragma pack(pop)
+
+// The Dock parses these records positionally, so a layout drift would be
+// silently mis-read rather than rejected. Fail the build instead.
+_Static_assert(sizeof(MimiIOHIDEventBase) == 16, "unexpected IOHID event base layout");
+_Static_assert(sizeof(MimiIOHIDFluidTouchGestureData) == 40, "unexpected IOHID fluid gesture layout");
+_Static_assert(sizeof(MimiIOHIDVelocityEventData) == 28, "unexpected IOHID velocity layout");
+_Static_assert(sizeof(MimiIOHIDSystemQueueElementHeader) == 28, "unexpected IOHID queue header layout");
+
+// See IOHIDEventType in IOHIDFamily.
+static const uint32_t kMimiIOHIDEventTypeVelocity = 9;
+static const uint32_t kMimiIOHIDEventTypeFluidTouchGesture = 23;
+static const uint16_t kMimiIOHIDGestureFlavorDockPrimary = 3;
+
+// Gesture fields read back off the CGEvent when building the payload. Kept
+// local to this file so the payload builder stays independent of whichever
+// caller populated the event.
+static const int kMimiCGEventGestureSwipeMask = 115;
+static const int kMimiCGEventGestureSwipeMotion = 123;
+static const int kMimiCGEventGestureSwipeProgress = 124;
+static const int kMimiCGEventGestureSwipePositionX = 125;
+static const int kMimiCGEventGestureSwipePositionY = 126;
+static const int kMimiCGEventGestureSwipeVelocityX = 129;
+static const int kMimiCGEventGestureSwipeVelocityY = 130;
+static const int kMimiCGEventGesturePhase = 132;
+
+static const int kMimiCGSGesturePhaseEnded = 4;
+
+// Field ID the payload is attached under in the serialized event, and the
+// serialization format version this encoding is known to match.
+static const uint16_t kMimiCGEventRawIOHIDPayloadField = 4205;
+static const uint8_t kMimiCGEventDataFormatVersion = 2;
+
+/// Convert a double to the 16.16 fixed-point encoding IOHID uses, preserving
+/// the sign of values that would otherwise truncate to zero. Direction matters
+/// more than magnitude here, and truncating a tiny progress value to zero reads
+/// as "no movement".
+static int32_t mimiDoubleToFixed1616(double value) {
+	int32_t fixed = (int32_t)(value * 65536.0);
+	if (fixed == 0 && value != 0.0) {
+		return value > 0.0 ? 1 : -1;
+	}
+
+	return fixed;
+}
+
+/// Build the IOHID queue payload described by an event's gesture fields.
+/// @param event Dock-control gesture event to read fields from
+/// @param outLength Receives the payload length in bytes
+/// @return malloc'd buffer (caller must free), or NULL on allocation failure
+static uint8_t *mimiBuildIOHIDPayload(CGEventRef event, size_t *outLength) {
+	int64_t phase = CGEventGetIntegerValueField(event, kMimiCGEventGesturePhase);
+	int64_t motion = CGEventGetIntegerValueField(event, kMimiCGEventGestureSwipeMotion);
+	int64_t swipeMask = CGEventGetIntegerValueField(event, kMimiCGEventGestureSwipeMask);
+	double progress = CGEventGetDoubleValueField(event, kMimiCGEventGestureSwipeProgress);
+	double posX = CGEventGetDoubleValueField(event, kMimiCGEventGestureSwipePositionX);
+	double posY = CGEventGetDoubleValueField(event, kMimiCGEventGestureSwipePositionY);
+	double velX = CGEventGetDoubleValueField(event, kMimiCGEventGestureSwipeVelocityX);
+	double velY = CGEventGetDoubleValueField(event, kMimiCGEventGestureSwipeVelocityY);
+
+	// A real trackpad only reports velocity once the fingers lift, so the
+	// velocity record is omitted unless there is a velocity to report.
+	bool includeVelocity = (velX != 0.0 || velY != 0.0 || phase == kMimiCGSGesturePhaseEnded);
+
+	size_t length = sizeof(MimiIOHIDSystemQueueElementHeader) + sizeof(MimiIOHIDFluidTouchGestureData);
+	if (includeVelocity) {
+		length += sizeof(MimiIOHIDVelocityEventData);
+	}
+
+	uint8_t *payload = (uint8_t *)calloc(1, length);
+	if (!payload) {
+		return NULL;
+	}
+
+	MimiIOHIDSystemQueueElementHeader *header = (MimiIOHIDSystemQueueElementHeader *)payload;
+	uint64_t timestamp = CGEventGetTimestamp(event);
+	header->timestamp = timestamp != 0 ? timestamp : mach_absolute_time();
+	header->eventCount = includeVelocity ? 2 : 1;
+
+	MimiIOHIDFluidTouchGestureData *fluid =
+	    (MimiIOHIDFluidTouchGestureData *)(payload + sizeof(MimiIOHIDSystemQueueElementHeader));
+	fluid->base.size = sizeof(MimiIOHIDFluidTouchGestureData);
+	fluid->base.type = kMimiIOHIDEventTypeFluidTouchGesture;
+	fluid->base.options = (uint32_t)((phase & 0xFF) << 24);
+	fluid->positionX = mimiDoubleToFixed1616(posX);
+	fluid->positionY = mimiDoubleToFixed1616(posY);
+	fluid->swipeMask = (uint32_t)swipeMask;
+	fluid->gestureMotion = (uint16_t)motion;
+	fluid->gestureFlavor = kMimiIOHIDGestureFlavorDockPrimary;
+	fluid->swipeProgress = mimiDoubleToFixed1616(progress);
+
+	if (includeVelocity) {
+		MimiIOHIDVelocityEventData *velocity =
+		    (MimiIOHIDVelocityEventData *)(payload + sizeof(MimiIOHIDSystemQueueElementHeader) +
+		                                   sizeof(MimiIOHIDFluidTouchGestureData));
+		velocity->base.size = sizeof(MimiIOHIDVelocityEventData);
+		velocity->base.type = kMimiIOHIDEventTypeVelocity;
+		velocity->base.depth = 1;
+		velocity->velocityX = mimiDoubleToFixed1616(velX);
+		velocity->velocityY = mimiDoubleToFixed1616(velY);
+	}
+
+	*outLength = length;
+
+	return payload;
+}
+
+#pragma mark - Public Dock Swipe API
+
+CGEventRef MimiDockSwipeAugment(CGEventRef event) {
+	if (!event) {
+		return NULL;
+	}
+
+	CFDataRef data = CGEventCreateData(kCFAllocatorDefault, event);
+	if (!data) {
+		MIMI_LOG("dock swipe augmentation failed: could not serialize event");
+
+		return NULL;
+	}
+
+	const uint8_t *bytes = CFDataGetBytePtr(data);
+	CFIndex length = CFDataGetLength(data);
+
+	// The trailing-field encoding below is only known to hold for format
+	// version 2. Bail out rather than append bytes the Dock may misparse.
+	if (length < 4 || bytes[0] != 0 || bytes[1] != 0 || bytes[2] != 0 || bytes[3] != kMimiCGEventDataFormatVersion) {
+		MIMI_LOG("dock swipe augmentation failed: unexpected event data format (length=%ld)", (long)length);
+		CFRelease(data);
+
+		return NULL;
+	}
+
+	size_t payloadLength = 0;
+	uint8_t *payload = mimiBuildIOHIDPayload(event, &payloadLength);
+	if (!payload) {
+		CFRelease(data);
+
+		return NULL;
+	}
+
+	// Serialized event, then a 4-byte trailing field header (big-endian payload
+	// length, then field ID), then the payload itself.
+	size_t newLength = (size_t)length + 4 + payloadLength;
+	uint8_t *newBytes = (uint8_t *)malloc(newLength);
+	if (!newBytes) {
+		free(payload);
+		CFRelease(data);
+
+		return NULL;
+	}
+
+	memcpy(newBytes, bytes, (size_t)length);
+	newBytes[length] = (uint8_t)((payloadLength >> 8) & 0xFF);
+	newBytes[length + 1] = (uint8_t)(payloadLength & 0xFF);
+	newBytes[length + 2] = (uint8_t)((kMimiCGEventRawIOHIDPayloadField >> 8) & 0xFF);
+	newBytes[length + 3] = (uint8_t)(kMimiCGEventRawIOHIDPayloadField & 0xFF);
+	memcpy(newBytes + length + 4, payload, payloadLength);
+
+	free(payload);
+	CFRelease(data);
+
+	CFDataRef newData = CFDataCreate(kCFAllocatorDefault, newBytes, (CFIndex)newLength);
+	free(newBytes);
+	if (!newData) {
+		return NULL;
+	}
+
+	CGEventRef augmented = CGEventCreateFromData(kCFAllocatorDefault, newData);
+	CFRelease(newData);
+
+	if (!augmented) {
+		MIMI_LOG("dock swipe augmentation failed: could not rebuild event from data");
+	}
+
+	return augmented;
+}
+
+bool MimiDockSwipeRequiresAugmentation(void) {
+	static int cached = -1;
+	if (cached != -1) {
+		return cached == 1;
+	}
+
+	const char *override = getenv("MIMI_FORCE_DOCK_SWIPE_AUGMENTATION");
+	if (override) {
+		cached = (strcmp(override, "1") == 0) ? 1 : 0;
+		MIMI_LOG("dock swipe augmentation forced by environment (enabled=%d)", cached);
+
+		return cached == 1;
+	}
+
+	// Ask the kernel for the running product version rather than the SDK the
+	// binary was built against — the Dock's behaviour follows the former.
+	char version[32];
+	size_t size = sizeof(version);
+	if (sysctlbyname("kern.osproductversion", version, &size, NULL, 0) != 0) {
+		MIMI_LOG("could not read kern.osproductversion; assuming legacy dock swipe encoding");
+		cached = 0;
+
+		return false;
+	}
+
+	int major = 0;
+	if (sscanf(version, "%d", &major) != 1) {
+		MIMI_LOG("could not parse kern.osproductversion; assuming legacy dock swipe encoding");
+		cached = 0;
+
+		return false;
+	}
+
+	cached = (major >= 27) ? 1 : 0;
+
+	return cached == 1;
+}

--- a/internal/native/space.m
+++ b/internal/native/space.m
@@ -6,6 +6,7 @@
 //
 
 #import "constants.h"
+#import "dockswipe.h"
 #import "mimi.h"
 #import "mimi_log.h"
 
@@ -17,6 +18,7 @@
 #import <mach-o/dyld.h>
 #import <mach-o/loader.h>
 #import <mach-o/nlist.h>
+#import <mach/mach_time.h>
 #import <objc/message.h>
 #import <objc/objc.h>
 #import <objc/runtime.h>
@@ -241,7 +243,18 @@ static const int kMimiCGEventGestureSwipeProgress = 124;   // kCGEventGestureSwi
 static const int kMimiCGEventGestureSwipeVelocityX = 129;  // kCGEventGestureSwipeVelocityX
 static const int kMimiCGEventGesturePhase = 132;           // kCGEventGesturePhase
 static const int kMimiCGSGesturePhaseBegan = 1;            // kCGSGesturePhaseBegan
+static const int kMimiCGSGesturePhaseChanged = 2;          // kCGSGesturePhaseChanged
 static const int kMimiCGSGesturePhaseEnded = 4;            // kCGSGesturePhaseEnded
+
+// Additional fields the Dock requires on macOS 27+, alongside the serialized
+// IOHID payload built in dockswipe.m. See MimiDockSwipeRequiresAugmentation.
+static const int kMimiCGEventGestureSwipePositionX = 125;     // kCGEventGestureSwipePositionX
+static const int kMimiCGEventGesturePhaseAlias = 134;         // kCGEventGesturePhaseAlias
+static const int kMimiCGEventGestureZoomDeltaY = 138;         // kCGEventGestureZoomDeltaY
+static const int kMimiCGEventSourceUnixProcessIDAlias = 169;  // kCGEventSourceUnixProcessIDAlias
+static const double kMimiDockSwipeAugmentedZoomDeltaY = 3.0;  // empirically required
+static const double kMimiDockSwipeAugmentedPositionX = 0.1;   // empirically required
+static const double kMimiDockSwipeVelocity = 9999.0;          // high enough to skip the animation
 
 /// Return the 1-based local index of a space within its display's space
 /// ordering. Returns 0 if the space is not found on the given display.
@@ -292,6 +305,68 @@ static int mimiLocalSpaceIndex(uint64_t sid, uint32_t did) {
 	CFRelease(uuid);
 	return 0;
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+/// Build one phase of a synthetic dock swipe for macOS 27+, carrying both the
+/// extra gesture fields and the serialized IOHID payload the Dock now reads.
+/// @param phase kCGSGesturePhase value for this event
+/// @param sign Direction of travel through the display's space ordering
+/// @return Retained CGEventRef (caller must CFRelease), or NULL on failure
+static CGEventRef mimiCreateAugmentedDockSwipeEvent(int phase, double sign) {
+	CGEventRef event = CGEventCreate(NULL);
+	if (!event) {
+		return NULL;
+	}
+
+	CGEventSetIntegerValueField(event, kMimiCGSEventTypeField, kMimiCGSEventDockControl);
+	CGEventSetIntegerValueField(event, kMimiCGEventGestureHIDType, kMimiIOHIDEventTypeDockSwipe);
+	CGEventSetIntegerValueField(event, kMimiCGEventGestureSwipeMotion, kMimiCGGestureMotionHorizontal);
+	CGEventSetIntegerValueField(event, kMimiCGEventGesturePhase, phase);
+	CGEventSetIntegerValueField(event, kMimiCGEventGesturePhaseAlias, phase);
+
+	// The payload is read with the raw HID sign convention, which runs opposite
+	// to the space-index direction used everywhere else here.
+	CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipeProgress, -sign);
+	CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipePositionX, kMimiDockSwipeAugmentedPositionX);
+	CGEventSetDoubleValueField(event, kMimiCGEventGestureZoomDeltaY, kMimiDockSwipeAugmentedZoomDeltaY);
+	CGEventSetDoubleValueField(event, kMimiCGEventSourceUnixProcessIDAlias, (double)mach_absolute_time());
+
+	// Only the ending phase carries velocity, matching a real trackpad lift.
+	if (phase == kMimiCGSGesturePhaseEnded) {
+		CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipeVelocityX, -sign * kMimiDockSwipeVelocity);
+	}
+
+	CGEventRef augmented = MimiDockSwipeAugment(event);
+	CFRelease(event);
+
+	return augmented;
+}
+
+/// Post one whole synthetic swipe as the began/changed/ended phase sequence a
+/// real trackpad produces. macOS 27 rejects the abbreviated began/ended pair
+/// the legacy path gets away with.
+/// @return true if every phase was posted
+static bool mimiPostAugmentedDockSwipe(double sign) {
+	static const int phases[] = {kMimiCGSGesturePhaseBegan, kMimiCGSGesturePhaseChanged, kMimiCGSGesturePhaseEnded};
+
+	for (size_t i = 0; i < sizeof(phases) / sizeof(phases[0]); i++) {
+		CGEventRef event = mimiCreateAugmentedDockSwipeEvent(phases[i], sign);
+		if (!event) {
+			MIMI_LOG("failed to build augmented dock swipe event (phase=%d)", phases[i]);
+
+			return false;
+		}
+
+		CGEventPost(kCGSessionEventTap, event);
+		CFRelease(event);
+	}
+
+	return true;
+}
+
+#pragma clang diagnostic pop
 
 /// Focus a space using a synthetic high-velocity horizontal dock swipe
 /// gesture to skip the standard Mission Control swipe animation — macOS
@@ -359,28 +434,38 @@ int MimiFocusSpaceUsingGesture(uint32_t new_did, uint64_t new_sid) {
 		return 1;
 	}
 
-	CGEventRef event = CGEventCreate(NULL);
-	if (!event) {
-		return 0;
-	}
-
 	double sign = (toIdx - fromIdx) > 0 ? 1.0 : -1.0;
 
-	CGEventSetIntegerValueField(event, kMimiCGSEventTypeField, kMimiCGSEventDockControl);
-	CGEventSetIntegerValueField(event, kMimiCGEventGestureHIDType, kMimiIOHIDEventTypeDockSwipe);
-	CGEventSetIntegerValueField(event, kMimiCGEventGestureSwipeMotion, kMimiCGGestureMotionHorizontal);
-	CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipeProgress, sign);
-	CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipeVelocityX, sign * 9999.0);
+	if (MimiDockSwipeRequiresAugmentation()) {
+		for (int i = 0; i < count; i++) {
+			if (!mimiPostAugmentedDockSwipe(sign)) {
+				return 0;
+			}
 
-	for (int i = 0; i < count; i++) {
-		CGEventSetIntegerValueField(event, kMimiCGEventGesturePhase, kMimiCGSGesturePhaseBegan);
-		CGEventPost(kCGSessionEventTap, event);
-		CGEventSetIntegerValueField(event, kMimiCGEventGesturePhase, kMimiCGSGesturePhaseEnded);
-		CGEventPost(kCGSessionEventTap, event);
-		mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay);
+			mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay);
+		}
+	} else {
+		CGEventRef event = CGEventCreate(NULL);
+		if (!event) {
+			return 0;
+		}
+
+		CGEventSetIntegerValueField(event, kMimiCGSEventTypeField, kMimiCGSEventDockControl);
+		CGEventSetIntegerValueField(event, kMimiCGEventGestureHIDType, kMimiIOHIDEventTypeDockSwipe);
+		CGEventSetIntegerValueField(event, kMimiCGEventGestureSwipeMotion, kMimiCGGestureMotionHorizontal);
+		CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipeProgress, sign);
+		CGEventSetDoubleValueField(event, kMimiCGEventGestureSwipeVelocityX, sign * kMimiDockSwipeVelocity);
+
+		for (int i = 0; i < count; i++) {
+			CGEventSetIntegerValueField(event, kMimiCGEventGesturePhase, kMimiCGSGesturePhaseBegan);
+			CGEventPost(kCGSessionEventTap, event);
+			CGEventSetIntegerValueField(event, kMimiCGEventGesturePhase, kMimiCGSGesturePhaseEnded);
+			CGEventPost(kCGSessionEventTap, event);
+			mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay);
+		}
+
+		CFRelease(event);
 	}
-
-	CFRelease(event);
 
 	mimiPumpRunLoop(kMimiSpaceGestureProcessingDelay * (CFTimeInterval)count + kMimiSpaceGestureProcessingDelay);
 


### PR DESCRIPTION
## Description

This PR fixes space switching doing nothing on macOS 27. On that version the Dock stopped reconstructing a swipe from the gesture information mimi sets on a synthetic event, and instead reads a serialized low-level input payload carried inside the event. mimi was not attaching one, so its swipes were accepted and then silently discarded — which is why the reporter saw no space change and no errors in the log.

Synthetic swipes now carry that payload on macOS 27 and later, along with the extra fields, the inverted direction sign, and the full began/changed/ended phase sequence the Dock expects there. Which encoding is used is decided from the running macOS version rather than the SDK the binary was built against, so a single build serves both. macOS 26 and earlier keep the exact path they had.

## Related Issues

Closes #147

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, the behaviour is a synthetic event reaching the Dock, which the unit tiers cannot observe; the byte layout is pinned by compile-time assertions instead.
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Environment variables

One new variable, read by `mimi action space …` and the daemon:

| Variable | Values | Default |
| --- | --- | --- |
| `MIMI_FORCE_DOCK_SWIPE_AUGMENTATION` | `1` forces the macOS 27 encoding, `0` forces the pre-27 one | unset — the encoding is chosen from the running macOS version |

```bash
MIMI_FORCE_DOCK_SWIPE_AUGMENTATION=1 mimi action space next
```

It is read once per process, so a running daemon has to be restarted for a change to take effect. Nothing else about the config or command surface changes, and existing configs and invocations are unaffected.

## Additional Context

**Behaviour on older macOS is deliberately untouched.** The new encoding sits behind a runtime version check; on macOS 26 and below the previous code path runs verbatim, down to reusing a single event across the swipe loop. `mimi action space next` and `space prev` were run on macOS 26.6.1 against this build and behave as before.

**How the encoding was verified without macOS 27 hardware.** The payload layout and the field it is attached under were cross-checked against three independent implementations that agree on it — the `macos-27` branch of jurplel/InstantSpaceSwitcher, joshuarli/iss (a separate codebase with a byte-identical layout), and BetterTouchTool, which shipped the same fix in 6.571. A standalone harness then exercised the builder against the real CoreGraphics on macOS 26: the augmented event grows by exactly the trailer plus payload, every gesture field survives the round trip, and the payload decodes with the expected record type, phase, flavour, and fixed-point progress. Most tellingly, CoreGraphics relocates the appended field when it re-serializes the event, which means it parsed it as a legitimate field rather than trailing junk.

**Timing and macOS-version sensitivity.** This is synthetic dock-swipe territory, so it is user-visible by nature. The macOS 27 path posts three events per swipe where the old path posted two; the delay between swipes is unchanged. Should the payload ever fail to build, the swipe is abandoned rather than posted half-formed, and the reason is logged with a `Mimi: dock swipe augmentation failed` prefix.
