### PR TITLE
feat(systray): show the last config reload's outcome in the tray menu

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -57,6 +57,13 @@ edit, so the notice keeps appearing on every reload for as long as the file and
 the running daemon disagree — and stops on its own if you put the old value
 back.
 
+With `systray.enabled = true`, the menu shows the same outcome to someone who
+has no log in front of them: a disabled line under **Reload Config** reading
+`Reloaded 14:32`, `Reloaded 14:32 — restart required`, or
+`Reload failed 14:32`, and `No config reload yet` until the daemon has reloaded
+once. It reports the daemon's own reload, so every route above updates it, not
+just the menu item.
+
 These two lists are not maintained by hand: each config field is classified on
 the type itself, and a test fails if this document and that classification
 disagree.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -72,8 +72,13 @@ func Run(cfg *config.Config, logger *zap.SugaredLogger, configPath string, versi
 		)
 	}
 
+	// The component, when there is one, is built above and outlives the core,
+	// so a reload that lands before Cocoa has drawn the menu still has
+	// somewhere to be recorded.
+	reportReload := reloadReporter(component)
+
 	go func() {
-		err := runCore(cfg, logger, configPath, quitCh)
+		err := runCore(cfg, logger, configPath, quitCh, reportReload)
 
 		systray.Quit()
 
@@ -95,6 +100,7 @@ func runCore(
 	logger *zap.SugaredLogger,
 	configPath string,
 	quitCh <-chan struct{},
+	reportReload func(systray.ReloadOutcome),
 ) error {
 	err := writePID(cfg.Settings.PIDFile)
 	if err != nil {
@@ -126,7 +132,7 @@ func runCore(
 	)
 
 	onChange := func() {
-		reloadConfig(configPath, cfgReloader, reloadTriggerFsnotify, logger)
+		reloadConfig(configPath, cfgReloader, reloadTriggerFsnotify, reportReload, logger)
 	}
 
 	watcher := config.NewWatcher(configPath, onChange, logger)
@@ -142,7 +148,7 @@ func runCore(
 		}
 	}()
 
-	runSignalLoop(cancel, quitCh, cfgReloader, pipeline, logger, configPath)
+	runSignalLoop(cancel, quitCh, cfgReloader, pipeline, logger, configPath, reportReload)
 
 	return nil
 }
@@ -285,10 +291,16 @@ const (
 // daemon has applied everything it can and is still running the old value for
 // the rest, so it says so and names them. The names are mimi's own; the
 // values the user gave them stay out of the log.
+// The outcome also goes to reportReload, which is how a surface with no log in front
+// of it — the systray menu — can show what the last reload did. It travels one
+// way and carries the outcome alone: reporting is the daemon telling, never a
+// caller asking, and no config content rides along
+// (docs/adr/0002-reload-is-signal-mediated.md).
 func reloadConfig(
 	configPath string,
 	cfgReloader *reloader,
 	trigger reloadTrigger,
+	reportReload func(systray.ReloadOutcome),
 	logger *zap.SugaredLogger,
 ) {
 	newCfg, err := config.Load(configPath)
@@ -301,6 +313,7 @@ func reloadConfig(
 
 	if err != nil {
 		logger.Warnw(reloadFailedMessage, "trigger", trigger, "err", err)
+		reportReload(systray.ReloadOutcomeFailed)
 
 		return
 	}
@@ -313,11 +326,26 @@ func reloadConfig(
 			"trigger", trigger,
 			"restart_only", restartOnly,
 		)
+		reportReload(systray.ReloadOutcomeRestartRequired)
 
 		return
 	}
 
 	logger.Infow(reloadedMessage, "trigger", trigger)
+	reportReload(systray.ReloadOutcomeApplied)
+}
+
+// reloadReporter is where a reload's outcome goes. With a tray, that is the
+// component, which holds the outcome and shows it in the menu; with
+// [systray] enabled = false there is no component and the outcome is dropped.
+// Every reload reports through one of these two, so the reload path never has
+// to know which of them it has.
+func reloadReporter(component *systray.Component) func(systray.ReloadOutcome) {
+	if component == nil {
+		return func(systray.ReloadOutcome) {}
+	}
+
+	return component.ReportReload
 }
 
 // warnUnknownHookKeys notes that the config asked for hook kinds mimi does not
@@ -347,6 +375,7 @@ func runSignalLoop(
 	pipeline *eventPipeline,
 	logger *zap.SugaredLogger,
 	configPath string,
+	reportReload func(systray.ReloadOutcome),
 ) {
 	sigCh := make(chan os.Signal, 1)
 
@@ -362,7 +391,7 @@ func runSignalLoop(
 			return
 		case sig := <-sigCh:
 			if sig == syscall.SIGHUP {
-				reloadConfig(configPath, cfgReloader, reloadTriggerSighup, logger)
+				reloadConfig(configPath, cfgReloader, reloadTriggerSighup, reportReload, logger)
 
 				continue
 			}

--- a/internal/daemon/reload_report_test.go
+++ b/internal/daemon/reload_report_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/systray"
 )
 
 // reloadReportMarker is a value only a user's config file would contain. It
@@ -87,6 +88,10 @@ func entryText(entry observer.LoggedEntry) string {
 	return text.String()
 }
 
+// discardReloadOutcome stands in for the tray's callback in tests that assert
+// about the log rather than the outcome.
+func discardReloadOutcome(systray.ReloadOutcome) {}
+
 func TestReloadConfig_ReportsTheOutcome(t *testing.T) {
 	t.Parallel()
 
@@ -96,24 +101,28 @@ func TestReloadConfig_ReportsTheOutcome(t *testing.T) {
 		wantLevel   zapcore.Level
 		wantMessage string
 		wantInEntry []string
+		wantOutcome systray.ReloadOutcome
 	}{
 		{
 			name:        "a config that does not parse",
 			contents:    "not valid toml [[[",
 			wantLevel:   zapcore.WarnLevel,
 			wantMessage: reloadFailedMessage,
+			wantOutcome: systray.ReloadOutcomeFailed,
 		},
 		{
 			name:        "a config that parses but cannot be applied",
 			contents:    "[[hooks.on_window_focus]]\nrun = \"echo new\"\ntitle = \"[\"\n",
 			wantLevel:   zapcore.WarnLevel,
 			wantMessage: reloadFailedMessage,
+			wantOutcome: systray.ReloadOutcomeFailed,
 		},
 		{
 			name:        "only reloadable settings changed",
 			contents:    "[settings]\nlog_level = \"info\"\nhook_shell = \"/bin/bash\"\n",
 			wantLevel:   zapcore.InfoLevel,
 			wantMessage: reloadedMessage,
+			wantOutcome: systray.ReloadOutcomeApplied,
 		},
 		{
 			name:        "a restart-only setting changed",
@@ -121,6 +130,7 @@ func TestReloadConfig_ReportsTheOutcome(t *testing.T) {
 			wantLevel:   zapcore.WarnLevel,
 			wantMessage: reloadRestartRequiredMessage,
 			wantInEntry: []string{keyLogLevel},
+			wantOutcome: systray.ReloadOutcomeRestartRequired,
 		},
 		{
 			name:        "several restart-only settings changed",
@@ -128,6 +138,7 @@ func TestReloadConfig_ReportsTheOutcome(t *testing.T) {
 			wantLevel:   zapcore.WarnLevel,
 			wantMessage: reloadRestartRequiredMessage,
 			wantInEntry: []string{keyLogLevel, keyMaxHookWorkers},
+			wantOutcome: systray.ReloadOutcomeRestartRequired,
 		},
 	}
 
@@ -139,7 +150,21 @@ func TestReloadConfig_ReportsTheOutcome(t *testing.T) {
 
 			writeReloadTestConfig(t, path, testCase.contents)
 
-			reloadConfig(path, cfgReloader, reloadTriggerSighup, logger)
+			var reported []systray.ReloadOutcome
+
+			report := func(outcome systray.ReloadOutcome) {
+				reported = append(reported, outcome)
+			}
+
+			reloadConfig(path, cfgReloader, reloadTriggerSighup, report, logger)
+
+			if len(reported) != 1 {
+				t.Fatalf("reported %d outcomes, want 1: %v", len(reported), reported)
+			}
+
+			if reported[0] != testCase.wantOutcome {
+				t.Errorf("reported outcome = %v, want %v", reported[0], testCase.wantOutcome)
+			}
 
 			entries := logs.All()
 			if len(entries) != 1 {
@@ -181,7 +206,7 @@ func TestReloadConfig_KeepsUserConfigValuesOutOfTheLog(t *testing.T) {
 
 	writeReloadTestConfig(t, path, "[settings]\nlog_file = \""+reloadReportMarker+"\"\n")
 
-	reloadConfig(path, cfgReloader, reloadTriggerFsnotify, logger)
+	reloadConfig(path, cfgReloader, reloadTriggerFsnotify, discardReloadOutcome, logger)
 
 	entries := logs.All()
 	if len(entries) != 1 {
@@ -197,4 +222,20 @@ func TestReloadConfig_KeepsUserConfigValuesOutOfTheLog(t *testing.T) {
 	if strings.Contains(text, reloadReportMarker) {
 		t.Errorf("log entry %q carries the user's config value", text)
 	}
+}
+
+// TestReloadReporter_WithoutATrayReportsNowhere pins that the reload path does
+// not depend on the tray existing. With [systray] enabled = false there is no
+// component to hold an outcome, and a reload still has to report through
+// something — so the reporter is a no-op rather than a nil the reload path
+// would have to remember to check.
+func TestReloadReporter_WithoutATrayReportsNowhere(t *testing.T) {
+	t.Parallel()
+
+	report := reloadReporter(nil)
+	if report == nil {
+		t.Fatal("reloadReporter(nil) = nil, want a callback the reload path can call")
+	}
+
+	report(systray.ReloadOutcomeApplied)
 }

--- a/internal/systray/component.go
+++ b/internal/systray/component.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os/exec"
 	"strconv"
+	"sync"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -20,12 +22,23 @@ type Component struct {
 	ctx    context.Context //nolint:containedctx // Ties menu event goroutine to tray lifecycle.
 	cancel context.CancelFunc
 
+	// now reads the wall clock a reload is stamped with. A field so a test can
+	// pin the rendered time without waiting for one.
+	now func() time.Time
+
+	// reloadMu guards the last reload and the item that shows it. The daemon
+	// reports from its reload goroutine while Cocoa builds the menu on the
+	// main thread, so both are written from either side.
+	reloadMu   sync.Mutex
+	lastReload *reloadStatus
+
 	mVersion      *MenuItem
 	mHelp         *MenuItem
 	mSourceCode   *MenuItem
 	mConfigDocs   *MenuItem
 	mCLI          *MenuItem
 	mReloadConfig *MenuItem
+	mReloadStatus *MenuItem
 	mQuit         *MenuItem
 }
 
@@ -53,6 +66,7 @@ func NewComponent(
 		logger:              logger,
 		ctx:                 ctx,
 		cancel:              cancel,
+		now:                 time.Now,
 	}
 }
 
@@ -69,6 +83,13 @@ func (c *Component) OnReady() {
 	AddSeparator()
 
 	c.mReloadConfig = AddMenuItem("Reload Config")
+
+	// The outcome of the daemon's last reload, whichever trigger fired it.
+	// The item starts on the line for a daemon that has not reloaded and is
+	// then handed to the component, which renders whatever outcome has already
+	// arrived: the core starts before Cocoa is ready, so a reload can land
+	// before this line exists.
+	c.adoptReloadStatusItem(AddMenuItem(formatReloadStatus(nil)))
 
 	AddSeparator()
 

--- a/internal/systray/reload_status.go
+++ b/internal/systray/reload_status.go
@@ -1,0 +1,105 @@
+package systray
+
+import "time"
+
+// reloadStatusTimeFormat renders the local wall-clock time a reload happened.
+// It is absolute on purpose: a relative "2 min ago" would need a timer ticking
+// behind a label that is read only when someone opens the menu.
+const reloadStatusTimeFormat = "15:04"
+
+// ReloadOutcome is what a reload did, as the daemon that ran it saw it. The
+// systray is told the outcome after the fact and holds it; it never learns of
+// one by asking, and gains no route into the reload path from having it
+// (docs/adr/0002-reload-is-signal-mediated.md).
+type ReloadOutcome int
+
+// The outcomes count from one so that the zero value is none of them: an
+// outcome nobody set renders as unknown rather than as the success that
+// happens to sort first.
+const (
+	// ReloadOutcomeApplied is a reload the daemon applied in full.
+	ReloadOutcomeApplied ReloadOutcome = iota + 1
+	// ReloadOutcomeRestartRequired is a reload the daemon applied as far as it
+	// can: restart-only settings changed too, and those keep their old values
+	// until the daemon is restarted. It is its own outcome rather than a
+	// success because it is the case where the reload worked and the user's
+	// change still did nothing.
+	ReloadOutcomeRestartRequired
+	// ReloadOutcomeFailed is a reload the daemon did not apply at all; the
+	// previous config is still running, entirely.
+	ReloadOutcomeFailed
+)
+
+// reloadStatus is the last reload the daemon reported, if there was one.
+type reloadStatus struct {
+	outcome ReloadOutcome
+	at      time.Time
+}
+
+// ReportReload records the outcome of the daemon's most recent reload and
+// updates the menu to match. It is the systray's whole share of reloading:
+// one call, one way, after the fact — every reload trigger reaches it, because
+// the daemon reports from the single place all of them funnel through, so a
+// reload from a file save or a signal shows up here just as a click does.
+//
+// It is safe to call before Cocoa has built the menu, which is the normal case
+// for a reload that lands during startup: the outcome is held as state and
+// OnReady renders it.
+func (c *Component) ReportReload(outcome ReloadOutcome) {
+	c.reloadMu.Lock()
+	defer c.reloadMu.Unlock()
+
+	c.lastReload = &reloadStatus{outcome: outcome, at: c.now()}
+
+	if c.mReloadStatus != nil {
+		// SetTitle marshals onto the main thread, so reporting from the
+		// daemon's reload goroutine is safe.
+		c.mReloadStatus.SetTitle(formatReloadStatus(c.lastReload))
+	}
+}
+
+// adoptReloadStatusItem takes ownership of the menu item that shows the reload
+// status, giving it the outcome the component is already holding. Taking the
+// item and rendering into it happen under one lock so that a reload landing
+// while Cocoa builds the menu cannot slip between the two and leave the line
+// showing an outcome older than the one recorded.
+//
+// The item is disabled because it is a label: it reports what a reload did and
+// offers no way to ask for another one.
+func (c *Component) adoptReloadStatusItem(item *MenuItem) {
+	c.reloadMu.Lock()
+	defer c.reloadMu.Unlock()
+
+	c.mReloadStatus = item
+
+	item.SetTitle(formatReloadStatus(c.lastReload))
+	item.Disable()
+}
+
+// formatReloadStatus renders a reload status for the menu. A nil status is a
+// daemon that has not reloaded since it started, which says so rather than
+// showing a time or implying a success that never happened.
+//
+// Nothing from the user's config file can reach these lines: the outcome is
+// three values and a clock reading, so no setting name, no setting value and
+// no error text has a way in.
+func formatReloadStatus(status *reloadStatus) string {
+	if status == nil {
+		return "No config reload yet"
+	}
+
+	when := status.at.Format(reloadStatusTimeFormat)
+
+	switch status.outcome {
+	case ReloadOutcomeApplied:
+		return "Reloaded " + when
+	case ReloadOutcomeRestartRequired:
+		return "Reloaded " + when + " — restart required"
+	case ReloadOutcomeFailed:
+		return "Reload failed " + when
+	default:
+		// An outcome nobody set, or one added without a line of its own.
+		// Honest rather than claiming a success it knows nothing about.
+		return "Reload reported " + when + " — unknown outcome"
+	}
+}

--- a/internal/systray/reload_status_test.go
+++ b/internal/systray/reload_status_test.go
@@ -1,0 +1,159 @@
+//nolint:testpackage // pins the last-reload status, an unexported seam of the tray component
+package systray
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The clock readings the tests render. Fixed, because the status line is
+// absolute local time and a test that waited for a real one would be pinning
+// nothing.
+const (
+	testReloadHour   = 14
+	testReloadMinute = 32
+)
+
+// fixedClock reads a fixed wall-clock time, standing in for time.Now. The
+// zone is pinned rather than local because what these tests assert is the
+// rendered reading of whatever clock the component was given; the daemon's own
+// clock is the local one, and it is time.Now that supplies it.
+func fixedClock(hour, minute int) func() time.Time {
+	return func() time.Time {
+		return time.Date(2026, time.August, 15, hour, minute, 0, 0, time.UTC)
+	}
+}
+
+// newStatusTestComponent builds a component with a fixed clock and no menu —
+// the state the daemon's callback finds during startup, before Cocoa is ready.
+func newStatusTestComponent(t *testing.T) *Component {
+	t.Helper()
+
+	requestReload := func(context.Context, string) error { return nil }
+
+	component := NewComponent("v0", "config.toml", requestReload, func() {}, false, nil)
+	component.now = fixedClock(testReloadHour, testReloadMinute)
+
+	t.Cleanup(component.Close)
+
+	return component
+}
+
+// newStatusTestItem stands in for the item OnReady adds. Its id matches no
+// item in Cocoa's menu, so titling and disabling it change only the Go-side
+// copy a test reads.
+func newStatusTestItem() *MenuItem {
+	return &MenuItem{ClickedCh: make(chan struct{}, 1)}
+}
+
+// TestFormatReloadStatus_RendersEveryOutcome pins the line the menu shows for
+// each reload outcome. The three outcomes must stay distinguishable at a
+// glance: a reload that left restart-only settings unapplied worked and still
+// did not do what the user asked, so rendering it as a plain success would be
+// the same lie the reload menu item stopped telling
+// (docs/adr/0002-reload-is-signal-mediated.md).
+//
+// The time is absolute and local. A relative "2 min ago" would need a timer
+// ticking behind a label read only when someone opens the menu.
+func TestFormatReloadStatus_RendersEveryOutcome(t *testing.T) {
+	t.Parallel()
+
+	reloadedAt := fixedClock(testReloadHour, testReloadMinute)()
+
+	tests := []struct {
+		name   string
+		status *reloadStatus
+		want   string
+	}{
+		{
+			name:   "no reload has happened yet",
+			status: nil,
+			want:   "No config reload yet",
+		},
+		{
+			name:   "the reload applied cleanly",
+			status: &reloadStatus{outcome: ReloadOutcomeApplied, at: reloadedAt},
+			want:   "Reloaded 14:32",
+		},
+		{
+			name:   "the reload left restart-only settings unapplied",
+			status: &reloadStatus{outcome: ReloadOutcomeRestartRequired, at: reloadedAt},
+			want:   "Reloaded 14:32 — restart required",
+		},
+		{
+			name:   "the reload failed",
+			status: &reloadStatus{outcome: ReloadOutcomeFailed, at: reloadedAt},
+			want:   "Reload failed 14:32",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := formatReloadStatus(testCase.status)
+			if got != testCase.want {
+				t.Errorf("formatReloadStatus() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestComponent_ReportReload_UpdatesAMenuThatAlreadyExists pins the ordinary
+// case: the menu is up, and a reload from any trigger — a file save or a
+// signal, not only a click on the menu item — rewrites the status line, with
+// the time it happened.
+func TestComponent_ReportReload_UpdatesAMenuThatAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	component := newStatusTestComponent(t)
+	item := newStatusTestItem()
+
+	component.adoptReloadStatusItem(item)
+
+	component.ReportReload(ReloadOutcomeRestartRequired)
+
+	got := item.Title()
+	if got != "Reloaded 14:32 — restart required" {
+		t.Errorf("status item title = %q, want %q", got, "Reloaded 14:32 — restart required")
+	}
+}
+
+// TestComponent_ReportReload_IsRenderedWhenTheMenuIsBuiltLater pins that a
+// reload landing before the menu exists is not lost. The daemon's core starts
+// after the component is built but before Cocoa calls OnReady, so the first
+// reload can be reported into a component that has no menu items at all; the
+// component holds the outcome and renders it when it is handed the item.
+func TestComponent_ReportReload_IsRenderedWhenTheMenuIsBuiltLater(t *testing.T) {
+	t.Parallel()
+
+	component := newStatusTestComponent(t)
+
+	component.ReportReload(ReloadOutcomeFailed)
+
+	item := newStatusTestItem()
+	component.adoptReloadStatusItem(item)
+
+	got := item.Title()
+	if got != "Reload failed 14:32" {
+		t.Errorf("status item title = %q, want %q", got, "Reload failed 14:32")
+	}
+}
+
+// TestComponent_AdoptReloadStatusItem_DisablesTheLine pins that the status is a
+// label and not a second way to ask for a reload. The systray reaches the
+// reload path through exactly one item, and that item signals
+// (docs/adr/0002-reload-is-signal-mediated.md).
+func TestComponent_AdoptReloadStatusItem_DisablesTheLine(t *testing.T) {
+	t.Parallel()
+
+	component := newStatusTestComponent(t)
+	item := newStatusTestItem()
+
+	component.adoptReloadStatusItem(item)
+
+	if !item.Disabled() {
+		t.Error("status item is enabled, want disabled — it is a label, not a command")
+	}
+}


### PR DESCRIPTION
## Description

This PR adds a status line to the systray menu showing when the daemon last
reloaded its config and how it went. The tray is the one surface where nobody
has a log in front of them, so a reload that failed after a menu click used to
be invisible; now the menu says so after the fact, and it says it for every
reload, not only the ones started from the menu.

The line sits under **Reload Config**, is greyed out because it is a label
rather than a command, and reads one of four things: `No config reload yet`
until the daemon has reloaded once, then `Reloaded 14:32`,
`Reloaded 14:32 — restart required`, or `Reload failed 14:32`. The middle one
is kept distinct on purpose — that reload worked and the user's change still
did nothing, so showing it as a plain success would repeat one layer up the
claim the reload menu item stopped making.

The status reflects a reload however it was triggered — a file save, a signal,
`mimi config reload`, or the menu item — and a reload that lands before the
menu has been drawn is shown once it is. With `systray.enabled = false` nothing
is reported and nothing changes.

## Related Issues

Closes #146

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

`just vet`, `just fmt-check` and `just test-all` were run too, all green.

## Config, commands and hooks

No new config keys, commands, flags or hook variables. The only interface
change is the menu itself, which `systray.enabled` already governs.

## Additional Context

- The outcome travels one way only. The daemon reports it from the single
  place every reload trigger funnels through, and what it hands over is one of
  three values and nothing else — no setting names, no config values, no error
  text — so nothing from the config file can reach the menu, and the tray gains
  no route back into the reload path
  (`docs/adr/0002-reload-is-signal-mediated.md`).
- The tray component holds the outcome as state rather than only painting it,
  because the daemon's core starts before the menu exists and the first reload
  can beat it.
- The time is absolute and local (`14:32`) rather than relative (`2 min ago`),
  which would need a timer ticking behind a label that is only read when
  someone opens the menu. The trigger is not named: the daemon deliberately
  cannot tell a menu click, a `mimi config reload` and a hand-typed `kill -HUP`
  apart, so naming it would be wrong exactly where it matters.
- The type describing an outcome lives with the tray rather than with the
  daemon. The daemon already depends on the tray package and the tray cannot
  depend back on the daemon, so the alternatives were a second enum plus a
  mapping, or a new package holding one type; neither seemed worth it for a
  value that exists to be displayed.
