### PR TITLE
fix(service,cli): make services install replace a stale plist instead of refusing

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -48,14 +48,14 @@ func newServicesInstallCmd(state *cliState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "install",
 		Short: "Install and load the system service",
-		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.\n\nThe daemon's stdout and stderr are captured beside settings.log_file, as <name>.out.log and <name>.err.log, and that directory is created if missing. When log_file is unset — or is not an absolute path, which launchd cannot open — they fall back to /tmp/mimi.log and /tmp/mimi.err.log.",
+		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.\n\nThe plist is a snapshot of the config taken at install time, so run install again after changing a setting it bakes in — it replaces the plist and reloads the service, and does nothing at all when the plist already matches.\n\nThe daemon's stdout and stderr are captured beside settings.log_file, as <name>.out.log and <name>.err.log, and that directory is created if missing. When log_file is unset — or is not an absolute path, which launchd cannot open — they fall back to /tmp/mimi.log and /tmp/mimi.err.log.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := defaultService.Install(state.configPath, state.logFilePath())
+			outcome, err := defaultService.Install(state.configPath, state.logFilePath())
 			if err != nil {
 				return err
 			}
 
-			cmd.Println("Service installed and loaded successfully")
+			cmd.Println(formatInstallOutcome(outcome))
 
 			return nil
 		},
@@ -144,6 +144,25 @@ func newServicesStatusCmd() *cobra.Command {
 
 			return nil
 		},
+	}
+}
+
+// formatInstallOutcome renders what `mimi services install` did. Install is
+// idempotent, so the line has to say which of the three things happened —
+// "installed successfully" printed over an untouched service is how a stale
+// plist stays believed-current.
+func formatInstallOutcome(outcome service.InstallOutcome) string {
+	switch outcome {
+	case service.InstallOutcomeInstalled:
+		return "Service installed and loaded successfully"
+	case service.InstallOutcomeReplaced:
+		return "Service plist updated and service reloaded"
+	case service.InstallOutcomeUnchanged:
+		return "Service already up to date"
+	default:
+		// An outcome added without a line of its own. The install returned
+		// no error, so say only that much.
+		return "Service install completed"
 	}
 }
 

--- a/cmd/mimi/cmd/services_test.go
+++ b/cmd/mimi/cmd/services_test.go
@@ -56,6 +56,48 @@ func TestCLIState_LogFilePath(t *testing.T) {
 	}
 }
 
+// TestFormatInstallOutcome pins that each of the three things `mimi services
+// install` can do gets its own line. They are distinguishable on purpose: a
+// replace and a no-op both exit 0, and only the wording separates a service
+// that was just brought in line with the config from one that never needed it.
+func TestFormatInstallOutcome(t *testing.T) {
+	tests := []struct {
+		name    string
+		outcome service.InstallOutcome
+		want    string
+	}{
+		{
+			name:    "installed",
+			outcome: service.InstallOutcomeInstalled,
+			want:    "Service installed and loaded successfully",
+		},
+		{
+			name:    "replaced",
+			outcome: service.InstallOutcomeReplaced,
+			want:    "Service plist updated and service reloaded",
+		},
+		{
+			name:    "unchanged",
+			outcome: service.InstallOutcomeUnchanged,
+			want:    "Service already up to date",
+		},
+		{
+			name:    "an outcome with no line of its own",
+			outcome: service.InstallOutcome(0),
+			want:    "Service install completed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatInstallOutcome(tt.outcome)
+			if got != tt.want {
+				t.Errorf("formatInstallOutcome(%v) = %q, want %q", tt.outcome, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatStatus(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -192,6 +192,22 @@ The generated plist captures the daemon's stdout and stderr beside
 `log_file` is unset. See
 [Troubleshooting](TROUBLESHOOTING.md#where-a-service-installed-daemons-console-output-lands).
 
+The plist is a snapshot of the config taken at install time, so running install
+again is how an installed service is brought back in line with a config that
+has moved since. It is idempotent and reports which of three things it did:
+
+| Output                                       | What happened                                                              |
+| -------------------------------------------- | -------------------------------------------------------------------------- |
+| `Service installed and loaded successfully`  | The service was not loaded; the plist was written and the service loaded.   |
+| `Service plist updated and service reloaded` | The plist disagreed with the config; it was replaced and the service reloaded. |
+| `Service already up to date`                 | The installed plist already matched. Nothing was written or reloaded.       |
+
+Install refuses rather than replaces when what it finds is not a plist it
+wrote: a symlink at `~/Library/LaunchAgents/com.y3owk1n.mimi.plist` — the shape
+home-manager installs — or a loaded `com.y3owk1n.mimi` with no plist of mimi's
+behind it. Both errors name nix-darwin and home-manager, because the fix is in
+their configuration.
+
 ### `mimi services uninstall`
 
 Remove the launchd agent.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -118,8 +118,10 @@ Notes on this:
   `creating log directory` error if that is not possible — fix `log_file` and
   install again.
 - The paths are baked into the plist at install time. After changing
-  `settings.log_file`, run `mimi services uninstall && mimi services install`
-  to regenerate it — a restart alone keeps the old paths.
+  `settings.log_file`, run `mimi services install` again to regenerate it — a
+  restart alone keeps the old paths. Install is idempotent: it replaces the
+  plist and reloads the service when the rendered plist differs, prints
+  `Service already up to date` and does nothing when it does not.
 - The Nix modules (`nix/darwin.nix`, `nix/home.nix`) write their own plists,
   which always use `/tmp/mimi.log` and `/tmp/mimi.err.log` regardless of
   `settings.log_file`.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -15,12 +15,37 @@ const (
 	filePerm = 0o644
 )
 
+// foreignInstallAdvice is the tail of every refusal to touch a service mimi
+// did not install. It names the tools that install one of their own, because
+// the fix is always in their configuration and never in mimi.
+const foreignInstallAdvice = "check for existing installations (e.g., nix-darwin, home-manager) and uninstall them first"
+
 // Status is what checking the launchd service reports: a typed result a
 // caller can act on, in place of a formatted string only a human can read.
 type Status struct {
 	// Loaded reports whether launchctl currently has the service loaded.
 	Loaded bool
 }
+
+// InstallOutcome is what an [Service.Install] did. Install is idempotent, so
+// "it succeeded" is no longer enough for a caller to tell the user what
+// happened: the same command creates a service, brings a stale one back in
+// line with the config, or does nothing at all.
+type InstallOutcome int
+
+// The outcomes count from one so that the zero value is none of them: an
+// outcome nobody set is not silently the one that sorts first.
+const (
+	// InstallOutcomeInstalled is a service that was not loaded and now is.
+	InstallOutcomeInstalled InstallOutcome = iota + 1
+	// InstallOutcomeReplaced is a loaded service whose plist disagreed with
+	// the config describing it: the plist was replaced and the service
+	// reloaded so launchd reads the new one.
+	InstallOutcomeReplaced
+	// InstallOutcomeUnchanged is a loaded service whose plist already is the
+	// bytes mimi would render. Nothing was written and nothing was reloaded.
+	InstallOutcomeUnchanged
+)
 
 // Service manages the mimi launchd service. Every launchctl invocation runs
 // through the launcher it holds.
@@ -36,22 +61,33 @@ func New() *Service {
 // Install renders the plist for the running binary and configPath, writes it
 // to ~/Library/LaunchAgents, and loads it with launchctl bootstrap.
 //
+// It is idempotent, and that is the point: the plist is a snapshot of the
+// config taken at install time, so running install again is how an installed
+// service is brought back in line with a config that has moved since. A plist
+// that already matches is left alone and the loaded service is not disturbed.
+//
 // logFile is settings.log_file as config resolved it, and is only used to
 // place the daemon's captured stdout/stderr alongside it; an empty value is
 // valid and leaves those streams at their /tmp defaults.
-func (s *Service) Install(configPath, logFile string) error {
+func (s *Service) Install(configPath, logFile string) (InstallOutcome, error) {
 	ctx := context.Background()
 
-	if s.launcher.list(ctx, Label) == nil {
-		return derrors.New(
-			derrors.CodeServiceFailed,
-			"service is already loaded; check for existing installations (e.g., nix-darwin, home-manager) and uninstall them first",
-		)
+	loaded := s.launcher.list(ctx, Label) == nil
+	expandedPlist := plistPath()
+
+	installed, err := readInstalledPlist(expandedPlist)
+	if err != nil {
+		return 0, err
+	}
+
+	err = installed.refuseForeign(loaded)
+	if err != nil {
+		return 0, err
 	}
 
 	binPath, err := binaryPath()
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "getting binary path")
+		return 0, derrors.Wrapf(err, derrors.CodeServiceFailed, "getting binary path")
 	}
 
 	plistContent := renderPlist(binPath, configPath, logFile)
@@ -60,72 +96,26 @@ func (s *Service) Install(configPath, logFile string) error {
 	// creates no directories of its own: a missing one silently discards the
 	// console output of the very first run, which is the startup crash these
 	// streams exist to capture. mimi's own file log only creates the
-	// directory later, once the logger is built.
+	// directory later, once the logger is built. This runs before the
+	// unchanged check on purpose — a directory deleted since the last install
+	// is exactly the drift a re-run should repair.
 	captureDir := capturedStreamsFor(logFile).dir()
 
 	err = os.MkdirAll(captureDir, dirPerm)
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "creating log directory")
+		return 0, derrors.Wrapf(err, derrors.CodeServiceFailed, "creating log directory")
 	}
 
-	expandedDir := paths.ExpandHome(launchAgentsDir)
+	if loaded && installed.matches(plistContent) {
+		return InstallOutcomeUnchanged, nil
+	}
 
-	err = os.MkdirAll(expandedDir, dirPerm)
+	err = os.MkdirAll(filepath.Dir(expandedPlist), dirPerm)
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "creating LaunchAgents directory")
+		return 0, derrors.Wrapf(err, derrors.CodeServiceFailed, "creating LaunchAgents directory")
 	}
 
-	expandedPlist := filepath.Join(expandedDir, Label+".plist")
-
-	err = writePlist(expandedPlist, plistContent)
-	if err != nil {
-		return err
-	}
-
-	currentUser, err := user.Current()
-	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "getting current user")
-	}
-
-	err = s.launcher.bootstrap(ctx, "gui/"+currentUser.Uid, expandedPlist)
-	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "loading service")
-	}
-
-	return nil
-}
-
-// writePlist creates path with content, using O_EXCL to create it atomically
-// and avoid a TOCTOU race between checking for and writing the file. A
-// partial write is rolled back rather than left behind.
-func writePlist(path, content string) error {
-	plistFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
-	if err != nil {
-		if os.IsExist(err) {
-			return derrors.Newf(
-				derrors.CodeServiceFailed,
-				"plist file already exists at %s; remove it manually or uninstall first",
-				path,
-			)
-		}
-
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "creating plist")
-	}
-
-	_, err = plistFile.WriteString(content)
-	if err != nil {
-		_ = plistFile.Close()
-		_ = os.Remove(path)
-
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "writing plist")
-	}
-
-	err = plistFile.Close()
-	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "closing plist")
-	}
-
-	return nil
+	return s.apply(ctx, loaded, expandedPlist, plistContent)
 }
 
 // Uninstall unloads the service and removes its plist. A launchctl bootout
@@ -134,16 +124,14 @@ func writePlist(path, content string) error {
 func (s *Service) Uninstall() error {
 	ctx := context.Background()
 
-	expandedPlist := filepath.Join(paths.ExpandHome(launchAgentsDir), Label+".plist")
-
-	currentUser, err := user.Current()
+	domain, err := guiDomain()
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeServiceFailed, "getting current user")
+		return err
 	}
 
-	_ = s.launcher.bootout(ctx, "gui/"+currentUser.Uid+"/"+Label)
+	_ = s.launcher.bootout(ctx, domain+"/"+Label)
 
-	err = os.Remove(expandedPlist)
+	err = os.Remove(plistPath())
 	if err != nil && !os.IsNotExist(err) {
 		return derrors.Wrapf(err, derrors.CodeServiceFailed, "removing plist")
 	}
@@ -182,6 +170,195 @@ func (s *Service) Restart() error {
 // Status reports whether the service is currently loaded.
 func (s *Service) Status() Status {
 	return Status{Loaded: s.launcher.list(context.Background(), Label) == nil}
+}
+
+// apply makes the installed service be content: it unloads whatever is
+// loaded, replaces the plist at path, and hands the new one to launchd.
+//
+// The order is the whole of it. launchd holds the plist it was bootstrapped
+// with and re-reads one only when the job is loaded again, so replacing the
+// file alone changes nothing — but writing before unloading is worse than
+// useless. A bootout that failed after the write would leave the new plist on
+// disk in front of a service still running the old one, and every later
+// install would find the file it wanted and report the service up to date,
+// forever. Unloading first means a failure leaves the old plist untouched, so
+// the next install sees the same disagreement this one did and retries it.
+func (s *Service) apply(
+	ctx context.Context,
+	loaded bool,
+	path, content string,
+) (InstallOutcome, error) {
+	domain, err := guiDomain()
+	if err != nil {
+		return 0, err
+	}
+
+	outcome := InstallOutcomeInstalled
+
+	if loaded {
+		outcome = InstallOutcomeReplaced
+
+		err = s.launcher.bootout(ctx, domain+"/"+Label)
+		if err != nil {
+			return 0, derrors.Wrapf(
+				err,
+				derrors.CodeServiceFailed,
+				"unloading the previous service",
+			)
+		}
+	}
+
+	err = writePlist(path, content)
+	if err != nil {
+		return 0, err
+	}
+
+	err = s.launcher.bootstrap(ctx, domain, path)
+	if err != nil {
+		return 0, derrors.Wrapf(err, derrors.CodeServiceFailed, "loading service")
+	}
+
+	return outcome, nil
+}
+
+// installedPlist is what sits at mimi's plist path when an install starts.
+type installedPlist struct {
+	// path is where this was read from.
+	path string
+	// present reports whether there is anything at path at all.
+	present bool
+	// regular reports whether what is there is a plain file. It is a weaker
+	// claim than "mimi wrote it" and deliberately so: a symlink is
+	// home-manager's link into the Nix store, and that is the shape mimi can
+	// actually tell apart. Anything else at mimi's own path is treated as
+	// mimi's to replace.
+	regular bool
+	// content is the file's current bytes, empty unless regular.
+	content string
+}
+
+// readInstalledPlist describes what is at path without changing it. A path
+// with nothing at it is not an error: that is the first install.
+func readInstalledPlist(path string) (installedPlist, error) {
+	// Lstat, not Stat: a symlink must be seen as a symlink rather than as
+	// whatever it points at.
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return installedPlist{path: path}, nil
+		}
+
+		return installedPlist{}, derrors.Wrapf(err, derrors.CodeServiceFailed, "inspecting plist")
+	}
+
+	if !info.Mode().IsRegular() {
+		return installedPlist{path: path, present: true}, nil
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return installedPlist{}, derrors.Wrapf(err, derrors.CodeServiceFailed, "reading plist")
+	}
+
+	return installedPlist{path: path, present: true, regular: true, content: string(content)}, nil
+}
+
+// refuseForeign reports the two shapes that mean this label belongs to an
+// installer other than mimi: something at mimi's plist path that mimi could
+// not have written, and a loaded service with no plist of mimi's behind it.
+// Overwriting either would fight whatever manages it, and lose on the next
+// rebuild.
+func (p installedPlist) refuseForeign(loaded bool) error {
+	if p.present && !p.regular {
+		return derrors.Newf(
+			derrors.CodeServiceFailed,
+			"%s is not a file mimi wrote; %s",
+			p.path,
+			foreignInstallAdvice,
+		)
+	}
+
+	if loaded && !p.present {
+		return derrors.Newf(
+			derrors.CodeServiceFailed,
+			"service is already loaded but mimi did not install it; %s",
+			foreignInstallAdvice,
+		)
+	}
+
+	return nil
+}
+
+// matches reports whether the plist on disk already is the bytes rendered for
+// this install, which is what makes a re-run a no-op.
+func (p installedPlist) matches(content string) bool {
+	return p.present && p.content == content
+}
+
+// writePlist puts content at path by writing a temporary file in the same
+// directory and renaming it over the target. Rename within a directory
+// replaces the name in one step, so an install interrupted at any point
+// leaves either the old plist or the new one — never a truncated file for
+// launchd to reject on the next login.
+func writePlist(path, content string) error {
+	dir := filepath.Dir(path)
+
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "creating plist")
+	}
+
+	tmpPath := tmpFile.Name()
+
+	_, err = tmpFile.WriteString(content)
+	if err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "writing plist")
+	}
+
+	err = tmpFile.Close()
+	if err != nil {
+		_ = os.Remove(tmpPath)
+
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "closing plist")
+	}
+
+	// CreateTemp makes the file 0600, which is not the mode a LaunchAgents
+	// plist has ever had here.
+	err = os.Chmod(tmpPath, filePerm)
+	if err != nil {
+		_ = os.Remove(tmpPath)
+
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "setting plist permissions")
+	}
+
+	err = os.Rename(tmpPath, path)
+	if err != nil {
+		_ = os.Remove(tmpPath)
+
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "replacing plist")
+	}
+
+	return nil
+}
+
+// plistPath is where mimi's own plist lives, expanded. Install and Uninstall
+// have to name the same file, so neither builds the path itself.
+func plistPath() string {
+	return filepath.Join(paths.ExpandHome(launchAgentsDir), Label+".plist")
+}
+
+// guiDomain is the launchd domain a per-user agent belongs to, for the user
+// running mimi. Every launchctl target mimi names is built from it.
+func guiDomain() (string, error) {
+	currentUser, err := user.Current()
+	if err != nil {
+		return "", derrors.Wrapf(err, derrors.CodeServiceFailed, "getting current user")
+	}
+
+	return "gui/" + currentUser.Uid, nil
 }
 
 // binaryPath resolves the real, symlink-free path to the running mimi

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -11,11 +11,22 @@ import (
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
 
+// testConfigPath is the config path the install tests hand the plist
+// renderer. Only its presence in the rendered bytes matters, so every test
+// that does not vary it uses this one.
+const testConfigPath = "/Users/test/.config/mimi/config.toml"
+
 // fakeLauncher is a launcher made of plain values: every call it sees lands
 // in a field a test can assert against, and every call it returns is a field
 // a test can set up in advance.
 type fakeLauncher struct {
 	loaded bool
+
+	// calls names the state-changing launchctl calls in the order they
+	// arrived, for the tests where "which, and in what order" is the
+	// behavior under test. The read-only list is deliberately absent: it
+	// changes nothing, so a caller making it is not an observable effect.
+	calls []string
 
 	bootstrapErr error
 	bootstrapped bool
@@ -37,24 +48,28 @@ func (f *fakeLauncher) list(_ context.Context, _ string) error {
 
 func (f *fakeLauncher) bootstrap(_ context.Context, _, _ string) error {
 	f.bootstrapped = true
+	f.calls = append(f.calls, "bootstrap")
 
 	return f.bootstrapErr
 }
 
 func (f *fakeLauncher) bootout(_ context.Context, _ string) error {
 	f.booted = true
+	f.calls = append(f.calls, "bootout")
 
 	return f.bootoutErr
 }
 
 func (f *fakeLauncher) start(_ context.Context, _ string) error {
 	f.started = true
+	f.calls = append(f.calls, "start")
 
 	return f.startErr
 }
 
 func (f *fakeLauncher) stop(_ context.Context, _ string) error {
 	f.stopped = true
+	f.calls = append(f.calls, "stop")
 
 	return f.stopErr
 }
@@ -166,9 +181,13 @@ func TestService_Install_WritesThePlistAndBootstraps(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := &Service{launcher: fake}
 
-	err := svc.Install("/Users/test/.config/mimi/config.toml", logFile)
+	outcome, err := svc.Install(testConfigPath, logFile)
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil", err)
+	}
+
+	if outcome != InstallOutcomeInstalled {
+		t.Errorf("Install() outcome = %v, want %v", outcome, InstallOutcomeInstalled)
 	}
 
 	if !fake.bootstrapped {
@@ -208,17 +227,119 @@ func TestService_Install_WritesThePlistAndBootstraps(t *testing.T) {
 	}
 }
 
-func TestService_Install_FailsWhenAlreadyLoaded(t *testing.T) {
+// TestService_Install_IsANoOpWhenTheLoadedServiceAlreadyMatches pins the
+// promise that makes install safe to run at any time: with the service loaded
+// and its plist already the bytes mimi would render, nothing is torn down and
+// nothing is loaded again.
+func TestService_Install_IsANoOpWhenTheLoadedServiceAlreadyMatches(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	logFile := filepath.Join(dir, "state", "mimi", "mimi.log")
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	_, err := svc.Install(testConfigPath, logFile)
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	// The service that install just loaded, asked to install again with the
+	// same config.
+	fake.loaded = true
+	fake.calls = nil
+
+	outcome, err := svc.Install(testConfigPath, logFile)
+	if err != nil {
+		t.Fatalf("second Install() = %v, want nil", err)
+	}
+
+	if outcome != InstallOutcomeUnchanged {
+		t.Errorf("second Install() outcome = %v, want %v", outcome, InstallOutcomeUnchanged)
+	}
+
+	if len(fake.calls) != 0 {
+		t.Errorf("second Install() drove launchctl: %v, want no calls", fake.calls)
+	}
+}
+
+// TestService_Install_ReplacesAStalePlistAndReloadsTheService is the bug this
+// idempotence exists for: the plist bakes in settings.log_file's derived
+// capture paths, so a service installed before log_file moved keeps writing
+// its console output to the old place until the plist is replaced. launchd
+// holds the plist it was bootstrapped with, so replacing the file alone
+// changes nothing — the service has to be booted out and bootstrapped again.
+func TestService_Install_ReplacesAStalePlistAndReloadsTheService(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	oldLogFile := filepath.Join(dir, "old", "mimi.log")
+	newLogFile := filepath.Join(dir, "new", "mimi.log")
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	_, err := svc.Install(testConfigPath, oldLogFile)
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	// The service install just loaded, with settings.log_file moved since.
+	fake.loaded = true
+	fake.calls = nil
+
+	outcome, err := svc.Install(testConfigPath, newLogFile)
+	if err != nil {
+		t.Fatalf("second Install() = %v, want nil", err)
+	}
+
+	if outcome != InstallOutcomeReplaced {
+		t.Errorf("second Install() outcome = %v, want %v", outcome, InstallOutcomeReplaced)
+	}
+
+	// Booted out first: bootstrapping over a loaded job is what makes
+	// launchd re-read the plist, and it cannot while the old one is loaded.
+	if got := strings.Join(fake.calls, ","); got != "bootout,bootstrap" {
+		t.Errorf("second Install() calls = %v, want [bootout bootstrap]", fake.calls)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "Library", "LaunchAgents", Label+".plist"))
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	if !strings.Contains(string(content), filepath.Join(dir, "new", "mimi.out.log")) {
+		t.Errorf("installed plist does not carry the new capture path:\n%s", content)
+	}
+
+	if strings.Contains(string(content), filepath.Join(dir, "old", "mimi.out.log")) {
+		t.Errorf("installed plist still carries the old capture path:\n%s", content)
+	}
+
+	// The plist points at the new directory, so that directory has to exist
+	// before launchd spawns the daemon against it.
+	info, err := os.Stat(filepath.Join(dir, "new"))
+	if err != nil {
+		t.Fatalf("Install() did not create the new captured-stream directory: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Error("the new captured-stream path is not a directory")
+	}
+}
+
+// TestService_Install_FailsWhenLoadedByAnotherInstaller pins the refusal that
+// survives idempotence: a loaded service with no plist of mimi's behind it is
+// nix-darwin's or home-manager's, and mimi must not adopt it.
+func TestService_Install_FailsWhenLoadedByAnotherInstaller(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
 	fake := &fakeLauncher{loaded: true}
 	svc := &Service{launcher: fake}
 
-	err := svc.Install(
-		"/Users/test/.config/mimi/config.toml",
-		filepath.Join(dir, "state", "mimi", "mimi.log"),
-	)
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"))
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}
@@ -227,12 +348,21 @@ func TestService_Install_FailsWhenAlreadyLoaded(t *testing.T) {
 		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
 	}
 
-	if fake.bootstrapped {
-		t.Error("Install() bootstrapped an already-loaded service")
+	for _, tool := range []string{"nix-darwin", "home-manager"} {
+		if !strings.Contains(err.Error(), tool) {
+			t.Errorf("Install() error %q does not name %s", err, tool)
+		}
+	}
+
+	if len(fake.calls) != 0 {
+		t.Errorf("Install() drove launchctl: %v, want no calls", fake.calls)
 	}
 }
 
-func TestService_Install_FailsWhenThePlistAlreadyExists(t *testing.T) {
+// TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote covers the plist
+// home-manager installs: a symlink into the Nix store. Replacing it would
+// break its link and lose to the next rebuild anyway.
+func TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
@@ -243,18 +373,24 @@ func TestService_Install_FailsWhenThePlistAlreadyExists(t *testing.T) {
 		t.Fatalf("creating LaunchAgents dir: %v", err)
 	}
 
-	err = os.WriteFile(filepath.Join(agentsDir, Label+".plist"), []byte("existing"), 0o644)
+	storePlist := filepath.Join(dir, "nix-store-mimi.plist")
+
+	err = os.WriteFile(storePlist, []byte("someone else's plist"), 0o644)
 	if err != nil {
-		t.Fatalf("seeding existing plist: %v", err)
+		t.Fatalf("seeding store plist: %v", err)
+	}
+
+	plistPath := filepath.Join(agentsDir, Label+".plist")
+
+	err = os.Symlink(storePlist, plistPath)
+	if err != nil {
+		t.Fatalf("seeding plist symlink: %v", err)
 	}
 
 	fake := &fakeLauncher{}
 	svc := &Service{launcher: fake}
 
-	err = svc.Install(
-		"/Users/test/.config/mimi/config.toml",
-		filepath.Join(dir, "state", "mimi", "mimi.log"),
-	)
+	_, err = svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"))
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}
@@ -263,8 +399,263 @@ func TestService_Install_FailsWhenThePlistAlreadyExists(t *testing.T) {
 		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
 	}
 
-	if fake.bootstrapped {
-		t.Error("Install() bootstrapped despite a pre-existing plist")
+	for _, tool := range []string{"nix-darwin", "home-manager"} {
+		if !strings.Contains(err.Error(), tool) {
+			t.Errorf("Install() error %q does not name %s", err, tool)
+		}
+	}
+
+	if len(fake.calls) != 0 {
+		t.Errorf("Install() drove launchctl: %v, want no calls", fake.calls)
+	}
+
+	// The symlink is still a symlink, still pointing where it did.
+	info, err := os.Lstat(plistPath)
+	if err != nil {
+		t.Fatalf("Install() removed the foreign plist: %v", err)
+	}
+
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("Install() replaced the foreign plist symlink with a file")
+	}
+}
+
+// TestService_Install_LoadsAPlistLeftBehindByAPreviousInstall covers the
+// half-installed machine: an uninstall that removed nothing, or a service
+// booted out by hand. The plist is rewritten from the current config and
+// bootstrapped, rather than the install refusing because a file is in the way.
+func TestService_Install_LoadsAPlistLeftBehindByAPreviousInstall(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	agentsDir := filepath.Join(dir, "Library", "LaunchAgents")
+
+	err := os.MkdirAll(agentsDir, 0o755)
+	if err != nil {
+		t.Fatalf("creating LaunchAgents dir: %v", err)
+	}
+
+	plistPath := filepath.Join(agentsDir, Label+".plist")
+
+	err = os.WriteFile(plistPath, []byte("a stale plist"), 0o644)
+	if err != nil {
+		t.Fatalf("seeding existing plist: %v", err)
+	}
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	outcome, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"))
+	if err != nil {
+		t.Fatalf("Install() = %v, want nil", err)
+	}
+
+	if outcome != InstallOutcomeInstalled {
+		t.Errorf("Install() outcome = %v, want %v", outcome, InstallOutcomeInstalled)
+	}
+
+	// Nothing was loaded, so there was nothing to boot out.
+	if diff := strings.Join(fake.calls, ","); diff != "bootstrap" {
+		t.Errorf("Install() calls = %v, want [bootstrap]", fake.calls)
+	}
+
+	content, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	if !strings.Contains(string(content), testConfigPath) {
+		t.Errorf("Install() left the stale plist in place:\n%s", content)
+	}
+}
+
+// TestService_Install_NeverLeavesAPartialPlist pins the atomic replace. The
+// plist goes to a temporary file in the same directory and is renamed over the
+// target, so a replace that fails leaves the previous plist whole and readable
+// — launchd loads it at every login, and a truncated one is a service that
+// stops coming back. The temporary file is not litter left in LaunchAgents
+// either way.
+func TestService_Install_NeverLeavesAPartialPlist(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the directory permissions this test denies writes with")
+	}
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"))
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	agentsDir := filepath.Join(dir, "Library", "LaunchAgents")
+	plistPath := filepath.Join(agentsDir, Label+".plist")
+
+	installed, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	assertOnlyThePlist(t, agentsDir)
+
+	// A LaunchAgents directory no new file can be created in — the shape any
+	// interruption of the replace takes, seen from the target file.
+	err = os.Chmod(agentsDir, 0o555)
+	if err != nil {
+		t.Fatalf("making LaunchAgents read-only: %v", err)
+	}
+
+	t.Cleanup(func() { _ = os.Chmod(agentsDir, 0o755) })
+
+	fake.loaded = true
+
+	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"))
+	if err == nil {
+		t.Fatal("second Install() = nil, want an error")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf(
+			"second Install() code = %v, want %v",
+			derrors.GetCode(err),
+			derrors.CodeServiceFailed,
+		)
+	}
+
+	after, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading the plist after the failed replace: %v", err)
+	}
+
+	if string(after) != string(installed) {
+		t.Errorf(
+			"a failed replace changed the installed plist:\ngot\n%s\nwant\n%s",
+			after,
+			installed,
+		)
+	}
+
+	assertOnlyThePlist(t, agentsDir)
+}
+
+// TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded pins
+// the order of the replace. Writing the plist before unloading the service
+// would leave, on a failed unload, a new plist on disk in front of a service
+// still running the old one — and every later install would find the file it
+// wanted and report the service up to date, forever. That is the exact
+// "stale plist believed current" failure idempotence exists to remove, so the
+// failed install has to leave the old plist behind for the next one to find.
+func TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"))
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	plistPath := filepath.Join(dir, "Library", "LaunchAgents", Label+".plist")
+
+	stale, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	fake.loaded = true
+	fake.bootoutErr = derrors.New(derrors.CodeServiceFailed, "launchd said no")
+	fake.calls = nil
+
+	newLogFile := filepath.Join(dir, "new", "mimi.log")
+
+	_, err = svc.Install(testConfigPath, newLogFile)
+	if err == nil {
+		t.Fatal("Install() = nil, want the unload failure")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	// Nothing was written, so nothing was bootstrapped over the old service.
+	if got := strings.Join(fake.calls, ","); got != "bootout" {
+		t.Errorf("Install() calls = %v, want [bootout]", fake.calls)
+	}
+
+	after, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading the plist after the failed unload: %v", err)
+	}
+
+	if string(after) != string(stale) {
+		t.Errorf("a failed unload replaced the plist:\ngot\n%s\nwant\n%s", after, stale)
+	}
+
+	// The next install still sees the disagreement, rather than a plist that
+	// already matches in front of a service that never got it.
+	fake.bootoutErr = nil
+	fake.calls = nil
+
+	outcome, err := svc.Install(testConfigPath, newLogFile)
+	if err != nil {
+		t.Fatalf("retried Install() = %v, want nil", err)
+	}
+
+	if outcome != InstallOutcomeReplaced {
+		t.Errorf("retried Install() outcome = %v, want %v", outcome, InstallOutcomeReplaced)
+	}
+}
+
+// TestService_Install_DoesNotUseTheSystemTempDirectory pins the "same
+// directory" half of the atomic write. A temporary file anywhere else risks a
+// rename across filesystems, which is not atomic and can fail outright — and
+// a TMPDIR that does not exist is how a test can tell the two apart.
+func TestService_Install_DoesNotUseTheSystemTempDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("TMPDIR", filepath.Join(dir, "no-such-temp-dir"))
+
+	fake := &fakeLauncher{}
+	svc := &Service{launcher: fake}
+
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"))
+	if err != nil {
+		t.Fatalf("Install() = %v, want nil (the plist never goes via TMPDIR)", err)
+	}
+
+	agentsDir := filepath.Join(dir, "Library", "LaunchAgents")
+
+	_, err = os.Stat(filepath.Join(agentsDir, Label+".plist"))
+	if err != nil {
+		t.Fatalf("Install() wrote no plist: %v", err)
+	}
+
+	assertOnlyThePlist(t, agentsDir)
+}
+
+// assertOnlyThePlist fails unless dir holds mimi's plist and nothing else, so
+// that a temporary file left behind by the atomic write is caught wherever it
+// is checked.
+func assertOnlyThePlist(t *testing.T, dir string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading LaunchAgents: %v", err)
+	}
+
+	if len(entries) != 1 || entries[0].Name() != Label+".plist" {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+
+		t.Errorf("LaunchAgents holds %v, want only %s", names, Label+".plist")
 	}
 }
 
@@ -286,10 +677,7 @@ func TestService_Install_FailsWhenTheCapturedStreamDirectoryCannotBeCreated(t *t
 	fake := &fakeLauncher{}
 	svc := &Service{launcher: fake}
 
-	err = svc.Install(
-		"/Users/test/.config/mimi/config.toml",
-		filepath.Join(blocker, "mimi", "mimi.log"),
-	)
+	_, err = svc.Install(testConfigPath, filepath.Join(blocker, "mimi", "mimi.log"))
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}


### PR DESCRIPTION
## Description

This PR fixes an installed service quietly disagreeing with the config that describes it. The launchd plist is a snapshot taken at install time — it bakes in the config path and the stdout/stderr capture paths derived from `settings.log_file` — so changing `log_file` afterwards left the running service writing its console output to the old place, with no command that fixed it. Installing again refused twice over: once because the service was loaded, once because the plist already existed. The only recovery was `mimi services uninstall && mimi services install`, which nobody had a reason to know they needed.

Running `mimi services install` again is now how an installed service is brought back in line with the config, and running it when nothing has changed is harmless. It compares the plist on disk against the bytes it would render: identical means it reports the service is already up to date and touches nothing at all; different means it unloads the service, replaces the plist, and loads it again so launchd re-reads it. The plist is written to a temporary file beside the target and renamed over it, so an interrupted install can never leave a truncated plist for launchd to reject at the next login.

A service mimi did not install is still refused rather than adopted, and both refusals name nix-darwin and home-manager. The deliberate limitation is how "mimi did not install it" is decided: a symlink at `~/Library/LaunchAgents/com.y3owk1n.mimi.plist` — the shape home-manager installs — and a loaded `com.y3owk1n.mimi` with no plist of mimi's behind it. A plain file at mimi's own path under mimi's own label is treated as mimi's to replace, because that is what an earlier `mimi services install` leaves.

## Command output changes

`mimi services install` is the only command touched. Its exit code is unchanged (0 on success, including the no-op), but it now prints one of three lines instead of always the first:

| Output                                       | What happened                                                                  |
| -------------------------------------------- | ------------------------------------------------------------------------------ |
| `Service installed and loaded successfully`  | The service was not loaded; the plist was written and the service loaded.       |
| `Service plist updated and service reloaded` | The plist disagreed with the config; it was replaced and the service reloaded.  |
| `Service already up to date`                 | The installed plist already matched. Nothing was written and nothing reloaded.  |

No config keys, flags, subcommands, or `mimi_*` hook variables change.

## Potentially breaking

Nothing a user writes changes, but two behaviours a script could depend on do:

- **`mimi services install` no longer exits non-zero when the service is already installed.** A script that relied on that failure to detect "already installed" now sees a success and one of the two new lines. There is no migration — `mimi services status` is the check that was always meant for this.
- **The success line is no longer a fixed string.** Anything matching on `Service installed and loaded successfully` should match on the exit code instead, or accept all three lines above.

The refusal for a foreign install is narrower than it was: previously *any* loaded `com.y3owk1n.mimi` was refused, and now one backed by a plain file at mimi's own plist path is replaced. That narrowing is the point of the change, and the repo's own Nix modules are unaffected — `nix/darwin.nix` and `nix/home.nix` install under `org.nixos.mimi` and `org.nix-community.home.mimi`, not under mimi's label, so neither was ever reached by this check.

## Related Issues

Closes #152

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

— N/A, the change is to a CLI line and to what is written to disk; the three output lines are tabled above.

## Additional Context

**The unload happens before the write, not after.** The other order looks equivalent and is not: a bootout that failed after the write would leave the new plist on disk in front of a service still running the old one, and every later install would find the file it wanted and report the service up to date — permanently, and silently, which is exactly the failure this PR exists to remove. Unloading first means a failure leaves the old plist untouched, so the next install sees the same disagreement and retries it. There is a test that fails if the two are swapped.

**What the tests pin.** The replace, the no-op, and both refusals go through the existing launcher fake; `renderPlist` stays pure and keeps its table tests. Three of the new tests were checked against a deliberately broken implementation to confirm they discriminate rather than pass by construction: a truncate-in-place write, a temporary file in the system temp directory instead of beside the target, and the swapped unload/write order.

**Not covered:** the temporary file is not `fsync`ed before the rename, so the atomic-replace guarantee holds for an interrupted process but not for a power loss mid-install. `launchctl bootout` is also assumed to have completed when it returns; a job slow to exit could in principle make the following `bootstrap` fail, which surfaces as an error with the old plist already removed — recoverable by running install again.
