### PR TITLE
feat(service,cli): tell a running service apart from a merely loaded one

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/y3owk1n/mimi/internal/service"
@@ -31,7 +33,7 @@ Subcommands:
   start       Start the system service
   stop        Stop the system service
   restart     Restart the system service
-  status      Check whether the service is loaded and running`,
+  status      Check whether the service is loaded, and whether it is running`,
 	}
 
 	cmd.AddCommand(newServicesInstallCmd(state))
@@ -138,7 +140,7 @@ func newServicesStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Check the status of the system service",
-		Long:  "Check whether the Mimi launchd service is currently loaded and running. Displays whether the service is active.",
+		Long:  "Check whether the Mimi launchd service is currently loaded, and whether it is actually running.\n\nThe two are not the same: the installed plist sets KeepAlive, so a daemon that crashes at startup is relaunched every ten seconds and stays loaded the whole time. A running service reports the pid it runs under; a loaded one that is not running reports the status it last exited with — a repeated non-zero status there is a daemon in a crash loop, and the captured stderr beside settings.log_file says why.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.Println(formatStatus(defaultService.Status()))
 
@@ -166,13 +168,30 @@ func formatInstallOutcome(outcome service.InstallOutcome) string {
 	}
 }
 
-// formatStatus renders a service.Status the way the CLI has always printed
-// it, so nothing that scripts against the old string output sees a
-// difference now that Status is a typed result.
+// formatStatus renders a service.Status as the one line `mimi services status`
+// prints.
+//
+// Loaded and running are not the same thing, and that is the point of the
+// line: the installed plist sets KeepAlive, so a daemon that crashes at
+// startup is relaunched every ten seconds forever while staying exactly as
+// loaded as a healthy one. The pid says it is up; the exit status it left
+// behind says it is not. When launchd's description carries neither — it is
+// undocumented text and may change shape — this falls back to the two words
+// the command printed before it ever asked.
 func formatStatus(status service.Status) string {
-	if status.Loaded {
-		return "Service loaded"
+	if !status.Loaded {
+		return "Service not loaded"
 	}
 
-	return "Service not loaded"
+	switch {
+	case status.PID.Known:
+		return fmt.Sprintf("Service loaded and running (pid %d)", status.PID.Value)
+	case status.LastExitStatus.Known:
+		return fmt.Sprintf(
+			"Service loaded but not running (last exit status %d)",
+			status.LastExitStatus.Value,
+		)
+	default:
+		return "Service loaded"
+	}
 }

--- a/cmd/mimi/cmd/services_test.go
+++ b/cmd/mimi/cmd/services_test.go
@@ -98,13 +98,60 @@ func TestFormatInstallOutcome(t *testing.T) {
 	}
 }
 
+// TestFormatStatus pins the line each shape of a status prints. The wording is
+// the whole feature: the installed plist relaunches a crashing daemon forever,
+// so "loaded" said on its own is the answer that hides the failure this
+// command is run to find.
 func TestFormatStatus(t *testing.T) {
 	tests := []struct {
 		name   string
 		status service.Status
 		want   string
 	}{
-		{name: "loaded", status: service.Status{Loaded: true}, want: "Service loaded"},
+		{
+			name: "loaded and running",
+			status: service.Status{
+				Loaded: true,
+				PID:    service.OptionalInt{Value: 1478, Known: true},
+			},
+			want: "Service loaded and running (pid 1478)",
+		},
+		{
+			name: "loaded but respawning after a crash",
+			status: service.Status{
+				Loaded:         true,
+				LastExitStatus: service.OptionalInt{Value: 1, Known: true},
+			},
+			want: "Service loaded but not running (last exit status 1)",
+		},
+		{
+			// A clean exit is still not running, and launchd will bring it
+			// back: the number is what separates it from a crash.
+			name: "loaded, exited cleanly",
+			status: service.Status{
+				Loaded:         true,
+				LastExitStatus: service.OptionalInt{Value: 0, Known: true},
+			},
+			want: "Service loaded but not running (last exit status 0)",
+		},
+		{
+			// A job that is running now has a last exit status from before it
+			// was restarted. The pid is the fact worth printing.
+			name: "loaded and running, having exited before",
+			status: service.Status{
+				Loaded:         true,
+				PID:            service.OptionalInt{Value: 1478, Known: true},
+				LastExitStatus: service.OptionalInt{Value: 1, Known: true},
+			},
+			want: "Service loaded and running (pid 1478)",
+		},
+		{
+			// launchd's description could not be read, so the command falls
+			// back to everything it has ever said.
+			name:   "loaded, with nothing else known",
+			status: service.Status{Loaded: true},
+			want:   "Service loaded",
+		},
 		{name: "not loaded", status: service.Status{Loaded: false}, want: "Service not loaded"},
 	}
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -216,6 +216,24 @@ Remove the launchd agent.
 
 Control the launchd service directly.
 
+`status` separates a loaded service from a running one — the installed plist
+sets `KeepAlive`, so a daemon that crashes at startup is relaunched forever
+while staying loaded:
+
+```
+Service loaded and running (pid 1478)
+Service loaded but not running (last exit status 1)
+Service loaded
+Service not loaded
+```
+
+The bare `Service loaded` is the fallback, printed whenever neither number is
+available — the daemon has never run, it was killed by a signal rather than
+exiting, or launchd's description of the job could not be read. That
+description is undocumented text, so output mimi cannot parse costs the detail,
+never the answer. See
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md#reading-mimi-services-status).
+
 ---
 
 ## Configuration Management

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -71,6 +71,22 @@ launchctl list | grep mimi
 cat /tmp/mimi.err.log    # Nix module, or mimi services install with log_file unset
 ```
 
+### Reading `mimi services status`
+
+Loaded is not the same as running. The installed plist sets `KeepAlive` with a
+ten second `ThrottleInterval`, so a daemon that crashes at startup is
+relaunched forever and stays loaded the whole time.
+
+| Line                                                  | What it means                                                                                                              |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `Service loaded and running (pid 1478)`               | Healthy: launchd has a live process for it.                                                                                 |
+| `Service loaded but not running (last exit status 1)` | launchd is respawning it. A non-zero status that stays put is a crash loop — the captured stderr below says why.             |
+| `Service loaded`                                      | Neither number was available: the daemon has never run, it was killed by a signal rather than exiting, or launchd's description of the job could not be read. That output is undocumented, so an unreadable one costs the detail, never the answer. |
+| `Service not loaded`                                  | No service installed, or it was unloaded.                                                                                   |
+
+`launchctl print gui/$(id -u)/com.y3owk1n.mimi` is the same description mimi
+reads, in full, when a bare `Service loaded` leaves a question open.
+
 ### Where a service-installed daemon's console output lands
 
 `mimi services install` writes a launchd plist that captures the daemon's

--- a/internal/service/launcher.go
+++ b/internal/service/launcher.go
@@ -12,6 +12,11 @@ type launcher interface {
 	// list reports whether label is currently loaded. Every caller here only
 	// cares whether it succeeded, so its stdout is never surfaced.
 	list(ctx context.Context, label string) error
+	// printJob runs `launchctl print` against target (e.g.
+	// "gui/501/com.y3owk1n.mimi") and returns what it said. Alone among these
+	// calls, its stdout is the reason for making it: that text is where a
+	// loaded job's pid and last exit status live.
+	printJob(ctx context.Context, target string) (string, error)
 	// bootstrap loads the plist at plistPath into domain (e.g. "gui/501").
 	bootstrap(ctx context.Context, domain, plistPath string) error
 	// bootout unloads target (e.g. "gui/501/com.y3owk1n.mimi").
@@ -27,6 +32,12 @@ type execLauncher struct{}
 
 func (execLauncher) list(ctx context.Context, label string) error {
 	return exec.CommandContext(ctx, "launchctl", "list", label).Run()
+}
+
+func (execLauncher) printJob(ctx context.Context, target string) (string, error) {
+	out, err := exec.CommandContext(ctx, "launchctl", "print", target).Output()
+
+	return string(out), err
 }
 
 func (execLauncher) bootstrap(ctx context.Context, domain, plistPath string) error {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -22,9 +22,23 @@ const foreignInstallAdvice = "check for existing installations (e.g., nix-darwin
 
 // Status is what checking the launchd service reports: a typed result a
 // caller can act on, in place of a formatted string only a human can read.
+//
+// Loaded is the only field always answered. The installed plist sets KeepAlive
+// with a ten second ThrottleInterval, so a daemon that crashes at startup is
+// relaunched forever and stays as loaded as a healthy one — the other two
+// fields are what tell them apart, and both are optional because launchd's own
+// description of the job is undocumented text that may not carry them.
 type Status struct {
 	// Loaded reports whether launchctl currently has the service loaded.
 	Loaded bool
+	// PID is the process id of the running daemon. It is unknown whenever the
+	// service is not loaded, is not currently running, or launchd's
+	// description could not be read.
+	PID OptionalInt
+	// LastExitStatus is how the daemon last exited. It is unknown before it
+	// ever has, when it was killed by a signal rather than exiting, and
+	// whenever launchd's description could not be read.
+	LastExitStatus OptionalInt
 }
 
 // InstallOutcome is what an [Service.Install] did. Install is idempotent, so
@@ -167,9 +181,37 @@ func (s *Service) Restart() error {
 	return s.Start()
 }
 
-// Status reports whether the service is currently loaded.
+// Status reports whether the service is currently loaded, and — when it is —
+// the pid it runs under or the status it last exited with.
+//
+// Only the loaded answer is guaranteed. Everything past it comes from
+// `launchctl print`, whose output Apple documents nowhere, so anything that
+// goes wrong there degrades to the answer this returned before it asked:
+// loaded, or not. A status command that fails tells a user less than one that
+// says a little less.
 func (s *Service) Status() Status {
-	return Status{Loaded: s.launcher.list(context.Background(), Label) == nil}
+	ctx := context.Background()
+
+	status := Status{Loaded: s.launcher.list(ctx, Label) == nil}
+	if !status.Loaded {
+		return status
+	}
+
+	domain, err := guiDomain()
+	if err != nil {
+		return status
+	}
+
+	output, err := s.launcher.printJob(ctx, domain+"/"+Label)
+	if err != nil {
+		return status
+	}
+
+	report := parseJobReport(output)
+	status.PID = report.pid
+	status.LastExitStatus = report.lastExitStatus
+
+	return status
 }
 
 // apply makes the installed service be content: it unloads whatever is

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -36,6 +36,12 @@ type fakeLauncher struct {
 	started      bool
 	stopErr      error
 	stopped      bool
+
+	// printOutput and printErr stand in for `launchctl print`, whose stdout —
+	// unlike every other call here — is the point of making it.
+	printOutput string
+	printErr    error
+	printedFor  string
 }
 
 func (f *fakeLauncher) list(_ context.Context, _ string) error {
@@ -44,6 +50,12 @@ func (f *fakeLauncher) list(_ context.Context, _ string) error {
 	}
 
 	return derrors.New(derrors.CodeServiceFailed, "not loaded")
+}
+
+func (f *fakeLauncher) printJob(_ context.Context, target string) (string, error) {
+	f.printedFor = target
+
+	return f.printOutput, f.printErr
 }
 
 func (f *fakeLauncher) bootstrap(_ context.Context, _, _ string) error {
@@ -74,23 +86,81 @@ func (f *fakeLauncher) stop(_ context.Context, _ string) error {
 	return f.stopErr
 }
 
+// TestService_Status_ReportsWhatTheLauncherSees covers the distinction the
+// status exists to make: a loaded service is not necessarily a running one.
+// The installed plist sets KeepAlive with a ten second ThrottleInterval, so a
+// daemon that crashes at startup stays loaded forever while never running, and
+// only the pid and the last exit status tell it apart from a healthy one.
 func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
 	tests := []struct {
-		name   string
-		loaded bool
-		want   Status
+		name        string
+		loaded      bool
+		printOutput string
+		printErr    error
+		want        Status
 	}{
-		{name: "loaded", loaded: true, want: Status{Loaded: true}},
-		{name: "not loaded", loaded: false, want: Status{Loaded: false}},
+		{
+			name:        "loaded and running",
+			loaded:      true,
+			printOutput: "\tstate = running\n\tpid = 1478\n\tlast exit code = (never exited)\n",
+			want:        Status{Loaded: true, PID: OptionalInt{Value: 1478, Known: true}},
+		},
+		{
+			name:        "loaded but respawning after a crash",
+			loaded:      true,
+			printOutput: "\tstate = spawn scheduled\n\tlast exit code = 1\n",
+			want:        Status{Loaded: true, LastExitStatus: OptionalInt{Value: 1, Known: true}},
+		},
+		{
+			// launchctl print is undocumented text with no promise behind it,
+			// so a shape this parser does not know must cost the command
+			// nothing beyond the detail it could not read.
+			name:        "loaded, with output nothing can be read from",
+			loaded:      true,
+			printOutput: "some future launchctl saying something else entirely",
+			want:        Status{Loaded: true},
+		},
+		{
+			name:     "loaded, with launchctl print failing outright",
+			loaded:   true,
+			printErr: derrors.New(derrors.CodeServiceFailed, "no such process"),
+			want:     Status{Loaded: true},
+		},
+		{
+			// Nothing to describe, so nothing is asked.
+			name:        "not loaded",
+			loaded:      false,
+			printOutput: "\tpid = 1478\n",
+			want:        Status{Loaded: false},
+		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			svc := &Service{launcher: &fakeLauncher{loaded: testCase.loaded}}
+			fake := &fakeLauncher{
+				loaded:      testCase.loaded,
+				printOutput: testCase.printOutput,
+				printErr:    testCase.printErr,
+			}
+			svc := &Service{launcher: fake}
 
 			got := svc.Status()
 			if got != testCase.want {
 				t.Errorf("Status() = %+v, want %+v", got, testCase.want)
+			}
+
+			if !testCase.loaded && fake.printedFor != "" {
+				t.Errorf("Status() described an unloaded service: %q", fake.printedFor)
+			}
+
+			// launchctl print takes a domain target, not the bare label a
+			// launchctl list takes.
+			if testCase.loaded && !strings.HasSuffix(fake.printedFor, "/"+Label) {
+				t.Errorf(
+					"Status() printed %q, want a domain target ending in /%s",
+					fake.printedFor,
+					Label,
+				)
 			}
 		})
 	}

--- a/internal/service/status.go
+++ b/internal/service/status.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"strconv"
+	"strings"
+)
+
+// OptionalInt is a number launchctl either reported or did not. Both numbers a
+// status carries need one: the pid is absent whenever the job is not running,
+// and an exit status cannot use zero as its "no value" — zero is a clean exit,
+// which is exactly the case a caller wants told apart from a crash.
+type OptionalInt struct {
+	// Value is the number launchctl reported. It means nothing unless Known.
+	Value int
+	// Known reports whether launchctl gave this number at all.
+	Known bool
+}
+
+// jobReport is what `launchctl print` says about a loaded job, reduced to the
+// two facts that separate a healthy daemon from one launchd keeps respawning.
+type jobReport struct {
+	// pid is the process id of the running job, unknown when it is not
+	// running.
+	pid OptionalInt
+	// lastExitStatus is how the job last exited, unknown before it ever has.
+	lastExitStatus OptionalInt
+}
+
+// parseJobReport reads pid and last exit status out of `launchctl print`
+// output.
+//
+// That output is semi-structured text Apple documents nowhere and promises
+// nothing about, so every line it does not recognize is skipped and an
+// unrecognizable report simply comes back with nothing known. A status that
+// says less is the intended failure: the command still answers whether the
+// service is loaded, which is all it ever answered before.
+func parseJobReport(output string) jobReport {
+	var (
+		report  jobReport
+		running bool
+	)
+
+	for line := range strings.SplitSeq(output, "\n") {
+		key, value, found := strings.Cut(strings.TrimSpace(line), " = ")
+		if !found {
+			continue
+		}
+
+		// The first occurrence a number could be read from wins. launchctl
+		// prints the job's own fields before the nested blocks (endpoints,
+		// coalitions) that could repeat a key with an unrelated meaning.
+		switch key {
+		case "state":
+			running = running || value == "running"
+		case "pid":
+			if !report.pid.Known {
+				report.pid = parseLeadingInt(value)
+			}
+		case "last exit code":
+			if !report.lastExitStatus.Known {
+				report.lastExitStatus = parseLeadingInt(value)
+			}
+		}
+	}
+
+	// launchd prints a last exit code for a running job too, where it is how
+	// the job exited the previous time round rather than a reason it is down.
+	// Only the pid distinguishes the two, so a job launchd calls running whose
+	// pid could not be read is output this could not parse — and reporting the
+	// exit status anyway would tell a user the daemon is down moments after
+	// launchd said it is up.
+	if running && !report.pid.Known {
+		report.lastExitStatus = OptionalInt{}
+	}
+
+	return report
+}
+
+// parseLeadingInt reads the number a launchctl value starts with. The value is
+// not always only a number: an exit status is printed as "78: EX_CONFIG" when
+// launchd has a name for it, and as "(never exited)" when there is no number
+// there at all.
+func parseLeadingInt(value string) OptionalInt {
+	number, _, _ := strings.Cut(value, ":")
+
+	parsed, err := strconv.Atoi(strings.TrimSpace(number))
+	if err != nil {
+		return OptionalInt{}
+	}
+
+	return OptionalInt{Value: parsed, Known: true}
+}

--- a/internal/service/status_test.go
+++ b/internal/service/status_test.go
@@ -1,0 +1,125 @@
+//nolint:testpackage // parseJobReport is unexported; the seam under test is intentionally internal.
+package service
+
+import "testing"
+
+// runningPrint is `launchctl print gui/501/com.y3owk1n.mimi` for a healthy
+// daemon, trimmed to the lines around the ones that are read. It is real
+// output, kept verbatim down to the tabs, because the parser's whole job is to
+// survive the shape launchctl actually prints.
+const runningPrint = `gui/501/com.y3owk1n.mimi = {
+	active count = 1
+	path = /Users/test/Library/LaunchAgents/com.y3owk1n.mimi.plist
+	type = LaunchAgent
+	state = running
+
+	program = /usr/local/bin/mimi
+	runs = 1
+	pid = 1478
+	immediate reason = speculative
+	last exit code = (never exited)
+}`
+
+// respawningPrint is the same command against the daemon this whole feature
+// exists for: one that crashes at startup and that KeepAlive schedules again
+// ten seconds later, forever. It is loaded, it has no pid, and the only thing
+// that says so is the exit status.
+const respawningPrint = `gui/501/com.y3owk1n.mimi = {
+	active count = 0
+	path = /Users/test/Library/LaunchAgents/com.y3owk1n.mimi.plist
+	type = LaunchAgent
+	state = spawn scheduled
+
+	program = /usr/local/bin/mimi
+	runs = 17169
+	last exit code = 1
+}`
+
+func TestParseJobReport(t *testing.T) {
+	tests := []struct {
+		name               string
+		output             string
+		wantPID            OptionalInt
+		wantLastExitStatus OptionalInt
+	}{
+		{
+			name:    "a running job reports its pid",
+			output:  runningPrint,
+			wantPID: OptionalInt{Value: 1478, Known: true},
+			// "(never exited)" is not a number, and pretending it is zero
+			// would report a clean exit that never happened.
+			wantLastExitStatus: OptionalInt{},
+		},
+		{
+			name:               "a respawning job reports how it last exited",
+			output:             respawningPrint,
+			wantLastExitStatus: OptionalInt{Value: 1, Known: true},
+		},
+		{
+			name:               "an exit status launchd has a name for keeps its number",
+			output:             "\tlast exit code = 78: EX_CONFIG\n",
+			wantLastExitStatus: OptionalInt{Value: 78, Known: true},
+		},
+		{
+			name:               "a clean exit is told apart from no exit at all",
+			output:             "\tlast exit code = 0\n",
+			wantLastExitStatus: OptionalInt{Value: 0, Known: true},
+		},
+		{
+			// launchd prints a name and no number when the job was killed by
+			// a signal rather than exiting.
+			name:   "an exit with a reason and no code reports neither",
+			output: "\tstate = not running\n\tlast exit reason = JETSAM_REASON_MEMORY_IDLE_EXIT\n",
+		},
+		{
+			name:   "output in a shape this parser does not know reports nothing",
+			output: "some future launchctl saying something else entirely",
+		},
+		{
+			// launchd prints a last exit code for a running job too — there it
+			// is how the job exited the previous time round, not a reason it
+			// is down. Only the pid says a job is up, so a job launchd calls
+			// running with no pid this could read is unreadable output, and
+			// reporting its exit status would assert it is down when launchd
+			// just said it is not.
+			name:   "a running job with an unreadable pid reports nothing",
+			output: "\tstate = running\n\tpid = ?\n\tlast exit code = 1\n",
+		},
+		{
+			name:               "a running job that exited before still reports its pid",
+			output:             "\tstate = running\n\tpid = 1478\n\tlast exit code = 1\n",
+			wantPID:            OptionalInt{Value: 1478, Known: true},
+			wantLastExitStatus: OptionalInt{Value: 1, Known: true},
+		},
+		{
+			name:   "empty output reports nothing",
+			output: "",
+		},
+		{
+			// The nested blocks launchctl prints after the job's own fields
+			// carry keys of their own; none may overwrite what was read.
+			name: "a nested block does not overwrite the job's own fields",
+			output: "\tpid = 1478\n\tpid-local endpoints = {\n" +
+				"\t\t\"com.apple.axserver\" = {\n\t\t\tpid = 99\n\t\t}\n\t}\n",
+			wantPID: OptionalInt{Value: 1478, Known: true},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := parseJobReport(testCase.output)
+
+			if got.pid != testCase.wantPID {
+				t.Errorf("parseJobReport() pid = %+v, want %+v", got.pid, testCase.wantPID)
+			}
+
+			if got.lastExitStatus != testCase.wantLastExitStatus {
+				t.Errorf(
+					"parseJobReport() lastExitStatus = %+v, want %+v",
+					got.lastExitStatus,
+					testCase.wantLastExitStatus,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR makes `mimi services status` tell a healthy daemon apart from one launchd keeps respawning. The installed plist sets `KeepAlive` with a ten second `ThrottleInterval`, so a daemon that crashes at startup is relaunched forever — and until now that printed `Service loaded`, the same two words as a healthy one. The command run to find a crash loop was the command that hid it.

Status now asks launchd to describe the job and reports the pid it is running under, or the status it last exited with when it is loaded but down. A service that is not loaded prints exactly what it printed before.

The deliberate limitation is that launchd's description of a job is undocumented text with no stability guarantee, so nothing here depends on it succeeding: an unreadable description costs the detail and never the answer, and the command falls back to the bare loaded / not-loaded line rather than failing. That fallback also covers the honest gaps — a daemon that has never run, or one killed by a signal rather than exiting, has neither number to report.

## Related Issues

Closes #153

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Command output changes

`mimi services status` is the only command whose output changes. Nothing else about the command changes — no new flags, no new subcommands, same exit code, same config keys.

| Situation                                     | Before             | After                                                 |
| --------------------------------------------- | ------------------ | ----------------------------------------------------- |
| Loaded and running                            | `Service loaded`     | `Service loaded and running (pid 1478)`                 |
| Loaded, respawning after a crash              | `Service loaded`     | `Service loaded but not running (last exit status 1)`   |
| Loaded, exited cleanly and awaiting respawn   | `Service loaded`     | `Service loaded but not running (last exit status 0)`   |
| Loaded, never run / killed by a signal        | `Service loaded`     | `Service loaded`                                        |
| Loaded, launchd's description unreadable      | `Service loaded`     | `Service loaded`                                        |
| Not loaded                                    | `Service not loaded` | `Service not loaded` (unchanged)                        |

The subcommand's `--help` text is expanded to explain the loaded/running distinction; `docs/CLI.md` and `docs/TROUBLESHOOTING.md` carry the same table.

## Potentially breaking

Anything matching the exact string `Service loaded` from this command's stdout now sees a longer line in the two cases that matter — a running service and a respawning one. A script that tested for `Service loaded` as "the daemon is fine" was already wrong (it was true of a crash loop too), but it did work; the same script now matches nothing in the healthy case. `Service not loaded` and the exit code are untouched, so a script testing for *absence* keeps working. A prefix match (`Service loaded*`) restores the old behaviour; matching on `and running` is the better test.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Only the not-loaded path could be run end to end here — this machine has no mimi service installed, and installing one to take a screenshot would leave a launchd agent behind:

```console
$ just build && ./bin/mimi services status
Service not loaded
```

The parsing is pinned against real `launchctl print` output taken from this machine rather than invented text. The shapes covered, verbatim:

```
	state = running          	state = spawn scheduled  	state = not running
	pid = 1478               	runs = 17169             	last exit reason = JETSAM_REASON_MEMORY_IDLE_EXIT
	last exit code = (never exited)	last exit code = 1
```

plus `last exit code = 78: EX_CONFIG`, which is how launchd prints a status it has a name for. Each is a table case in the tests, alongside empty output, unrecognisable output, and a launchctl invocation that fails outright.

## Additional Context

Three notes on the shape:

- The typed status carries the two numbers as optional values, never as preformatted strings, so every word of the printed line lives in the CLI beside the existing install-outcome formatting.
- Only the pid says a job is up. launchd prints a last exit code for a running job too — there it is how the job exited the *previous* time round — so the parser drops the exit status when launchd calls the job running but no pid could be read. Reporting it would assert the daemon is down moments after launchd said it is up, which is worse than saying less.
- The launchctl seam gained one method and is still the only thing in the package that shells out, so all of this is exercised through the existing launcher fake with no real launchctl underneath.

Follow-on work in #155, #157, #160 and #161 builds on this and is deliberately not here.
