### PR TITLE
feat(config,service): let settings.service_path set the PATH the installed service runs with

### DIFF
--- a/cmd/mimi/cmd/runtime_paths.go
+++ b/cmd/mimi/cmd/runtime_paths.go
@@ -15,15 +15,20 @@ func (s *cliState) runtimePaths() (string, string) {
 	return config.DefaultPIDPath, config.DefaultSocketPath
 }
 
-// logFilePath returns the configured settings.log_file, already expanded by
-// the loader. It returns "" both when the setting is unset — it is optional —
-// and when the config cannot be read, which callers must treat the same way:
-// there is no log file to place anything beside.
-func (s *cliState) logFilePath() string {
+// plistSettings returns the config values `mimi services install` bakes into
+// the launchd plist: settings.log_file, already expanded by the loader, and
+// settings.service_path. Both are read from one load, so an install cannot
+// take two of them from two different reads of the file.
+//
+// Either is "" when the setting is unset — both are optional — and both are
+// when the config cannot be read, which callers must treat the same way: there
+// is no log file to place anything beside, and no configured PATH, so the
+// plist's own defaults stand.
+func (s *cliState) plistSettings() (string, string) {
 	cfg, err := config.Load(s.configPath)
 	if err != nil {
-		return ""
+		return "", ""
 	}
 
-	return cfg.Settings.LogFile
+	return cfg.Settings.LogFile, cfg.Settings.ServicePath
 }

--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -50,9 +50,11 @@ func newServicesInstallCmd(state *cliState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "install",
 		Short: "Install and load the system service",
-		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.\n\nThe plist is a snapshot of the config taken at install time, so run install again after changing a setting it bakes in — it replaces the plist and reloads the service, and does nothing at all when the plist already matches.\n\nReloading waits for the running service to unload before loading the new plist, for up to five seconds; a service still loaded after that fails the install with its old plist untouched. A load that fails for any other reason leaves the new plist in place, so running install again retries just the load.\n\nThe daemon's stdout and stderr are captured beside settings.log_file, as <name>.out.log and <name>.err.log, and that directory is created if missing. When log_file is unset — or is not an absolute path, which launchd cannot open — they fall back to /tmp/mimi.log and /tmp/mimi.err.log.",
+		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.\n\nThe plist is a snapshot of the config taken at install time, so run install again after changing a setting it bakes in — it replaces the plist and reloads the service, and does nothing at all when the plist already matches.\n\nReloading waits for the running service to unload before loading the new plist, for up to five seconds; a service still loaded after that fails the install with its old plist untouched. A load that fails for any other reason leaves the new plist in place, so running install again retries just the load.\n\nThe daemon's stdout and stderr are captured beside settings.log_file, as <name>.out.log and <name>.err.log, and that directory is created if missing. When log_file is unset — or is not an absolute path, which launchd cannot open — they fall back to /tmp/mimi.log and /tmp/mimi.err.log.\n\nThe PATH the installed service runs its hooks with comes from settings.service_path; unset, it is /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin. Nothing else reads that setting, so this command is what makes a change to it take effect.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			outcome, err := defaultService.Install(state.configPath, state.logFilePath())
+			logFile, servicePath := state.plistSettings()
+
+			outcome, err := defaultService.Install(state.configPath, logFile, servicePath)
 			if err != nil {
 				return err
 			}

--- a/cmd/mimi/cmd/services_test.go
+++ b/cmd/mimi/cmd/services_test.go
@@ -9,35 +9,42 @@ import (
 	"github.com/y3owk1n/mimi/internal/service"
 )
 
-// TestCLIState_LogFilePath covers what `mimi services install` hands the plist
-// renderer: the configured settings.log_file, and "" whenever there is none to
-// hand over — which decides whether the installed service captures stdout
-// beside the log file or in /tmp. See issue #99.
-func TestCLIState_LogFilePath(t *testing.T) {
+// TestCLIState_PlistSettings covers what `mimi services install` hands the
+// plist renderer: settings.log_file, which decides whether the installed
+// service captures stdout beside the log file or in /tmp (issue #99), and
+// settings.service_path, which is the PATH that service runs its hooks with
+// (issue #156). Either is "" whenever there is none to hand over, and both are
+// when the config cannot be read at all.
+func TestCLIState_PlistSettings(t *testing.T) {
 	tests := []struct {
 		name string
 		// body is the config to write; an empty body means write no config
 		// file at all, so config.Load fails.
-		body string
-		want string
+		body            string
+		wantLogFile     string
+		wantServicePath string
 	}{
 		{
-			name: "log_file set",
+			name: "both set",
 			body: fmt.Sprintf(
-				"[settings]\nlog_file = %q\n",
+				"[settings]\nlog_file = %q\nservice_path = %q\n",
 				"/Users/test/.local/state/mimi/mimi.log",
+				"/Users/test/.local/bin:/usr/bin",
 			),
-			want: "/Users/test/.local/state/mimi/mimi.log",
+			wantLogFile:     "/Users/test/.local/state/mimi/mimi.log",
+			wantServicePath: "/Users/test/.local/bin:/usr/bin",
 		},
 		{
-			name: "log_file unset",
-			body: "[settings]\nlog_level = \"debug\"\n",
-			want: "",
+			name:            "both unset",
+			body:            "[settings]\nlog_level = \"debug\"\n",
+			wantLogFile:     "",
+			wantServicePath: "",
 		},
 		{
-			name: "config unreadable",
-			body: "",
-			want: "",
+			name:            "config unreadable",
+			body:            "",
+			wantLogFile:     "",
+			wantServicePath: "",
 		},
 	}
 
@@ -49,8 +56,18 @@ func TestCLIState_LogFilePath(t *testing.T) {
 			}
 
 			state := &cliState{configPath: configPath}
-			if got := state.logFilePath(); got != testCase.want {
-				t.Errorf("logFilePath() = %q, want %q", got, testCase.want)
+
+			logFile, servicePath := state.plistSettings()
+			if logFile != testCase.wantLogFile {
+				t.Errorf("plistSettings() log file = %q, want %q", logFile, testCase.wantLogFile)
+			}
+
+			if servicePath != testCase.wantServicePath {
+				t.Errorf(
+					"plistSettings() service path = %q, want %q",
+					servicePath,
+					testCase.wantServicePath,
+				)
 			}
 		})
 	}

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -39,6 +39,17 @@ socket_file = "~/.local/share/mimi/mimi.sock"
 # Lower = more responsive, higher = fewer spurious fires during drag.
 resize_debounce_ms = 250
 
+# PATH the launchd-installed service runs with, and so the PATH every hook
+# inherits. A login shell's PATH never reaches a launchd agent, so set this if
+# a hook works from your terminal but does nothing under the installed service.
+# It replaces the default below entirely rather than adding to it, and takes
+# absolute directories only: "~" is not expanded here, and launchd would not
+# expand it either.
+#
+# Nothing else reads this: run `mimi services install` after changing it, which
+# re-renders the plist. A restart does not pick it up.
+# service_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
 [systray]
 enabled = true
 show_workspace_number = true

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -192,6 +192,11 @@ The generated plist captures the daemon's stdout and stderr beside
 `log_file` is unset. See
 [Troubleshooting](TROUBLESHOOTING.md#where-a-service-installed-daemons-console-output-lands).
 
+The `PATH` the service runs its hooks with comes from
+[`settings.service_path`](CONFIGURATION.md#service_path), defaulting to
+`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`. Nothing else reads that
+setting, so this command is what makes a change to it take effect.
+
 The plist is a snapshot of the config taken at install time, so running install
 again is how an installed service is brought back in line with a config that
 has moved since. It is idempotent and reports which of three things it did:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,17 +40,31 @@ mimi daemon start`, or equivalent):
 - `systray.enabled`
 - `systray.show_workspace_number`
 
-A reload that changes a restart-only setting still applies everything
-reloadable, and then logs a warning naming the settings that need the restart,
-for example:
+**Reinstall-only** — never read by the daemon at all. It is baked into the
+launchd plist by `mimi services install`, so the value in effect is the one in
+the installed plist, and only installing the service again replaces it. A
+restart does not:
+
+- `settings.service_path`
+
+A reload that changes a restart-only or reinstall-only setting still applies
+everything reloadable, and then logs a warning naming the settings it could not
+apply and what each of them needs, for example:
 
 ```text
 config reloaded; restart required for changed restart-only settings
   trigger=sighup restart_only=["settings.log_level","settings.max_hook_workers"]
 ```
 
+```text
+config reloaded; run `mimi services install` for changed reinstall-only settings
+  trigger=sighup reinstall_only=["settings.service_path"]
+```
+
+A reload that changes both logs both lines, in that order.
+
 A reload that changes only reloadable settings logs the plain
-`config reloaded` line, with no restart notice.
+`config reloaded` line, with neither notice.
 
 The comparison is against the config the daemon started with, not the previous
 edit, so the notice keeps appearing on every reload for as long as the file and
@@ -59,13 +73,16 @@ back.
 
 With `systray.enabled = true`, the menu shows the same outcome to someone who
 has no log in front of them: a disabled line under **Reload Config** reading
-`Reloaded 14:32`, `Reloaded 14:32 — restart required`, or
-`Reload failed 14:32`, and `No config reload yet` until the daemon has reloaded
-once. It reports the daemon's own reload, so every route above updates it, not
-just the menu item.
+`Reloaded 14:32`, `Reloaded 14:32 — restart required`,
+`Reloaded 14:32 — run mimi services install`, or `Reload failed 14:32`, and
+`No config reload yet` until the daemon has reloaded once. It reports the
+daemon's own reload, so every route above updates it, not just the menu item.
+The line shows one outcome, so a reload that needs both a restart and a
+reinstall shows the restart — the instruction that holds however the daemon
+was started — and the log names both.
 
-These two lists are not maintained by hand: each config field is classified on
-the type itself, and a test fails if this document and that classification
+These lists are not maintained by hand: each config field is classified on the
+type itself, and a test fails if this document and that classification
 disagree.
 
 ---
@@ -83,6 +100,7 @@ max_hook_workers = 4                         # restart-only
 pid_file = "~/.local/share/mimi/mimi.pid"    # restart-only
 socket_file = "~/.local/share/mimi/mimi.sock" # restart-only
 resize_debounce_ms = 250                     # on_window_resize debounce window
+service_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" # PATH for the installed service — reinstall-only
 ```
 
 `log_format` selects the **console** encoder only: `text` is the human-readable
@@ -111,6 +129,42 @@ daemon that hasn't picked up a changed `socket_file`, since it is
 restart-only) means actions silently execute directly instead of reaching the
 daemon. See [Troubleshooting](TROUBLESHOOTING.md#mimi-action-runs-but-seems-to-ignore-the-running-daemon)
 for how to tell which path an action actually took.
+
+### service_path
+
+`service_path` is the `PATH` `mimi services install` writes into the launchd
+plist, and therefore the `PATH` the installed daemon — and every hook it runs
+— inherits. Unset, it is
+`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`, which is what the plist has
+always hardcoded.
+
+Set it when a hook works from your shell but does nothing under the installed
+service. A login shell's `PATH` never reaches a launchd agent, so a hook
+calling something in `~/.local/bin`, a Nix profile, or a language version
+manager needs that directory listed here:
+
+```toml
+[settings]
+service_path = "/Users/me/.local/bin:/run/current-system/sw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+```
+
+It is the whole `PATH`, not an addition to one: what you write is what the
+service gets, so keep the directories you still need. Write absolute
+directories: unlike `log_file` and the other path settings, `~` is not expanded
+here, and launchd does not expand it either — a `~/.local/bin` entry is a
+directory the service will never find anything in.
+
+It is reinstall-only. The daemon never reads it — the value that matters is the
+one already in the installed plist — so run `mimi services install` after
+changing it. That re-renders the plist and reloads the service; a `mimi
+services restart`, or a plain daemon restart, keeps the old `PATH`. Running
+`mimi start` by hand ignores this setting entirely: that daemon inherits the
+`PATH` of whatever started it.
+
+If your service comes from the nix-darwin or home-manager module rather than
+from `mimi services install`, that module renders its own agent and this
+setting does not reach it — set `services.mimi.extraEnvironment.PATH` there
+instead.
 
 ### Debug logging
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -73,6 +73,30 @@ command uses.
 3. Set `log_level = "debug"` in config and check logs
 4. Window hooks require Accessibility; workspace hooks do not
 
+## A hook works by hand, but does nothing under the installed service
+
+The installed service does not inherit your login shell's `PATH` — launchd
+gives it the one baked into the plist, which is
+`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin` unless
+[`settings.service_path`](CONFIGURATION.md#service_path) says otherwise. A hook
+calling anything in `~/.local/bin`, a Nix profile, or a language version
+manager therefore runs from a terminal and fails from the service, usually
+with the daemon's captured stderr showing a "command not found".
+
+Set the whole `PATH` you need and install again — the setting is
+reinstall-only, so nothing shorter of that applies it:
+
+```toml
+[settings]
+service_path = "/Users/me/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+```
+
+```bash
+mimi services install
+```
+
+Or make the hook independent of `PATH` by calling absolute paths.
+
 ## Daemon won't start
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,9 +10,9 @@ import (
 
 // Config holds the full mimi configuration.
 //
-// The reload tags classify each part of the file as reloadable or
-// restart-only; see reloadability.go for what they mean and who reads them.
-// A section tagged per-field is classified one field at a time instead.
+// The reload tags classify each part of the file as reloadable, restart-only
+// or reinstall-only; see reloadability.go for what they mean and who reads
+// them. A section tagged per-field is classified one field at a time instead.
 type Config struct {
 	Settings SettingsConfig `json:"settings" reload:"per-field"  toml:"settings"`
 	Hooks    HooksConfig    `json:"hooks"    reload:"reloadable" toml:"hooks"`
@@ -33,16 +33,25 @@ type Config struct {
 // are opened once at startup, and the hook worker limit sizes a channel the
 // executor never resizes, so changing any of them takes a restart. The three
 // the reload path re-reads are tagged reloadable.
+//
+// ServicePath is read by nobody in the daemon at all. It is the PATH `mimi
+// services install` bakes into the launchd plist, so the value in effect is
+// the one on disk in the plist rather than the one in this struct, and only
+// installing the service again changes it — see
+// docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md. It is a
+// PATH rather than a path, so expandPaths leaves it alone: it is a list, and
+// launchd expands no "~" in it whatever mimi does.
 type SettingsConfig struct {
-	LogFile          string `json:"logFile"          reload:"restart-only" toml:"log_file"`
-	LogLevel         string `json:"logLevel"         reload:"restart-only" toml:"log_level"`
-	LogFormat        string `json:"logFormat"        reload:"restart-only" toml:"log_format"`
-	HookTimeoutSecs  int    `json:"hookTimeoutSecs"  reload:"reloadable"   toml:"hook_timeout_secs"`
-	HookShell        string `json:"hookShell"        reload:"reloadable"   toml:"hook_shell"`
-	MaxHookWorkers   int    `json:"maxHookWorkers"   reload:"restart-only" toml:"max_hook_workers"`
-	PIDFile          string `json:"pidFile"          reload:"restart-only" toml:"pid_file"`
-	SocketFile       string `json:"socketFile"       reload:"restart-only" toml:"socket_file"`
-	ResizeDebounceMS int    `json:"resizeDebounceMs" reload:"reloadable"   toml:"resize_debounce_ms"`
+	LogFile          string `json:"logFile"          reload:"restart-only"   toml:"log_file"`
+	LogLevel         string `json:"logLevel"         reload:"restart-only"   toml:"log_level"`
+	LogFormat        string `json:"logFormat"        reload:"restart-only"   toml:"log_format"`
+	HookTimeoutSecs  int    `json:"hookTimeoutSecs"  reload:"reloadable"     toml:"hook_timeout_secs"`
+	HookShell        string `json:"hookShell"        reload:"reloadable"     toml:"hook_shell"`
+	MaxHookWorkers   int    `json:"maxHookWorkers"   reload:"restart-only"   toml:"max_hook_workers"`
+	PIDFile          string `json:"pidFile"          reload:"restart-only"   toml:"pid_file"`
+	SocketFile       string `json:"socketFile"       reload:"restart-only"   toml:"socket_file"`
+	ResizeDebounceMS int    `json:"resizeDebounceMs" reload:"reloadable"     toml:"resize_debounce_ms"`
+	ServicePath      string `json:"servicePath"      reload:"reinstall-only" toml:"service_path"`
 }
 
 // SystrayConfig holds the [systray] section of the config.

--- a/internal/config/reload_docs_test.go
+++ b/internal/config/reload_docs_test.go
@@ -21,8 +21,9 @@ import (
 // reloadLabels maps the bold label that introduces each list in the Reloading
 // section of docs/CONFIGURATION.md onto the classification it documents.
 var reloadLabels = map[string]reloadability{
-	"Restart-only": restartOnly,
-	"Reloadable":   reloadable,
+	"Restart-only":   restartOnly,
+	"Reinstall-only": reinstallOnly,
+	"Reloadable":     reloadable,
 }
 
 var (

--- a/internal/config/reloadability.go
+++ b/internal/config/reloadability.go
@@ -7,8 +7,11 @@ import (
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
 
-// reloadability says whether changing a config field takes effect when a
-// running daemon reloads, or only once it is restarted.
+// reloadability says what a user has to do for a change to a config field to
+// take effect: nothing beyond the reload, a restart, or a reinstall of the
+// service. It is not only "when does the daemon pick this up", because a field
+// the daemon never reads has no answer to that
+// (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
 type reloadability string
 
 const (
@@ -19,6 +22,12 @@ const (
 	// startup and never again, so a change to it takes effect only after the
 	// daemon is restarted.
 	restartOnly reloadability = "restart-only"
+	// reinstallOnly marks a reinstall-only setting: the daemon never reads it,
+	// because it describes how the launchd service is set up rather than how
+	// the daemon behaves. `mimi services install` renders it into the plist, so
+	// a change to it takes effect only when the service is installed again —
+	// restarting the daemon runs it against the same plist.
+	reinstallOnly reloadability = "reinstall-only"
 )
 
 // reloadTagPerField is the reload tag a section carries when its fields are
@@ -37,10 +46,16 @@ const reloadTagPerField = "per-field"
 // being written, promising that log_format and max_hook_workers take effect
 // on reload when neither does.
 //
-// The tag records what the daemon's reload path re-reads. Widening that path
-// — teaching internal/daemon's reloader.Apply to re-read a field it ignores
-// today — means moving that field's tag to reloadable in the same change.
+// The tag records what a user must do for a change to the field to take
+// effect. Widening what the daemon's reload path re-reads — teaching
+// internal/daemon's reloader.Apply to re-read a field it ignores today —
+// means moving that field's tag to reloadable in the same change.
 const reloadTagKey = "reload"
+
+// reloadTagValues spells out every value reloadTagKey accepts, for the errors
+// an unclassified or misclassified field raises. It is one string so that the
+// two errors cannot list different sets.
+const reloadTagValues = `"reloadable", "restart-only", "reinstall-only", or "per-field"`
 
 // settingField is one classified part of the config file.
 type settingField struct {
@@ -104,8 +119,8 @@ func classifyFields(structType reflect.Type, prefix string, index []int) ([]sett
 		case !classified:
 			return nil, derrors.Newf(
 				derrors.CodeInternal,
-				"config field %q carries no %q tag: classify it as %q, %q, or %q",
-				key, reloadTagKey, reloadable, restartOnly, reloadTagPerField,
+				"config field %q carries no %q tag: classify it as %s",
+				key, reloadTagKey, reloadTagValues,
 			)
 		case tag == reloadTagPerField:
 			if field.Type.Kind() != reflect.Struct {
@@ -137,13 +152,13 @@ func classifyFields(structType reflect.Type, prefix string, index []int) ([]sett
 
 func parseReloadability(key, tag string) (reloadability, error) {
 	switch kind := reloadability(tag); kind {
-	case reloadable, restartOnly:
+	case reloadable, restartOnly, reinstallOnly:
 		return kind, nil
 	default:
 		return "", derrors.Newf(
 			derrors.CodeInternal,
-			"config field %q has %s tag %q: want %q, %q, or %q",
-			key, reloadTagKey, tag, reloadable, restartOnly, reloadTagPerField,
+			"config field %q has %s tag %q: want %s",
+			key, reloadTagKey, tag, reloadTagValues,
 		)
 	}
 }
@@ -158,6 +173,26 @@ func parseReloadability(key, tag string) (reloadability, error) {
 // in between. Changing log_level and then putting it back reports nothing,
 // because nothing is out of step any more.
 func RestartOnlyChanges(running, next *Config) []string {
+	return changedFields(running, next, restartOnly)
+}
+
+// ReinstallOnlyChanges names the reinstall-only settings whose values differ
+// between running and next, as dotted TOML keys in declaration order.
+//
+// These are the settings a restart would not pick up either: they are rendered
+// into the launchd plist by `mimi services install`, and the plist on disk is
+// what the service actually runs with. running is the same baseline
+// RestartOnlyChanges uses — the config this process started with — which is
+// the closest thing the daemon has to "what the installed service was built
+// from", since it cannot read the plist and would not know which install
+// produced it if it could.
+func ReinstallOnlyChanges(running, next *Config) []string {
+	return changedFields(running, next, reinstallOnly)
+}
+
+// changedFields names the settings of one classification whose values differ
+// between running and next, in declaration order.
+func changedFields(running, next *Config, kind reloadability) []string {
 	if running == nil || next == nil {
 		return nil
 	}
@@ -168,7 +203,7 @@ func RestartOnlyChanges(running, next *Config) []string {
 	var changed []string
 
 	for _, field := range settingFields {
-		if field.kind != restartOnly {
+		if field.kind != kind {
 			continue
 		}
 

--- a/internal/config/reloadability_test.go
+++ b/internal/config/reloadability_test.go
@@ -22,6 +22,7 @@ func runningConfig() *Config {
 			PIDFile:          "/tmp/mimi.pid",
 			SocketFile:       "/tmp/mimi.sock",
 			ResizeDebounceMS: 250,
+			ServicePath:      "/usr/bin:/bin",
 		},
 		Systray: SystrayConfig{Enabled: true, ShowWorkspaceNumber: true},
 	}
@@ -92,6 +93,35 @@ func TestClassifyFields_RejectsAnUnclassifiedField(t *testing.T) {
 	}
 }
 
+// TestClassifyFields_AcceptsEveryClassification is the other half of the guard
+// above: the tags a field may carry, pinned as a set so that adding a third
+// leaf classification means teaching the walk rather than working around it. A
+// field tagged reinstall-only must classify, not error
+// (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
+func TestClassifyFields_AcceptsEveryClassification(t *testing.T) {
+	t.Parallel()
+
+	fields, err := classifyFields(reflect.TypeOf(struct {
+		Reloads   string `reload:"reloadable"     toml:"reloads"`
+		Restarts  string `reload:"restart-only"   toml:"restarts"`
+		Reinstall string `reload:"reinstall-only" toml:"reinstall"`
+	}{}), "", nil)
+	if err != nil {
+		t.Fatalf("classifyFields() = %v, want nil", err)
+	}
+
+	want := []reloadability{reloadable, restartOnly, reinstallOnly}
+
+	got := make([]reloadability, 0, len(fields))
+	for _, field := range fields {
+		got = append(got, field.kind)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("classifyFields() classifications = %v, want %v", got, want)
+	}
+}
+
 func TestRestartOnlyChanges(t *testing.T) {
 	t.Parallel()
 
@@ -136,6 +166,14 @@ func TestRestartOnlyChanges(t *testing.T) {
 			want:   []string{"systray.show_workspace_number"},
 		},
 		{
+			// A reinstall-only setting is not restart-only: restarting the
+			// daemon runs it against the same plist, so reporting a restart
+			// here would be the wrong instruction, confidently given.
+			name:   "a reinstall-only setting needs no restart",
+			change: func(c *Config) { c.Settings.ServicePath = "/opt/homebrew/bin:/usr/bin" },
+			want:   nil,
+		},
+		{
 			name: "several restart-only changes are all named, in declaration order",
 			change: func(c *Config) {
 				c.Systray.Enabled = false
@@ -160,6 +198,54 @@ func TestRestartOnlyChanges(t *testing.T) {
 			got := RestartOnlyChanges(runningConfig(), next)
 			if !reflect.DeepEqual(got, testCase.want) {
 				t.Errorf("RestartOnlyChanges() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestReinstallOnlyChanges covers the classification the daemon never reads:
+// a change to one of these takes effect when the service is installed again,
+// so it is reported separately from the settings a restart would pick up.
+func TestReinstallOnlyChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		change func(*Config)
+		want   []string
+	}{
+		{
+			name:   "an unchanged config needs no reinstall",
+			change: func(*Config) {},
+			want:   nil,
+		},
+		{
+			name:   "a reloadable setting needs no reinstall",
+			change: func(c *Config) { c.Settings.HookShell = "/bin/bash" },
+			want:   nil,
+		},
+		{
+			name:   "a restart-only setting needs no reinstall",
+			change: func(c *Config) { c.Settings.LogLevel = "debug" },
+			want:   nil,
+		},
+		{
+			name:   "a changed service path is reinstall-only",
+			change: func(c *Config) { c.Settings.ServicePath = "/opt/homebrew/bin:/usr/bin" },
+			want:   []string{"settings.service_path"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			next := runningConfig()
+			testCase.change(next)
+
+			got := ReinstallOnlyChanges(runningConfig(), next)
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Errorf("ReinstallOnlyChanges() = %v, want %v", got, testCase.want)
 			}
 		})
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -271,13 +271,19 @@ const (
 	reloadTriggerSighup   reloadTrigger = "sighup"
 )
 
-// The three things a reload can report. They are constants so that the tests
+// The four things a reload can report. They are constants so that the tests
 // that pin which outcome a given config produces name the outcome rather than
 // repeating its wording.
+//
+// The reinstall line names the command, because that is the whole of what
+// distinguishes it: a restart does not apply a reinstall-only setting, so
+// saying "restart required" here would be a specific, confident, wrong
+// instruction (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
 const (
-	reloadFailedMessage          = "config reload failed"
-	reloadedMessage              = "config reloaded"
-	reloadRestartRequiredMessage = "config reloaded; restart required for changed restart-only settings"
+	reloadFailedMessage            = "config reload failed"
+	reloadedMessage                = "config reloaded"
+	reloadRestartRequiredMessage   = "config reloaded; restart required for changed restart-only settings"
+	reloadReinstallRequiredMessage = "config reloaded; run `mimi services install` for changed reinstall-only settings"
 )
 
 // reloadConfig loads the config at configPath, applies it, and logs the
@@ -287,10 +293,12 @@ const (
 // naming the trigger that noticed — previously the watcher logged parse
 // failures itself, without a trigger, while apply failures were logged here.
 //
-// A reload that changes a restart-only setting is not a plain success: the
-// daemon has applied everything it can and is still running the old value for
-// the rest, so it says so and names them. The names are mimi's own; the
-// values the user gave them stay out of the log.
+// A reload that changes a setting it cannot apply is not a plain success: the
+// daemon has applied everything it can and the rest keeps its old value, so it
+// says so and names those settings — one line per thing the user would have to
+// do, since a restart and a reinstall are different actions and a config can
+// ask for both at once. The names are mimi's own; the values the user gave
+// them stay out of the log.
 // The outcome also goes to reportReload, which is how a surface with no log in front
 // of it — the systray menu — can show what the last reload did. It travels one
 // way and carries the outcome alone: reporting is the daemon telling, never a
@@ -305,10 +313,10 @@ func reloadConfig(
 ) {
 	newCfg, err := config.Load(configPath)
 
-	var restartOnly []string
+	var changes reloadChanges
 
 	if err == nil {
-		restartOnly, err = cfgReloader.Apply(newCfg)
+		changes, err = cfgReloader.Apply(newCfg)
 	}
 
 	if err != nil {
@@ -320,19 +328,46 @@ func reloadConfig(
 
 	warnUnknownHookKeys(newCfg, logger)
 
-	if len(restartOnly) > 0 {
+	if changes.empty() {
+		logger.Infow(reloadedMessage, "trigger", trigger)
+	}
+
+	if len(changes.restartOnly) > 0 {
 		logger.Warnw(
 			reloadRestartRequiredMessage,
 			"trigger", trigger,
-			"restart_only", restartOnly,
+			"restart_only", changes.restartOnly,
 		)
-		reportReload(systray.ReloadOutcomeRestartRequired)
-
-		return
 	}
 
-	logger.Infow(reloadedMessage, "trigger", trigger)
-	reportReload(systray.ReloadOutcomeApplied)
+	if len(changes.reinstallOnly) > 0 {
+		logger.Warnw(
+			reloadReinstallRequiredMessage,
+			"trigger", trigger,
+			"reinstall_only", changes.reinstallOnly,
+		)
+	}
+
+	reportReload(reloadOutcomeFor(changes))
+}
+
+// reloadOutcomeFor is the single outcome the tray's one status line gets for a
+// reload that succeeded.
+//
+// A config that changes both a restart-only and a reinstall-only setting has
+// two answers and one line to say them in, and this picks the restart: it is
+// the instruction that holds however the daemon was started, where `mimi
+// services install` means nothing to someone running `mimi start` by hand. The
+// log names both either way, and it is the surface with room to.
+func reloadOutcomeFor(changes reloadChanges) systray.ReloadOutcome {
+	switch {
+	case len(changes.restartOnly) > 0:
+		return systray.ReloadOutcomeRestartRequired
+	case len(changes.reinstallOnly) > 0:
+		return systray.ReloadOutcomeReinstallRequired
+	default:
+		return systray.ReloadOutcomeApplied
+	}
 }
 
 // reloadReporter is where a reload's outcome goes. With a tray, that is the

--- a/internal/daemon/reload_report_test.go
+++ b/internal/daemon/reload_report_test.go
@@ -27,6 +27,7 @@ const (
 	keyLogFile        = "settings.log_file"
 	keyLogLevel       = "settings.log_level"
 	keyMaxHookWorkers = "settings.max_hook_workers"
+	keyServicePath    = "settings.service_path"
 )
 
 const reloadReportBaseConfig = `[settings]
@@ -140,6 +141,17 @@ func TestReloadConfig_ReportsTheOutcome(t *testing.T) {
 			wantInEntry: []string{keyLogLevel, keyMaxHookWorkers},
 			wantOutcome: systray.ReloadOutcomeRestartRequired,
 		},
+		{
+			// A restart would not pick this up either, so the report names the
+			// one thing that would
+			// (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
+			name:        "a reinstall-only setting changed",
+			contents:    "[settings]\nlog_level = \"info\"\nservice_path = \"/usr/bin:/bin\"\n",
+			wantLevel:   zapcore.WarnLevel,
+			wantMessage: reloadReinstallRequiredMessage,
+			wantInEntry: []string{keyServicePath},
+			wantOutcome: systray.ReloadOutcomeReinstallRequired,
+		},
 	}
 
 	for _, testCase := range tests {
@@ -193,6 +205,68 @@ func TestReloadConfig_ReportsTheOutcome(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestReloadConfig_ReportsARestartAndAReinstallTogether covers the config that
+// changes one of each. The two needs are different actions, so each gets its
+// own line naming its own settings; the tray gets one outcome and it is the
+// restart, the instruction that holds however the daemon was started, with the
+// reinstall a line away in the log.
+func TestReloadConfig_ReportsARestartAndAReinstallTogether(t *testing.T) {
+	t.Parallel()
+
+	path, cfgReloader, logger, logs := newTestReloadConfig(t, reloadReportBaseConfig)
+
+	writeReloadTestConfig(
+		t,
+		path,
+		"[settings]\nlog_level = \"debug\"\nservice_path = \"/usr/bin:/bin\"\n",
+	)
+
+	var reported []systray.ReloadOutcome
+
+	report := func(outcome systray.ReloadOutcome) {
+		reported = append(reported, outcome)
+	}
+
+	reloadConfig(path, cfgReloader, reloadTriggerSighup, report, logger)
+
+	if len(reported) != 1 || reported[0] != systray.ReloadOutcomeRestartRequired {
+		t.Errorf(
+			"reported outcomes = %v, want [%v]",
+			reported,
+			systray.ReloadOutcomeRestartRequired,
+		)
+	}
+
+	entries := logs.All()
+	if len(entries) != 2 {
+		t.Fatalf("got %d log entries, want 2: %+v", len(entries), entries)
+	}
+
+	restart, reinstall := entryText(entries[0]), entryText(entries[1])
+
+	if entries[0].Message != reloadRestartRequiredMessage ||
+		!strings.Contains(restart, keyLogLevel) {
+		t.Errorf("first entry %q does not report the restart-only setting that changed", restart)
+	}
+
+	if entries[1].Message != reloadReinstallRequiredMessage ||
+		!strings.Contains(reinstall, keyServicePath) {
+		t.Errorf(
+			"second entry %q does not report the reinstall-only setting that changed",
+			reinstall,
+		)
+	}
+
+	// The point of the fourth outcome: the user is told the command that
+	// applies the change, not to restart something a restart will not fix.
+	if !strings.Contains(reinstall, "mimi services install") {
+		t.Errorf(
+			"entry %q does not name the command that applies a reinstall-only change",
+			reinstall,
+		)
 	}
 }
 

--- a/internal/daemon/reloader.go
+++ b/internal/daemon/reloader.go
@@ -77,17 +77,18 @@ func newReloader(
 // Everything Apply does not touch — the logger, the pid file, the socket, the
 // systray, the hook worker limit — is restart-only, because nothing else in
 // the daemon reads a fresh value for it after startup either. Apply returns
-// the restart-only settings cfg changes, by TOML key, so the caller can say
-// so instead of reporting a reload that quietly did nothing. Those keys are
-// derived from the config type (config.RestartOnlyChanges); widening what
-// Apply re-reads means retagging that field as reloadable in the same change.
+// the settings cfg changes that it did not apply, by TOML key, so the caller
+// can say so instead of reporting a reload that quietly did nothing. Those
+// keys are derived from the config type (config.RestartOnlyChanges and
+// config.ReinstallOnlyChanges); widening what Apply re-reads means retagging
+// that field as reloadable in the same change.
 //
 // Apply is serialized: the whole of it runs under rl.mu, so a file save and a
 // SIGHUP arriving together apply one config after the other rather than
 // interleaving.
-func (rl *reloader) Apply(cfg *config.Config) ([]string, error) {
+func (rl *reloader) Apply(cfg *config.Config) (reloadChanges, error) {
 	if cfg == nil {
-		return nil, derrors.New(derrors.CodeInvalidInput, "nil config")
+		return reloadChanges{}, derrors.New(derrors.CodeInvalidInput, "nil config")
 	}
 
 	rl.mu.Lock()
@@ -95,7 +96,7 @@ func (rl *reloader) Apply(cfg *config.Config) ([]string, error) {
 
 	err := rl.reg.Reload(cfg)
 	if err != nil {
-		return nil, derrors.Wrapf(err, derrors.CodeInvalidConfig, "reloading hooks")
+		return reloadChanges{}, derrors.Wrapf(err, derrors.CodeInvalidConfig, "reloading hooks")
 	}
 
 	rl.executor.UpdateSettings(&cfg.Settings)
@@ -105,5 +106,33 @@ func (rl *reloader) Apply(cfg *config.Config) ([]string, error) {
 	perm := permissions.Check()
 	rl.axTracker.Update(perm.Accessibility && hasWindowEvents(cfg))
 
-	return config.RestartOnlyChanges(rl.running, cfg), nil
+	return reloadChanges{
+		restartOnly:   config.RestartOnlyChanges(rl.running, cfg),
+		reinstallOnly: config.ReinstallOnlyChanges(rl.running, cfg),
+	}, nil
+}
+
+// reloadChanges are the settings a reload did not apply, grouped by what the
+// user has to do for each of them to take effect. They are separate lists
+// rather than one because the two answers are different instructions, and
+// giving the wrong one confidently is the failure this reporting exists to
+// prevent (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
+//
+// Both are empty for a reload that applied everything, and for one that
+// applied nothing at all: a failed reload changed no value, so no value is
+// waiting on anything.
+type reloadChanges struct {
+	// restartOnly names the restart-only settings the new config changes,
+	// which the daemon will keep running the old values for until it restarts.
+	restartOnly []string
+	// reinstallOnly names the reinstall-only settings the new config changes.
+	// The daemon never read them; `mimi services install` bakes them into the
+	// launchd plist, so only installing the service again applies them.
+	reinstallOnly []string
+}
+
+// empty reports whether the reload applied the whole config, leaving nothing
+// waiting on the user.
+func (c reloadChanges) empty() bool {
+	return len(c.restartOnly) == 0 && len(c.reinstallOnly) == 0
 }

--- a/internal/daemon/reloader_test.go
+++ b/internal/daemon/reloader_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 const (
+	// reloaderDebugLogLevel is a log level distinguishable from the one
+	// baseSettings runs, so setting it is a restart-only change a test can see.
+	reloaderDebugLogLevel = "debug"
+
 	reloaderHookRunOld   = "echo old"
 	reloaderHookRunNew   = "echo new"
 	reloaderInvalidRegex = "["
@@ -55,30 +59,45 @@ func newTestReloader(
 	return cfgReloader, reg, bus
 }
 
-// TestReloader_Apply_ReportsRestartOnlySettingsThatChanged pins what a
-// trigger learns from a reload: the restart-only settings the new config
-// changes, so the caller can say a restart is needed instead of reporting a
-// success that changed nothing.
-func TestReloader_Apply_ReportsRestartOnlySettingsThatChanged(t *testing.T) {
+// TestReloader_Apply_ReportsSettingsItCouldNotApply pins what a trigger learns
+// from a reload: the settings the new config changes that the reload did not
+// apply, split by what each of them needs — a restart, or a reinstall of the
+// service — so the caller can say which instead of reporting a success that
+// changed nothing.
+func TestReloader_Apply_ReportsSettingsItCouldNotApply(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		change func(*config.Config)
-		want   []string
+		name              string
+		change            func(*config.Config)
+		wantRestartOnly   []string
+		wantReinstallOnly []string
 	}{
 		{
 			name:   "only reloadable settings changed",
 			change: func(c *config.Config) { c.Settings.HookShell = "/bin/bash" },
-			want:   nil,
 		},
 		{
 			name: "restart-only settings changed",
 			change: func(c *config.Config) {
-				c.Settings.LogLevel = "debug"
+				c.Settings.LogLevel = reloaderDebugLogLevel
 				c.Settings.MaxHookWorkers = 8
 			},
-			want: []string{keyLogLevel, keyMaxHookWorkers},
+			wantRestartOnly: []string{keyLogLevel, keyMaxHookWorkers},
+		},
+		{
+			name:              "a reinstall-only setting changed",
+			change:            func(c *config.Config) { c.Settings.ServicePath = "/usr/bin:/bin" },
+			wantReinstallOnly: []string{keyServicePath},
+		},
+		{
+			name: "both changed",
+			change: func(c *config.Config) {
+				c.Settings.LogLevel = reloaderDebugLogLevel
+				c.Settings.ServicePath = "/usr/bin:/bin"
+			},
+			wantRestartOnly:   []string{keyLogLevel},
+			wantReinstallOnly: []string{keyServicePath},
 		},
 	}
 
@@ -95,13 +114,25 @@ func TestReloader_Apply_ReportsRestartOnlySettingsThatChanged(t *testing.T) {
 			newCfg.Hooks.WindowFocus = []config.HookEntry{{Run: reloaderHookRunNew}}
 			testCase.change(newCfg)
 
-			restartOnly, err := cfgReloader.Apply(newCfg)
+			changes, err := cfgReloader.Apply(newCfg)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if !reflect.DeepEqual(restartOnly, testCase.want) {
-				t.Errorf("Apply() restart-only settings = %v, want %v", restartOnly, testCase.want)
+			if !reflect.DeepEqual(changes.restartOnly, testCase.wantRestartOnly) {
+				t.Errorf(
+					"Apply() restart-only settings = %v, want %v",
+					changes.restartOnly,
+					testCase.wantRestartOnly,
+				)
+			}
+
+			if !reflect.DeepEqual(changes.reinstallOnly, testCase.wantReinstallOnly) {
+				t.Errorf(
+					"Apply() reinstall-only settings = %v, want %v",
+					changes.reinstallOnly,
+					testCase.wantReinstallOnly,
+				)
 			}
 		})
 	}
@@ -122,28 +153,32 @@ func TestReloader_Apply_ComparesAgainstTheConfigTheDaemonIsRunning(t *testing.T)
 	cfgReloader, _, _ := newTestReloader(t, oldCfg)
 
 	changedCfg := &config.Config{Settings: baseSettings()}
-	changedCfg.Settings.LogLevel = "debug"
+	changedCfg.Settings.LogLevel = reloaderDebugLogLevel
 
-	restartOnly, err := cfgReloader.Apply(changedCfg)
+	changes, err := cfgReloader.Apply(changedCfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !reflect.DeepEqual(restartOnly, []string{keyLogLevel}) {
-		t.Fatalf("Apply() restart-only settings = %v, want %v", restartOnly, []string{keyLogLevel})
+	if !reflect.DeepEqual(changes.restartOnly, []string{keyLogLevel}) {
+		t.Fatalf(
+			"Apply() restart-only settings = %v, want %v",
+			changes.restartOnly,
+			[]string{keyLogLevel},
+		)
 	}
 
 	revertedCfg := &config.Config{Settings: baseSettings()}
 
-	restartOnly, err = cfgReloader.Apply(revertedCfg)
+	changes, err = cfgReloader.Apply(revertedCfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if restartOnly != nil {
+	if changes.restartOnly != nil {
 		t.Errorf(
 			"putting a restart-only setting back to the running value still asks for a restart: %v",
-			restartOnly,
+			changes.restartOnly,
 		)
 	}
 }
@@ -308,15 +343,15 @@ func TestReloader_Apply_InvalidHookRegexLeavesPreviousStateUntouched(t *testing.
 		{Run: reloaderHookRunNew, Title: reloaderInvalidRegex},
 	}
 
-	restartOnly, err := cfgReloader.Apply(newCfg)
+	changes, err := cfgReloader.Apply(newCfg)
 	if err == nil {
 		t.Fatal("expected an error for an invalid hook regex, got nil")
 	}
 
-	if restartOnly != nil {
+	if changes.restartOnly != nil || changes.reinstallOnly != nil {
 		t.Errorf(
-			"a failed reload reported %v as needing a restart; nothing was applied, so nothing does",
-			restartOnly,
+			"a failed reload reported %+v as unapplied; nothing was applied, so nothing is",
+			changes,
 		)
 	}
 

--- a/internal/service/plist.go
+++ b/internal/service/plist.go
@@ -23,8 +23,15 @@ const (
 	defaultStderrPath = "/tmp/mimi.err.log"
 )
 
-// plistTemplate is the launchd plist mimi installs, with the binary, config
-// and captured-stream paths left as tokens for renderPlist to fill in.
+// defaultServicePath is the PATH the installed service runs with when
+// settings.service_path says nothing. It is the value the plist hardcoded
+// before that setting existed, kept exactly so that a config which does not
+// mention it renders the same bytes as ever and leaves installed services
+// alone.
+const defaultServicePath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+// plistTemplate is the launchd plist mimi installs, with the binary, config,
+// captured-stream and PATH values left as tokens for renderPlist to fill in.
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -57,24 +64,54 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>MIMI_SERVICE_PATH</string>
     </dict>
 </dict>
 </plist>`
 
 // renderPlist fills plistTemplate with the binary and config paths mimi was
-// given, plus the stdout/stderr capture paths derived from logFile. It touches
-// no filesystem and makes no system call: the same inputs always render the
-// same bytes, which is what lets it be pinned with a plain table test instead
-// of an integration one.
-func renderPlist(binPath, configPath, logFile string) string {
+// given, the stdout/stderr capture paths derived from logFile, and the PATH the
+// service runs with. It touches no filesystem and makes no system call: the
+// same inputs always render the same bytes, which is what lets it be pinned
+// with a plain table test instead of an integration one.
+//
+// servicePath is settings.service_path, and is optional: an empty one renders
+// the PATH the plist hardcoded before that setting existed, so a config that
+// never mentions it produces the same bytes as ever.
+func renderPlist(binPath, configPath, logFile, servicePath string) string {
 	streams := capturedStreamsFor(logFile)
 
 	content := strings.ReplaceAll(plistTemplate, "MIMI_BINARY_PATH", binPath)
 	content = strings.ReplaceAll(content, "MIMI_CONFIG_PATH", configPath)
 	content = strings.ReplaceAll(content, "MIMI_STDOUT_PATH", streams.stdout)
+	content = strings.ReplaceAll(content, "MIMI_STDERR_PATH", streams.stderr)
 
-	return strings.ReplaceAll(content, "MIMI_STDERR_PATH", streams.stderr)
+	return strings.ReplaceAll(content, "MIMI_SERVICE_PATH", servicePathFor(servicePath))
+}
+
+// xmlTextEscaper escapes the characters that end an XML text node, so a value
+// carrying one cannot break out of the <string> it is rendered into. A plist
+// that is not well-formed is one launchd silently refuses at login, which is
+// the failure mode furthest from where it would be noticed.
+//
+// It is applied to service_path only, because that is the value this render
+// gained. The binary, config and captured-stream paths have always been
+// substituted raw and still are; a directory named with an XML metacharacter
+// breaks the plist there too, and fixing that is its own change rather than a
+// side effect of adding a setting.
+//
+//nolint:gochecknoglobals // an immutable replacer, built once
+var xmlTextEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
+// servicePathFor is the PATH value the plist gets for a given
+// settings.service_path: the configured one, escaped for XML, or the default
+// when the setting is unset.
+func servicePathFor(servicePath string) string {
+	if servicePath == "" {
+		return defaultServicePath
+	}
+
+	return xmlTextEscaper.Replace(servicePath)
 }
 
 // capturedStreams is where launchd writes the daemon's stdout and stderr. The

--- a/internal/service/plist_test.go
+++ b/internal/service/plist_test.go
@@ -17,14 +17,72 @@ import (
 // hardcoded /tmp/mimi.log and /tmp/mimi.err.log and onto log_file's directory.
 const wantGoldenPlist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>com.y3owk1n.mimi</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>/usr/local/bin/mimi</string>\n        <string>start</string>\n        <string>--config</string>\n        <string>/Users/test/.config/mimi/config.toml</string>\n    </array>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>StandardOutPath</key>\n    <string>/Users/test/.local/state/mimi/mimi.out.log</string>\n    <key>StandardErrorPath</key>\n    <string>/Users/test/.local/state/mimi/mimi.err.log</string>\n    <key>ProcessType</key>\n    <string>Interactive</string>\n    <key>LimitLoadToSessionType</key>\n    <string>Aqua</string>\n    <key>Nice</key>\n    <integer>-10</integer>\n    <key>ThrottleInterval</key>\n    <integer>10</integer>\n    <key>EnvironmentVariables</key>\n    <dict>\n        <key>PATH</key>\n        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>\n    </dict>\n</dict>\n</plist>"
 
+// TestRenderPlist_MatchesTheGoldenOutputByteForByte pins the plist rendered
+// for a config that sets no service_path. The golden bytes are the ones this
+// rendered before settings.service_path existed, so an unset service_path
+// changes nothing about an installed service — including whether `mimi
+// services install` decides the plist on disk needs replacing at all.
 func TestRenderPlist_MatchesTheGoldenOutputByteForByte(t *testing.T) {
 	got := renderPlist(
 		"/usr/local/bin/mimi",
 		"/Users/test/.config/mimi/config.toml",
 		"/Users/test/.local/state/mimi/mimi.log",
+		"",
 	)
 	if got != wantGoldenPlist {
 		t.Errorf("renderPlist() =\n%q\nwant\n%q", got, wantGoldenPlist)
+	}
+}
+
+// TestRenderPlist_ServicePath pins the PATH the installed service runs with,
+// which is the PATH its hooks inherit. Every expected value is written out
+// literally: the point of the setting is that what the user typed is what the
+// service gets.
+func TestRenderPlist_ServicePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		servicePath string
+		wantPath    string
+	}{
+		{
+			name:        "unset keeps the PATH the plist has always hardcoded",
+			servicePath: "",
+			wantPath:    "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+		},
+		{
+			name:        "a configured PATH replaces it entirely",
+			servicePath: "/Users/test/.local/bin:/usr/bin:/bin",
+			wantPath:    "/Users/test/.local/bin:/usr/bin:/bin",
+		},
+		{
+			// A directory name may legally contain XML markup characters, and
+			// a plist that is not well-formed XML is one launchd refuses to
+			// load at login — a failure nothing in an install would report.
+			name:        "XML markup in a directory name is escaped",
+			servicePath: "/Users/test/bin & tools/<x>:/usr/bin",
+			wantPath:    "/Users/test/bin &amp; tools/&lt;x&gt;:/usr/bin",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := renderPlist(
+				"/usr/local/bin/mimi",
+				"/Users/test/.config/mimi/config.toml",
+				"/Users/test/.local/state/mimi/mimi.log",
+				testCase.servicePath,
+			)
+
+			want := "<key>PATH</key>\n        <string>" + testCase.wantPath + "</string>"
+			if !strings.Contains(got, want) {
+				t.Errorf(
+					"renderPlist(servicePath=%q) does not contain %q:\n%s",
+					testCase.servicePath,
+					want,
+					got,
+				)
+			}
+		})
 	}
 }
 
@@ -110,6 +168,7 @@ func TestRenderPlist_CapturedStreamPaths(t *testing.T) {
 				"/usr/local/bin/mimi",
 				"/Users/test/.config/mimi/config.toml",
 				testCase.logFile,
+				"",
 			)
 
 			wantOut := "<key>StandardOutPath</key>\n    <string>" + testCase.wantStdout + "</string>"
@@ -146,34 +205,43 @@ func TestRenderPlist_CapturedStreamPaths(t *testing.T) {
 
 func TestRenderPlist_Table(t *testing.T) {
 	tests := []struct {
-		name       string
-		binPath    string
-		configPath string
-		logFile    string
+		name        string
+		binPath     string
+		configPath  string
+		logFile     string
+		servicePath string
 	}{
 		{
-			name:       "typical paths",
-			binPath:    "/opt/homebrew/bin/mimi",
-			configPath: "~/.config/mimi/config.toml",
-			logFile:    "/Users/test/.local/state/mimi/mimi.log",
+			name:        "typical paths",
+			binPath:     "/opt/homebrew/bin/mimi",
+			configPath:  "~/.config/mimi/config.toml",
+			logFile:     "/Users/test/.local/state/mimi/mimi.log",
+			servicePath: "/usr/bin:/bin",
 		},
 		{
-			name:       "empty inputs",
-			binPath:    "",
-			configPath: "",
-			logFile:    "",
+			name:        "empty inputs",
+			binPath:     "",
+			configPath:  "",
+			logFile:     "",
+			servicePath: "",
 		},
 		{
-			name:       "path containing the token-like substring MIMI",
-			binPath:    "/Users/mimi-user/bin/mimi",
-			configPath: "/Users/mimi-user/MIMI_CONFIG_PATH-lookalike/config.toml",
-			logFile:    "/Users/mimi-user/MIMI_STDOUT_PATH-lookalike/mimi.log",
+			name:        "path containing the token-like substring MIMI",
+			binPath:     "/Users/mimi-user/bin/mimi",
+			configPath:  "/Users/mimi-user/MIMI_CONFIG_PATH-lookalike/config.toml",
+			logFile:     "/Users/mimi-user/MIMI_STDOUT_PATH-lookalike/mimi.log",
+			servicePath: "/Users/mimi-user/MIMI_SERVICE_PATH-lookalike/bin:/usr/bin",
 		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := renderPlist(testCase.binPath, testCase.configPath, testCase.logFile)
+			got := renderPlist(
+				testCase.binPath,
+				testCase.configPath,
+				testCase.logFile,
+				testCase.servicePath,
+			)
 
 			wantBin := "<string>" + testCase.binPath + "</string>"
 			if !strings.Contains(got, wantBin) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -107,7 +107,13 @@ func New() *Service {
 // logFile is settings.log_file as config resolved it, and is only used to
 // place the daemon's captured stdout/stderr alongside it; an empty value is
 // valid and leaves those streams at their /tmp defaults.
-func (s *Service) Install(configPath, logFile string) (InstallOutcome, error) {
+//
+// servicePath is settings.service_path: the PATH the installed service, and so
+// every hook it runs, is given. An empty value is valid and leaves the PATH
+// the plist has always carried. It is baked in here and nowhere else, which is
+// what makes it reinstall-only
+// (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
+func (s *Service) Install(configPath, logFile, servicePath string) (InstallOutcome, error) {
 	ctx := context.Background()
 
 	loaded := s.launcher.list(ctx, Label) == nil
@@ -128,7 +134,7 @@ func (s *Service) Install(configPath, logFile string) (InstallOutcome, error) {
 		return 0, derrors.Wrapf(err, derrors.CodeServiceFailed, "getting binary path")
 	}
 
-	plistContent := renderPlist(binPath, configPath, logFile)
+	plistContent := renderPlist(binPath, configPath, logFile, servicePath)
 
 	// launchd opens StandardOutPath and StandardErrorPath at spawn time and
 	// creates no directories of its own: a missing one silently discards the

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -18,6 +18,11 @@ import (
 // that does not vary it uses this one.
 const testConfigPath = "/Users/test/.config/mimi/config.toml"
 
+// wantReloadCalls is the launchctl sequence that replaces the plist of a
+// loaded service: booted out first, because launchd re-reads a plist only when
+// the job is loaded again, and it cannot while the old one is loaded.
+const wantReloadCalls = "bootout,bootstrap"
+
 // fakeLauncher is a launcher made of plain values: every call it sees lands
 // in a field a test can assert against, and every call it returns is a field
 // a test can set up in advance.
@@ -386,7 +391,7 @@ func TestService_Install_WritesThePlistAndBootstraps(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	outcome, err := svc.Install(testConfigPath, logFile)
+	outcome, err := svc.Install(testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil", err)
 	}
@@ -445,7 +450,7 @@ func TestService_Install_IsANoOpWhenTheLoadedServiceAlreadyMatches(t *testing.T)
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, logFile)
+	_, err := svc.Install(testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -455,7 +460,7 @@ func TestService_Install_IsANoOpWhenTheLoadedServiceAlreadyMatches(t *testing.T)
 	fake.loaded = true
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, logFile)
+	outcome, err := svc.Install(testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("second Install() = %v, want nil", err)
 	}
@@ -485,7 +490,7 @@ func TestService_Install_ReplacesAStalePlistAndReloadsTheService(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, oldLogFile)
+	_, err := svc.Install(testConfigPath, oldLogFile, "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -494,7 +499,7 @@ func TestService_Install_ReplacesAStalePlistAndReloadsTheService(t *testing.T) {
 	fake.loaded = true
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, newLogFile)
+	outcome, err := svc.Install(testConfigPath, newLogFile, "")
 	if err != nil {
 		t.Fatalf("second Install() = %v, want nil", err)
 	}
@@ -505,7 +510,7 @@ func TestService_Install_ReplacesAStalePlistAndReloadsTheService(t *testing.T) {
 
 	// Booted out first: bootstrapping over a loaded job is what makes
 	// launchd re-read the plist, and it cannot while the old one is loaded.
-	if got := strings.Join(fake.calls, ","); got != "bootout,bootstrap" {
+	if got := strings.Join(fake.calls, ","); got != wantReloadCalls {
 		t.Errorf("second Install() calls = %v, want [bootout bootstrap]", fake.calls)
 	}
 
@@ -534,6 +539,53 @@ func TestService_Install_ReplacesAStalePlistAndReloadsTheService(t *testing.T) {
 	}
 }
 
+// TestService_Install_ReplacesAStalePlistAfterServicePathChanges is the same
+// staleness for settings.service_path, and the whole reason that setting is
+// reinstall-only: the PATH the daemon runs its hooks with is the one in the
+// plist launchd loaded, so changing the config reaches an installed service
+// only by installing it again.
+func TestService_Install_ReplacesAStalePlistAfterServicePathChanges(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	logFile := filepath.Join(dir, "state", "mimi", "mimi.log")
+
+	fake := &fakeLauncher{}
+	svc := newTestService(fake)
+
+	_, err := svc.Install(testConfigPath, logFile, "")
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	fake.loaded = true
+	fake.calls = nil
+
+	const wantPath = "/Users/test/.local/bin:/usr/bin:/bin"
+
+	outcome, err := svc.Install(testConfigPath, logFile, wantPath)
+	if err != nil {
+		t.Fatalf("second Install() = %v, want nil", err)
+	}
+
+	if outcome != InstallOutcomeReplaced {
+		t.Errorf("second Install() outcome = %v, want %v", outcome, InstallOutcomeReplaced)
+	}
+
+	if got := strings.Join(fake.calls, ","); got != wantReloadCalls {
+		t.Errorf("second Install() calls = %v, want [bootout bootstrap]", fake.calls)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "Library", "LaunchAgents", Label+".plist"))
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	if !strings.Contains(string(content), "<string>"+wantPath+"</string>") {
+		t.Errorf("installed plist does not carry the configured PATH:\n%s", content)
+	}
+}
+
 // TestService_Install_FailsWhenLoadedByAnotherInstaller pins the refusal that
 // survives idempotence: a loaded service with no plist of mimi's behind it is
 // nix-darwin's or home-manager's, and mimi must not adopt it.
@@ -544,7 +596,7 @@ func TestService_Install_FailsWhenLoadedByAnotherInstaller(t *testing.T) {
 	fake := &fakeLauncher{loaded: true}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"))
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}
@@ -595,7 +647,7 @@ func TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err = svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"))
+	_, err = svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}
@@ -650,7 +702,7 @@ func TestService_Install_LoadsAPlistLeftBehindByAPreviousInstall(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	outcome, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"))
+	outcome, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil", err)
 	}
@@ -691,7 +743,7 @@ func TestService_Install_NeverLeavesAPartialPlist(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"))
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -717,7 +769,7 @@ func TestService_Install_NeverLeavesAPartialPlist(t *testing.T) {
 
 	fake.loaded = true
 
-	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"))
+	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
 	if err == nil {
 		t.Fatal("second Install() = nil, want an error")
 	}
@@ -760,7 +812,7 @@ func TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded(t *tes
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"))
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -778,7 +830,7 @@ func TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded(t *tes
 
 	newLogFile := filepath.Join(dir, "new", "mimi.log")
 
-	_, err = svc.Install(testConfigPath, newLogFile)
+	_, err = svc.Install(testConfigPath, newLogFile, "")
 	if err == nil {
 		t.Fatal("Install() = nil, want the unload failure")
 	}
@@ -806,7 +858,7 @@ func TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded(t *tes
 	fake.bootoutErr = nil
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, newLogFile)
+	outcome, err := svc.Install(testConfigPath, newLogFile, "")
 	if err != nil {
 		t.Fatalf("retried Install() = %v, want nil", err)
 	}
@@ -829,7 +881,7 @@ func TestService_Install_WaitsForThePreviousServiceToUnloadBeforeBootstrapping(t
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"))
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -840,7 +892,7 @@ func TestService_Install_WaitsForThePreviousServiceToUnloadBeforeBootstrapping(t
 	fake.unloadLag = 2
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"))
+	outcome, err := svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("second Install() = %v, want nil", err)
 	}
@@ -849,7 +901,7 @@ func TestService_Install_WaitsForThePreviousServiceToUnloadBeforeBootstrapping(t
 		t.Errorf("second Install() outcome = %v, want %v", outcome, InstallOutcomeReplaced)
 	}
 
-	if got := strings.Join(fake.calls, ","); got != "bootout,bootstrap" {
+	if got := strings.Join(fake.calls, ","); got != wantReloadCalls {
 		t.Errorf("second Install() calls = %v, want [bootout bootstrap]", fake.calls)
 	}
 
@@ -869,7 +921,7 @@ func TestService_Install_FailsWhenThePreviousServiceNeverUnloads(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"))
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -892,7 +944,7 @@ func TestService_Install_FailsWhenThePreviousServiceNeverUnloads(t *testing.T) {
 	fake.neverUnloads = true
 	fake.calls = nil
 
-	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"))
+	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
 	if err == nil {
 		t.Fatal("Install() = nil, want the unload to time out")
 	}
@@ -948,7 +1000,7 @@ func TestService_Install_SaysAFailedLoadCanBeRetried(t *testing.T) {
 			fake := &fakeLauncher{}
 			svc := newTestService(fake)
 
-			_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"))
+			_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 			if err != nil {
 				t.Fatalf("first Install() = %v, want nil", err)
 			}
@@ -958,7 +1010,7 @@ func TestService_Install_SaysAFailedLoadCanBeRetried(t *testing.T) {
 
 			newLogFile := filepath.Join(dir, "new", "mimi.log")
 
-			_, err = svc.Install(testConfigPath, newLogFile)
+			_, err = svc.Install(testConfigPath, newLogFile, "")
 			if err == nil {
 				t.Fatal("Install() = nil, want the failed load")
 			}
@@ -984,7 +1036,7 @@ func TestService_Install_SaysAFailedLoadCanBeRetried(t *testing.T) {
 			fake.bootstrapErr = nil
 			fake.calls = nil
 
-			_, err = svc.Install(testConfigPath, newLogFile)
+			_, err = svc.Install(testConfigPath, newLogFile, "")
 			if err != nil {
 				t.Fatalf("retried Install() = %v, want nil", err)
 			}
@@ -1008,7 +1060,7 @@ func TestService_Install_DoesNotUseTheSystemTempDirectory(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"))
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil (the plist never goes via TMPDIR)", err)
 	}
@@ -1062,7 +1114,7 @@ func TestService_Install_FailsWhenTheCapturedStreamDirectoryCannotBeCreated(t *t
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err = svc.Install(testConfigPath, filepath.Join(blocker, "mimi", "mimi.log"))
+	_, err = svc.Install(testConfigPath, filepath.Join(blocker, "mimi", "mimi.log"), "")
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}

--- a/internal/systray/reload_status.go
+++ b/internal/systray/reload_status.go
@@ -25,6 +25,15 @@ const (
 	// success because it is the case where the reload worked and the user's
 	// change still did nothing.
 	ReloadOutcomeRestartRequired
+	// ReloadOutcomeReinstallRequired is a reload the daemon applied as far as
+	// it can, where what it could not apply is a reinstall-only setting: one
+	// baked into the launchd plist, which the daemon never reads and a restart
+	// would not change either. It is separate from RestartRequired because the
+	// two ask the user for different things, and telling someone to restart
+	// when only `mimi services install` will do is exactly the confident wrong
+	// instruction this reporting exists to avoid
+	// (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
+	ReloadOutcomeReinstallRequired
 	// ReloadOutcomeFailed is a reload the daemon did not apply at all; the
 	// previous config is still running, entirely.
 	ReloadOutcomeFailed
@@ -81,7 +90,7 @@ func (c *Component) adoptReloadStatusItem(item *MenuItem) {
 // showing a time or implying a success that never happened.
 //
 // Nothing from the user's config file can reach these lines: the outcome is
-// three values and a clock reading, so no setting name, no setting value and
+// four values and a clock reading, so no setting name, no setting value and
 // no error text has a way in.
 func formatReloadStatus(status *reloadStatus) string {
 	if status == nil {
@@ -95,6 +104,11 @@ func formatReloadStatus(status *reloadStatus) string {
 		return "Reloaded " + when
 	case ReloadOutcomeRestartRequired:
 		return "Reloaded " + when + " — restart required"
+	case ReloadOutcomeReinstallRequired:
+		// Named as the command to run, not as "reinstall required": a
+		// reinstall of what is the question a user would be left with, and
+		// this is a label they cannot click for more.
+		return "Reloaded " + when + " — run mimi services install"
 	case ReloadOutcomeFailed:
 		return "Reload failed " + when
 	default:

--- a/internal/systray/reload_status_test.go
+++ b/internal/systray/reload_status_test.go
@@ -48,11 +48,14 @@ func newStatusTestItem() *MenuItem {
 }
 
 // TestFormatReloadStatus_RendersEveryOutcome pins the line the menu shows for
-// each reload outcome. The three outcomes must stay distinguishable at a
+// each reload outcome. The four outcomes must stay distinguishable at a
 // glance: a reload that left restart-only settings unapplied worked and still
 // did not do what the user asked, so rendering it as a plain success would be
 // the same lie the reload menu item stopped telling
-// (docs/adr/0002-reload-is-signal-mediated.md).
+// (docs/adr/0002-reload-is-signal-mediated.md). A reinstall-only setting is
+// distinct again: restarting the daemon would not pick it up either, so the
+// line names the command that does
+// (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
 //
 // The time is absolute and local. A relative "2 min ago" would need a timer
 // ticking behind a label read only when someone opens the menu.
@@ -80,6 +83,11 @@ func TestFormatReloadStatus_RendersEveryOutcome(t *testing.T) {
 			name:   "the reload left restart-only settings unapplied",
 			status: &reloadStatus{outcome: ReloadOutcomeRestartRequired, at: reloadedAt},
 			want:   "Reloaded 14:32 — restart required",
+		},
+		{
+			name:   "the reload left reinstall-only settings unapplied",
+			status: &reloadStatus{outcome: ReloadOutcomeReinstallRequired, at: reloadedAt},
+			want:   "Reloaded 14:32 — run mimi services install",
 		},
 		{
 			name:   "the reload failed",


### PR DESCRIPTION
## Description

This PR adds a setting that decides the `PATH` the launchd-installed service runs with, and therefore the `PATH` every hook it fires inherits. Until now the plist hardcoded four directories, so a hook calling anything in a personal `bin`, a Nix profile, or a language version manager worked when the daemon was started by hand and silently did nothing when launchd started it at login — a symptom that is close to unguessable from the outside. Left unset, the plist renders byte-for-byte what it rendered before, so nothing about an existing installation changes.

Nothing in the daemon reads the new setting: the value that matters is the one already rendered into the plist on disk, and only installing the service again replaces it. That makes it the first *reinstall-only* setting — a third classification the config's reloadability check now accepts — and a reload that sees it change says a reinstall is required, naming the command, instead of advising a restart that would not pick it up. That report is a fourth reload outcome, visible both in the daemon's log and in the systray's last-reload line.

One deliberate limitation: the tray has a single status line, so a reload that changes a restart-only *and* a reinstall-only setting shows the restart there — the instruction that holds however the daemon was started — while the log names both.

## Related Issues

Closes #156

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config changes

One new key, `settings.service_path`. It is optional, and every existing config keeps working unchanged: unset, the installed plist carries the same `PATH` it always has, and renders identical bytes, so `mimi services install` still reports an untouched service as already up to date.

```toml
[settings]
# Optional. Default when unset (and what the plist has always hardcoded):
#   /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
service_path = "/Users/me/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
```

It replaces the whole `PATH` rather than adding to it, and takes absolute directories only — `~` is not expanded here, and launchd would not expand it either. It is reinstall-only: run `mimi services install` after changing it. A daemon restart, `mimi services restart`, and a config reload all leave the old `PATH` in place, and a reload now says so.

The key is documented in `docs/CONFIGURATION.md` (with its own section and in the reload lists), in `docs/CLI.md` under `mimi services install`, in a new `docs/TROUBLESHOOTING.md` entry for the symptom it fixes, and shipped commented-out in `configs/default-config.toml`.

Not applicable to services installed by the nix-darwin or home-manager module: those render their own agent, and `services.mimi.extraEnvironment.PATH` is the setting there. `docs/CONFIGURATION.md` says so.

## Additional Context

The design is `docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md`, which weighed and rejected tagging the field `restart-only`, giving it a new `[service]` section, making it a flag on `services install`, and merging a whole `EnvironmentVariables` dict from config. This PR implements that ADR as written; nothing in it reopens one of those options.

Two things worth a reviewer's eye:

- The configured value is XML-escaped before it reaches the plist, because a directory name may legally contain `&` or `<` and a malformed plist is one launchd silently refuses at login. The binary, config and captured-stream paths substituted alongside it are still rendered raw, as they always have been — that is a separate latent problem, left alone here rather than fixed as a side effect.
- `mimi services install` now takes both plist-baked settings from a single config load, so an install cannot read the log file from one read of the file and the service path from another.
