### PR TITLE
fix(service,cli): fail services uninstall when a loaded service will not unload

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -68,7 +68,7 @@ func newServicesUninstallCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "uninstall",
 		Short: "Unload and remove the system service",
-		Long:  "Unload the Mimi launchd service and remove its plist file. Mimi will no longer start automatically on login.",
+		Long:  "Unload the Mimi launchd service and remove its plist file. Mimi will no longer start automatically on login.\n\nA service that is not loaded is uninstalled without complaint. When a loaded service cannot be unloaded, the plist is left in place and this fails, so the uninstall can be retried once whatever blocked the unload is fixed.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			err := defaultService.Uninstall()
 			if err != nil {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -212,6 +212,12 @@ their configuration.
 
 Remove the launchd agent.
 
+A service that is not loaded is uninstalled without complaint — there is
+nothing to unload, and the leftover plist is removed. When a loaded service
+cannot be unloaded, the plist is left in place and the command fails, because a
+service that keeps running until logout with no plist behind it is one nothing
+can uninstall any more. Fix what blocked the unload and run it again.
+
 ### `mimi services start` / `stop` / `restart` / `status`
 
 Control the launchd service directly.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -132,9 +132,16 @@ func (s *Service) Install(configPath, logFile string) (InstallOutcome, error) {
 	return s.apply(ctx, loaded, expandedPlist, plistContent)
 }
 
-// Uninstall unloads the service and removes its plist. A launchctl bootout
-// failure is not fatal — the service may already be unloaded, e.g. after a
-// prior partial uninstall — so it only removes the plist file.
+// Uninstall unloads the service and removes its plist.
+//
+// The bootout is attempted either way, but whether its failure matters is
+// decided before it runs. An unloaded service — after a prior partial
+// uninstall, say — has nothing to unload, and a bootout that fails at nothing
+// must not stand between the leftover plist and its removal. A loaded service
+// whose bootout failed is a different thing wearing the same error: it is
+// still running, and it keeps running until logout. Removing its plist there
+// would take away the only thing an uninstall can still act on, so the file
+// stays and the failure is returned for the caller to retry.
 func (s *Service) Uninstall() error {
 	ctx := context.Background()
 
@@ -143,7 +150,16 @@ func (s *Service) Uninstall() error {
 		return err
 	}
 
-	_ = s.launcher.bootout(ctx, domain+"/"+Label)
+	// Sampled before the bootout, so a service that unloads between the two
+	// makes this uninstall report a failure the retry will not see again.
+	// Sampling after would be worse: the bootout's own success is what empties
+	// it, so every unload would look like it had nothing to unload.
+	loaded := s.launcher.list(ctx, Label) == nil
+
+	err = s.launcher.bootout(ctx, domain+"/"+Label)
+	if err != nil && loaded {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "unloading service")
+	}
 
 	err = os.Remove(plistPath())
 	if err != nil && !os.IsNotExist(err) {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -222,20 +223,105 @@ func TestService_Restart_StopsThenStartsEvenWhenStopFails(t *testing.T) {
 	}
 }
 
-func TestService_Uninstall_BootsOutEvenWhenNotLoaded(t *testing.T) {
-	fake := &fakeLauncher{bootoutErr: derrors.New(derrors.CodeServiceFailed, "not loaded")}
-	svc := &Service{launcher: fake}
+// The two failures a launchctl bootout can come back with, as the plain stdlib
+// errors a real one hands back — exec returns an *exec.ExitError, never a
+// derrors. Plain is also the only kind a test can identify: derrors matches
+// errors.Is on the code alone, so a derrors sentinel would match any other
+// service failure just as happily and prove nothing.
+var (
+	errBootoutRefused  = errors.New("operation not permitted")
+	errBootoutNotFound = errors.New("not loaded")
+)
 
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-
-	err := svc.Uninstall()
-	if err != nil {
-		t.Fatalf("Uninstall() = %v, want nil (a bootout failure is not fatal)", err)
+// TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService pins
+// the difference [Service.Uninstall] draws between the two reasons a bootout
+// fails, which mean opposite things: see its doc comment. Every case expects
+// the bootout to have been attempted — what varies is whether its failure
+// counted.
+func TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService(t *testing.T) {
+	tests := []struct {
+		name       string
+		loaded     bool
+		bootoutErr error
+		wantErr    bool
+		wantPlist  bool
+	}{
+		{
+			name:       "not loaded, so a bootout that fails failed at nothing",
+			loaded:     false,
+			bootoutErr: errBootoutNotFound,
+			wantErr:    false,
+			wantPlist:  false,
+		},
+		{
+			name:       "loaded, and the bootout failed",
+			loaded:     true,
+			bootoutErr: errBootoutRefused,
+			wantErr:    true,
+			wantPlist:  true,
+		},
+		{
+			name:      "loaded, and the bootout succeeded",
+			loaded:    true,
+			wantErr:   false,
+			wantPlist: false,
+		},
 	}
 
-	if !fake.booted {
-		t.Error("Uninstall() did not call the launcher's bootout")
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+
+			path := filepath.Join(dir, "Library", "LaunchAgents", Label+".plist")
+
+			err := os.MkdirAll(filepath.Dir(path), dirPerm)
+			if err != nil {
+				t.Fatalf("creating LaunchAgents directory: %v", err)
+			}
+
+			err = os.WriteFile(path, []byte("installed"), filePerm)
+			if err != nil {
+				t.Fatalf("writing plist: %v", err)
+			}
+
+			fake := &fakeLauncher{loaded: testCase.loaded, bootoutErr: testCase.bootoutErr}
+			svc := &Service{launcher: fake}
+
+			err = svc.Uninstall()
+			if (err != nil) != testCase.wantErr {
+				t.Fatalf("Uninstall() = %v, wantErr %v", err, testCase.wantErr)
+			}
+
+			// The bootout is attempted whatever the list said. Only whether
+			// its failure counted is in question here.
+			if !fake.booted {
+				t.Error("Uninstall() did not call the launcher's bootout")
+			}
+
+			if err != nil {
+				if derrors.GetCode(err) != derrors.CodeServiceFailed {
+					t.Errorf(
+						"Uninstall() code = %v, want %v",
+						derrors.GetCode(err),
+						derrors.CodeServiceFailed,
+					)
+				}
+
+				if !errors.Is(err, errBootoutRefused) {
+					t.Errorf("Uninstall() = %v, want it to carry the bootout failure", err)
+				}
+			}
+
+			_, statErr := os.Stat(path)
+			if testCase.wantPlist && statErr != nil {
+				t.Errorf("Uninstall() removed the plist: %v", statErr)
+			}
+
+			if !testCase.wantPlist && !os.IsNotExist(statErr) {
+				t.Errorf("Uninstall() left the plist in place, stat = %v", statErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes `mimi services uninstall` quietly succeeding when it could not actually stop the service. Unloading the service was attempted and its result thrown away, so a real launchctl failure looked identical to there being nothing loaded to unload — and the plist was removed either way. The service kept running until logout, and the one file an uninstall could still act on had already been deleted.

Uninstall now checks whether the service is loaded before attempting the unload, reusing the same launchctl call install and status already make. Nothing changes for a service that is not loaded: it is still uninstalled without complaint, plist and all. A loaded service whose unload fails now leaves the plist in place and reports the failure, so the uninstall can be retried once the cause is fixed.

The loaded check is a sample taken just before the unload, so a service that unloads between the two reports a failure that a retry will not see again. Sampling after the unload would be worse — the unload's own success is what empties it, so every successful unload would then look like it had nothing to do.

## Related Issues

Closes #154

## Command surface

No commands, flags or config keys are added, removed or renamed. The behaviour of one existing command changes:

| `mimi services uninstall` | Before | After |
| --- | --- | --- |
| Service not loaded | `Service uninstalled successfully`, exit 0, plist removed | unchanged |
| Loaded, unload succeeds | `Service uninstalled successfully`, exit 0, plist removed | unchanged |
| Loaded, unload fails | `Service uninstalled successfully`, exit 0, plist removed, service still running | `Error: [SERVICE_FAILED] unloading service: <launchctl error>` on stderr, exit 1, plist kept |

The `--help` text for the subcommand gains a sentence describing that last case; generated man pages pick it up automatically.

## Potentially breaking

Only in that third row, and only where uninstall was already failing to do its job. A script that runs `mimi services uninstall` and checks the exit code can now see a non-zero exit where it previously always saw success. That is the point of the change — the old zero was reported over a service that was still running — but anything treating the command as infallible should be re-checked. There is no migration; re-running the uninstall after fixing what blocked the unload completes it.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

— N/A, the changed output is the one-line stderr message and exit code in the table above; reproducing it needs a launchctl unload that genuinely fails.

## Additional Context

Covered through the existing launcher fake, as a table over the three cases: not loaded with the unload failing, loaded with it failing, and loaded with it succeeding. Each asserts the error, whether the unload was attempted, and whether the plist is still on disk afterwards. The failure the fake returns is a plain stdlib error rather than a `derrors` one — that is what a real failed launchctl hands back, and it is also the only kind the test can pin, since `derrors` matches `errors.Is` on the code alone.

The unload itself is still attempted in every case, including when the service is not loaded; only whether its failure counts is now conditional. Deliberately untouched: install's own unload-then-bootstrap path (#160), and the discarded stop error in restart (#155).
