### PR TITLE
docs: record reinstall-only as a third reloadability

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,9 +57,16 @@ _Avoid_: reload source, reload event, reload signal
 
 **Restart-only setting**:
 A config field the running daemon reads once at startup and never re-reads, so
-changing it takes effect only after the daemon is restarted. The complement of
-the fields a reload applies.
+changing it takes effect only after the daemon is restarted.
 _Avoid_: static setting, boot setting, startup setting
+
+**Reinstall-only setting**:
+A config field the daemon never reads at all, because it describes how the
+installed service is set up rather than how the daemon behaves. Changing it
+takes effect only when the service is installed again — a restart does not
+pick it up. Distinct from a **restart-only setting**: between them they account
+for every field a reload does not apply.
+_Avoid_: install setting, service setting, plist setting
 
 **Event kind**:
 The category of desktop change a hook subscribes to — window focused, space

--- a/docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md
+++ b/docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md
@@ -1,0 +1,56 @@
+# A setting the daemon never reads is reinstall-only
+
+**Status:** accepted
+
+`settings.service_path` sets the `PATH` the launchd-installed daemon runs with,
+and therefore the `PATH` its hooks inherit. Nothing in the daemon reads it: it
+is consumed by `mimi services install` when it renders the plist, and the value
+that matters is the one baked into the plist on disk. `reloadability.go` admits
+only `reloadable` and `restart-only` and rejects any field carrying neither, so
+the field must be classified — and neither existing value is true. We decided to
+add a third, `reinstall-only`, for fields whose new value takes effect when the
+service is installed again, not when the daemon next starts.
+
+The `reload:` tag was previously read as *when does the daemon pick this field
+up* — at every reload, or once at startup. A field the daemon never reads at all
+has no answer to that question. The tag is better understood as *what must the
+user do for a change to this field to take effect*, which admits actions the
+daemon plays no part in.
+
+## Considered options
+
+- **Tag it `restart-only`.** Rejected, and it is the option that would have been
+  actively worse than not shipping the setting. ADR-0002 committed the daemon to
+  reporting restart-only changes a reload could not apply, so this would make it
+  advise a restart for a field a restart does not change — a specific, confident,
+  wrong instruction, produced by machinery built to stop exactly that.
+- **Put it in a new `[service]` section, tagged at section level.** Rejected as
+  premature, not as wrong. `KeepAlive`, `Nice` and `ThrottleInterval` are all
+  plausible future install-time settings, and the second one that appears is
+  when this becomes the right shape. A section for one string is not.
+- **Make it a `--path` flag on `services install`, with no config field.** This
+  sidesteps the classification problem entirely, and was rejected because
+  `install` is idempotent and re-renders the plist when the rendered bytes
+  differ. A flag is not remembered, so the next plain `install` would silently
+  revert the `PATH` — reintroducing the drift between what the config says and
+  what the installed service does that placing the captured log streams beside
+  `log_file` was meant to end.
+- **Merge the whole `EnvironmentVariables` dict from config.** Rejected: the
+  plist also carries the captured-stream paths the daemon reads back, so a
+  user-supplied dict could overwrite keys the install path depends on. A single
+  `PATH` string cannot collide with anything.
+
+## Consequences
+
+- **A fourth reload outcome.** `ReloadOutcome` gains `ReinstallRequired`
+  alongside `Applied`, `RestartRequired` and `Failed`, with a daemon message
+  naming `mimi services install`. Folding it into `RestartRequired` and
+  accepting the wrong verb was considered and rejected for the same reason as
+  tagging the field `restart-only`.
+- **Restart-only is no longer the complement of reloadable.** ADR-0002 treats
+  the restart-only set as everything a reload does not apply. That is now two
+  sets, and the glossary in `CONTEXT.md` has been corrected to match.
+- **Nothing implements this yet.** The decision comes out of an architecture
+  review; the field, the tag value and the fourth outcome all ship together in
+  the PR that adds `settings.service_path`. A reader grepping for
+  `reinstall-only` before then will find only this file.


### PR DESCRIPTION
## Description

This PR records a decision that came out of an architecture review of the launchd service: settings that only take effect when the service is installed again need a category of their own, separate from restart-only.

The reload classification a config field carries has so far answered "when does the daemon pick this up" — at every reload, or once at startup. A field describing how the installed service is set up has no answer to that, because the daemon never reads it; the value that matters is the one already rendered into the service definition. Classifying such a field as restart-only would make a reload advise a restart that changes nothing, which is the opposite of what the reload reporting added in #149 exists to do. ADR-0003 records the third category, `reinstall-only`, and the four options weighed against it.

This also corrects the glossary, which defined a restart-only setting as the complement of the fields a reload applies. That is now split between two categories, and both entries say so.

Documentation only — nothing implements the new category yet. It ships with the first field that needs it (#156).

## Related Issues

Referenced by #156, which implements the first `reinstall-only` setting. Amends the last consequence of ADR-0002.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — N/A, documentation-only change; ran the `just fmt && just lint` fast path instead
- [x] Build succeeds (`just build`) — N/A, no Go or Objective-C touched
- [x] Tests added/updated for new or changed functionality — N/A, no behaviour changes
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Three alternatives were weighed and are recorded in the ADR rather than only here: tagging the field restart-only and accepting the wrong advice, grouping install-time settings into their own config section, and dropping the config field for a flag on the install command. The section is the shape this should take if a second install-time setting ever appears — one string does not justify it yet.

No user-facing surface changes in this PR: no config key, command, flag, or hook variable is added, renamed, or given a new default. Existing configs are unaffected.
