### PR TITLE
feat(daemon,service,cli): keep the installed service's captured console logs bounded

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -50,7 +51,7 @@ func newServicesInstallCmd(state *cliState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "install",
 		Short: "Install and load the system service",
-		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.\n\nThe plist is a snapshot of the config taken at install time, so run install again after changing a setting it bakes in — it replaces the plist and reloads the service, and does nothing at all when the plist already matches.\n\nReloading waits for the running service to unload before loading the new plist, for up to five seconds; a service still loaded after that fails the install with its old plist untouched. A load that fails for any other reason leaves the new plist in place, so running install again retries just the load.\n\nThe daemon's stdout and stderr are captured beside settings.log_file, as <name>.out.log and <name>.err.log, and that directory is created if missing. When log_file is unset — or is not an absolute path, which launchd cannot open — they fall back to /tmp/mimi.log and /tmp/mimi.err.log.\n\nThe PATH the installed service runs its hooks with comes from settings.service_path; unset, it is /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin. Nothing else reads that setting, so this command is what makes a change to it take effect.",
+		Long:  "Install the Mimi launchd service so it starts automatically on login. Creates the plist file and loads it with launchctl.\n\nThe plist is a snapshot of the config taken at install time, so run install again after changing a setting it bakes in — it replaces the plist and reloads the service, and does nothing at all when the plist already matches.\n\nReloading waits for the running service to unload before loading the new plist, for up to five seconds; a service still loaded after that fails the install with its old plist untouched. A load that fails for any other reason leaves the new plist in place, so running install again retries just the load.\n\nThe daemon's stdout and stderr are captured beside settings.log_file, as <name>.out.log and <name>.err.log, and that directory is created if missing. When log_file is unset — or is not an absolute path, which launchd cannot open — they fall back to /tmp/mimi.log and /tmp/mimi.err.log. The plist also names both paths in the service's environment, which is what tells the daemon to empty them once at each start; nothing rotates them otherwise, and a service installed before that existed picks it up here.\n\nThe PATH the installed service runs its hooks with comes from settings.service_path; unset, it is /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin. Nothing else reads that setting, so this command is what makes a change to it take effect.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logFile, servicePath := state.plistSettings()
 
@@ -142,7 +143,7 @@ func newServicesStatusCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Check the status of the system service",
-		Long:  "Check whether the Mimi launchd service is currently loaded, and whether it is actually running.\n\nThe two are not the same: the installed plist sets KeepAlive, so a daemon that crashes at startup is relaunched every ten seconds and stays loaded the whole time. A running service reports the pid it runs under; a loaded one that is not running reports the status it last exited with — a repeated non-zero status there is a daemon in a crash loop, and the captured stderr beside settings.log_file says why.",
+		Long:  "Check whether the Mimi launchd service is currently loaded, and whether it is actually running.\n\nThe two are not the same: the installed plist sets KeepAlive, so a daemon that crashes at startup is relaunched every ten seconds and stays loaded the whole time. A running service reports the pid it runs under; a loaded one that is not running reports the status it last exited with — a repeated non-zero status there is a daemon in a crash loop, and the captured stderr beside settings.log_file says why.\n\nUnder that line come the captured stdout and stderr the installed plist names, with how large each has grown. A daemon launchd started empties both at startup, so each size is one run's console output.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.Println(formatStatus(defaultService.Status()))
 
@@ -170,17 +171,54 @@ func formatInstallOutcome(outcome service.InstallOutcome) string {
 	}
 }
 
-// formatStatus renders a service.Status as the one line `mimi services status`
+// formatStatus renders a service.Status as the lines `mimi services status`
 // prints.
 //
-// Loaded and running are not the same thing, and that is the point of the
-// line: the installed plist sets KeepAlive, so a daemon that crashes at
-// startup is relaunched every ten seconds forever while staying exactly as
-// loaded as a healthy one. The pid says it is up; the exit status it left
-// behind says it is not. When launchd's description carries neither — it is
-// undocumented text and may change shape — this falls back to the two words
-// the command printed before it ever asked.
+// The first of them is the service itself. Loaded and running are not the same
+// thing, and that is the point of it: the installed plist sets KeepAlive, so a
+// daemon that crashes at startup is relaunched every ten seconds forever while
+// staying exactly as loaded as a healthy one. The pid says it is up; the exit
+// status it left behind says it is not. When launchd's description carries
+// neither — it is undocumented text and may change shape — this falls back to
+// the two words the command printed before it ever asked.
+//
+// Under that line come the captured console streams, one per line, each with
+// how large it has grown. They are the only place a crash before the logger
+// exists surfaces, and their size is the fact the line adds: the daemon empties
+// them once per start, so a size is one run's console output and a big one
+// under a service that keeps exiting is the crash loop this command is run to
+// find. A stream the installed plist did not name — because nothing is
+// installed, or because mimi did not write that plist — gets no line at all,
+// rather than a guess at where its output would have gone.
 func formatStatus(status service.Status) string {
+	lines := []string{loadedLine(status)}
+
+	captured := []struct {
+		stream string
+		log    service.CapturedLog
+	}{
+		{stream: "stdout", log: status.CapturedStdout},
+		{stream: "stderr", log: status.CapturedStderr},
+	}
+	for _, stream := range captured {
+		if stream.log.Path == "" {
+			continue
+		}
+
+		lines = append(lines, fmt.Sprintf(
+			"Captured %s: %s (%s)",
+			stream.stream,
+			stream.log.Path,
+			formatCapturedSize(stream.log),
+		))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// loadedLine is the first line of a status: whether the service is loaded, and
+// the one number that says whether it is up.
+func loadedLine(status service.Status) string {
 	if !status.Loaded {
 		return "Service not loaded"
 	}
@@ -196,4 +234,28 @@ func formatStatus(status service.Status) string {
 	default:
 		return "Service loaded"
 	}
+}
+
+// formatCapturedSize renders how large a captured stream has grown, in the
+// units a person reads. A file that is not there is said in words rather than
+// as a zero: launchd creates both when it first spawns the daemon, so an absent
+// one means the service has never run, which a "0 B" would hide.
+func formatCapturedSize(log service.CapturedLog) string {
+	if !log.Present {
+		return "not created yet"
+	}
+
+	const unit = 1024
+
+	if log.Size < unit {
+		return fmt.Sprintf("%d B", log.Size)
+	}
+
+	div, exp := int64(unit), 0
+	for size := log.Size / unit; size >= unit; size /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.1f %cB", float64(log.Size)/float64(div), "KMGTPE"[exp])
 }

--- a/cmd/mimi/cmd/services_test.go
+++ b/cmd/mimi/cmd/services_test.go
@@ -170,6 +170,57 @@ func TestFormatStatus(t *testing.T) {
 			want:   "Service loaded",
 		},
 		{name: "not loaded", status: service.Status{Loaded: false}, want: "Service not loaded"},
+		{
+			// Nothing rotates the captured streams, so the daemon empties them
+			// once per start and a size is one run's console output. Printing
+			// it next to the path is what turns "the stderr says why" into
+			// something a user can act on without going looking first.
+			name: "loaded and running, with both captured streams",
+			status: service.Status{
+				Loaded: true,
+				PID:    service.OptionalInt{Value: 1478, Known: true},
+				CapturedStdout: service.CapturedLog{
+					Path:    "/Users/test/.local/state/mimi/mimi.out.log",
+					Size:    2048,
+					Present: true,
+				},
+				CapturedStderr: service.CapturedLog{
+					Path:    "/Users/test/.local/state/mimi/mimi.err.log",
+					Size:    0,
+					Present: true,
+				},
+			},
+			want: "Service loaded and running (pid 1478)\n" +
+				"Captured stdout: /Users/test/.local/state/mimi/mimi.out.log (2.0 KB)\n" +
+				"Captured stderr: /Users/test/.local/state/mimi/mimi.err.log (0 B)",
+		},
+		{
+			// launchd creates both files when it first spawns the daemon, so a
+			// missing one is a service that has never run — a different thing
+			// from an empty one, and said differently.
+			name: "loaded, with a captured stream that does not exist yet",
+			status: service.Status{
+				Loaded: true,
+				CapturedStdout: service.CapturedLog{
+					Path: "/Users/test/.local/state/mimi/mimi.out.log",
+				},
+			},
+			want: "Service loaded\n" +
+				"Captured stdout: /Users/test/.local/state/mimi/mimi.out.log (not created yet)",
+		},
+		{
+			// The files outlive the service that wrote them, and an unloaded
+			// service is one of the states in which their contents matter most.
+			name: "not loaded, with the plist still naming its captured streams",
+			status: service.Status{
+				CapturedStderr: service.CapturedLog{
+					Path:    "/tmp/mimi.err.log",
+					Size:    1288490189,
+					Present: true,
+				},
+			},
+			want: "Service not loaded\nCaptured stderr: /tmp/mimi.err.log (1.2 GB)",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/mimi/cmd/start.go
+++ b/cmd/mimi/cmd/start.go
@@ -15,6 +15,17 @@ func newStartCmd(state *cliState) *cobra.Command {
 		Use:   "start",
 		Short: "Start the mimi hook daemon for window and space events",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// First, before this process writes a single byte to stdout or
+			// stderr. When launchd started the daemon, those two are the
+			// captured console logs it appends to forever, and emptying them
+			// here is the only rotation they get; anything printed before it
+			// would be printed into a file about to be emptied. When anything
+			// else started it, there is nothing to empty and nothing happens.
+			//
+			// The outcome is logged below rather than here: there is no logger
+			// yet, and building one would write to the stream first.
+			truncated, truncateErr := daemon.TruncateCapturedLogs()
+
 			if !config.Exists(state.configPath) {
 				choice := permissions.ShowConfigOnboardingAlert(state.configPath)
 				if choice == permissions.ConfigOnboardingQuit {
@@ -36,6 +47,14 @@ func newStartCmd(state *cliState) *cobra.Command {
 
 			logger := logging.New(cfg)
 			logger.Infow("mimi starting", "version", Version, "config", state.configPath)
+
+			if truncateErr != nil {
+				logger.Warnw("captured console logs not truncated", "err", truncateErr)
+			}
+
+			if truncated > 0 {
+				logger.Infow("captured console logs truncated", "count", truncated)
+			}
 
 			return daemon.Run(cfg, logger, state.configPath, Version)
 		},

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -189,7 +189,9 @@ mimi services install
 
 The generated plist captures the daemon's stdout and stderr beside
 `settings.log_file`, creating that directory if missing, or in `/tmp` when
-`log_file` is unset. See
+`log_file` is unset. It also names those two paths in the service's
+environment, which is how the daemon knows to empty them once at each start —
+nothing rotates them otherwise. See
 [Troubleshooting](TROUBLESHOOTING.md#where-a-service-installed-daemons-console-output-lands).
 
 The `PATH` the service runs its hooks with comes from
@@ -253,7 +255,21 @@ The bare `Service loaded` is the fallback, printed whenever neither number is
 available — the daemon has never run, it was killed by a signal rather than
 exiting, or launchd's description of the job could not be read. That
 description is undocumented text, so output mimi cannot parse costs the detail,
-never the answer. See
+never the answer.
+
+Under that line come the captured console streams the installed plist names,
+with how large each has grown:
+
+```
+Service loaded and running (pid 1478)
+Captured stdout: /Users/me/.local/state/mimi/mimi.out.log (2.0 KB)
+Captured stderr: /Users/me/.local/state/mimi/mimi.err.log (not created yet)
+```
+
+A daemon launchd started empties both at startup, so each size is one run's
+console output. `not created yet` is a file launchd has never spawned the
+daemon against, and a stream gets no line at all when there is no plist of
+mimi's to read its path from. See
 [TROUBLESHOOTING.md](TROUBLESHOOTING.md#reading-mimi-services-status).
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -130,6 +130,21 @@ relaunched forever and stays loaded the whole time.
 `launchctl print gui/$(id -u)/com.y3owk1n.mimi` is the same description mimi
 reads, in full, when a bare `Service loaded` leaves a question open.
 
+Under that line come the captured console streams, as the installed plist
+names them, with how large each has grown:
+
+```text
+Service loaded and running (pid 1478)
+Captured stdout: /Users/me/.local/state/mimi/mimi.out.log (2.0 KB)
+Captured stderr: /Users/me/.local/state/mimi/mimi.err.log (not created yet)
+```
+
+The size is one run's console output, because a daemon launchd started empties
+both files at startup (see below). `not created yet` is a file launchd has
+never spawned the daemon against. Neither line is printed when there is no
+plist to read the paths from: nothing installed, or a plist mimi cannot read —
+home-manager's, for one, is a symlink into the Nix store rather than a file.
+
 ### Where a service-installed daemon's console output lands
 
 `mimi services install` writes a launchd plist that captures the daemon's
@@ -159,17 +174,37 @@ Notes on this:
   `log_file` that is not an absolute path — a relative path, or a `~` that
   could not be expanded because the home directory was unresolvable — falls
   back the same way, since launchd expands neither and runs the job from `/`.
-- **The captured streams are not rotated.** `settings.log_file` gets size,
-  age, and backup limits; these two get none, while the same plist sets
-  `KeepAlive = true`, so the daemon is restarted for as long as you are
-  logged in. At `log_level = "debug"` mimi emits a console line per window
-  event, so these files grow without bound. Truncate them yourself if they
-  get large:
+- **The captured streams are bounded by one run, not rotated.**
+  `settings.log_file` gets size, age, and backup limits from the writer that
+  owns it; these two get none, and nothing can rotate them — launchd opens both
+  at spawn and holds the descriptors, while the same plist sets
+  `KeepAlive = true`, so the daemon is restarted for as long as you are logged
+  in. At `log_level = "debug"` mimi emits a console line per window event, and
+  a crash loop respawns every ten seconds, so they would otherwise grow without
+  bound.
+
+  Instead, a daemon launchd started empties both files once at startup, before
+  it writes anything to them. Each file therefore holds the console output of
+  the current run and nothing older, and `mimi services status` prints how
+  large each has grown.
+
+  The plist is what tells the daemon those files exist, in its
+  `MIMI_CAPTURED_STDOUT` and `MIMI_CAPTURED_STDERR` environment entries. A
+  daemon started any other way — `mimi start` by hand, with a terminal on
+  stdout — is told about no captured streams and empties nothing, so running
+  mimi in a shell never destroys the crash log the service left behind. The
+  next start does, though, so copy a run's output aside before restarting the
+  service — and truncate by hand whenever you want to:
 
   ```bash
+  cp ~/.local/state/mimi/mimi.err.log /tmp/mimi-crash.log   # keep it past the restart
   : > ~/.local/state/mimi/mimi.out.log
   : > ~/.local/state/mimi/mimi.err.log
   ```
+
+  A service installed before this behaviour existed keeps appending until
+  `mimi services install` is run again — that is what puts the two environment
+  entries into its plist.
 
 - launchd opens both files when it spawns the daemon and creates no
   directories of its own, so `mimi services install` creates
@@ -183,7 +218,9 @@ Notes on this:
   `Service already up to date` and does nothing when it does not.
 - The Nix modules (`nix/darwin.nix`, `nix/home.nix`) write their own plists,
   which always use `/tmp/mimi.log` and `/tmp/mimi.err.log` regardless of
-  `settings.log_file`.
+  `settings.log_file`. They carry no `MIMI_CAPTURED_*` entries either, so a
+  daemon from one of those modules appends to both files forever and never
+  empties them.
 
 ## Permission prompt keeps appearing
 

--- a/internal/daemon/captured_logs.go
+++ b/internal/daemon/captured_logs.go
@@ -1,0 +1,87 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// The environment entries the installed launchd plist carries the daemon's
+// captured stdout and stderr in.
+//
+// They are set by the plist `mimi services install` renders, and by nothing
+// else. The daemon deliberately does not ask internal/service to derive these
+// paths for it: that package is the install-time surface, and a daemon that
+// derived them itself would truncate files it was never told it owns — every
+// hand-started `mimi start` would empty the previous launchd run's crash log,
+// which is the one artifact the captured streams exist to preserve. Learning
+// them from the environment is what makes "launchd started me" the condition,
+// with no way to get it wrong.
+//
+// internal/service spells these same two names in its plist template. Nothing
+// but the names holds the two sides together, so the test on each side spells
+// the literals and a rename fails a test there.
+const (
+	envCapturedStdout = "MIMI_CAPTURED_STDOUT"
+	envCapturedStderr = "MIMI_CAPTURED_STDERR"
+)
+
+// TruncateCapturedLogs empties the console streams the installed service
+// captures, and reports how many it emptied.
+//
+// launchd opens those two files when it spawns the daemon and appends to them
+// for as long as the machine stays logged in, with no rotation of any kind —
+// and the daemon they exist to diagnose, one crash-looping under KeepAlive, is
+// the one that writes to them fastest and for longest. The daemon cannot rotate
+// files whose descriptors launchd holds, but it can empty them once at startup,
+// which bounds them at one run's output and leaves that run's console output
+// standing alone.
+//
+// It must run before anything is written to those streams, and so before the
+// logger exists — the count and any failure are returned for the caller to log
+// once it does. Running first is also what keeps the truncation safe: the
+// process has not yet written a byte through the descriptors launchd handed it,
+// so emptying the files behind them cannot leave a write landing past a new
+// end of file.
+//
+// A daemon told about no captured streams empties nothing: an entry that is
+// unset or empty is skipped, and so is a file that is not there yet, which is
+// simply a stream nobody has written to. Anything else is reported, and never
+// stops the other stream from being emptied — a console log that goes on
+// growing is worth saying out loud and not worth refusing to start over.
+func TruncateCapturedLogs() (int, error) {
+	var (
+		truncated int
+		failures  []error
+	)
+
+	for _, name := range []string{envCapturedStdout, envCapturedStderr} {
+		path := os.Getenv(name)
+		if path == "" {
+			continue
+		}
+
+		err := os.Truncate(path, 0)
+
+		switch {
+		case err == nil:
+			truncated++
+		case os.IsNotExist(err):
+			// launchd creates the file when it spawns the job, so a missing one
+			// is a stream that has never been written to.
+		default:
+			failures = append(failures, err)
+		}
+	}
+
+	if len(failures) > 0 {
+		return truncated, derrors.Wrapf(
+			errors.Join(failures...),
+			derrors.CodeLoggingFailed,
+			"truncating the captured console logs",
+		)
+	}
+
+	return truncated, nil
+}

--- a/internal/daemon/captured_logs_test.go
+++ b/internal/daemon/captured_logs_test.go
@@ -1,0 +1,218 @@
+package daemon_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/daemon"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// The environment entries the installed launchd plist carries the captured
+// stream paths in, spelled out literally rather than taken from the daemon's
+// own constants. internal/service writes these names into the plist and the
+// daemon reads them back; nothing links the two but the names themselves, so
+// the test on each side spells them and a rename fails one of them.
+const (
+	envCapturedStdout = "MIMI_CAPTURED_STDOUT"
+	envCapturedStderr = "MIMI_CAPTURED_STDERR"
+)
+
+// seedCapturedLog writes a previous run's console output to name in dir and
+// returns its path. Every case needs a file with something in it, because
+// "left alone" and "emptied" are only distinguishable when there was something
+// to lose.
+func seedCapturedLog(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+
+	err := os.WriteFile(path, []byte("output from the previous run\n"), 0o644)
+	if err != nil {
+		t.Fatalf("seeding %s: %v", name, err)
+	}
+
+	return path
+}
+
+// unsetCapturedLogEnv removes both entries from the environment, for the cases
+// that are about a daemon nothing told about a captured stream at all.
+func unsetCapturedLogEnv(t *testing.T) {
+	t.Helper()
+
+	for _, name := range []string{envCapturedStdout, envCapturedStderr} {
+		err := os.Unsetenv(name)
+		if err != nil {
+			t.Fatalf("unsetting %s: %v", name, err)
+		}
+	}
+}
+
+// assertSize fails unless the file at path is exactly want bytes long.
+func assertSize(t *testing.T, path string, want int64) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+
+	if info.Size() != want {
+		t.Errorf("%s is %d bytes, want %d", path, info.Size(), want)
+	}
+}
+
+// TestTruncateCapturedLogs_EmptiesTheStreamsThePlistNames is the behavior the
+// whole mechanism exists for: launchd holds those two files open from spawn and
+// appends to them forever, and the daemon it respawns every ten seconds is the
+// one that writes to them hardest. Truncating once at startup is the only
+// rotation available to a process that does not own the descriptors, and it
+// leaves each run's console output standing alone.
+func TestTruncateCapturedLogs_EmptiesTheStreamsThePlistNames(t *testing.T) {
+	dir := t.TempDir()
+	stdout := seedCapturedLog(t, dir, "mimi.out.log")
+	stderr := seedCapturedLog(t, dir, "mimi.err.log")
+
+	t.Setenv(envCapturedStdout, stdout)
+	t.Setenv(envCapturedStderr, stderr)
+
+	truncated, err := daemon.TruncateCapturedLogs()
+	if err != nil {
+		t.Fatalf("TruncateCapturedLogs() = %v, want nil", err)
+	}
+
+	if truncated != 2 {
+		t.Errorf("TruncateCapturedLogs() truncated %d, want 2", truncated)
+	}
+
+	assertSize(t, stdout, 0)
+	assertSize(t, stderr, 0)
+}
+
+// TestTruncateCapturedLogs_LeavesEverythingAloneWithoutTheEnvironment pins the
+// guard on all of it. A daemon started by hand — `mimi start`, with a terminal
+// on stdout — is told about no captured streams, and must empty nothing: the
+// files beside settings.log_file still hold the previous launchd run's crash
+// log, which is the single artifact this whole mechanism exists to preserve.
+func TestTruncateCapturedLogs_LeavesEverythingAloneWithoutTheEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	stdout := seedCapturedLog(t, dir, "mimi.out.log")
+	stderr := seedCapturedLog(t, dir, "mimi.err.log")
+
+	seeded, err := os.Stat(stdout)
+	if err != nil {
+		t.Fatalf("stat %s: %v", stdout, err)
+	}
+
+	// Set by nothing: the plist is the only thing that sets these, and there is
+	// no plist in front of a hand-started daemon. The Setenv pair is what
+	// registers the restore; the unset is the state under test.
+	t.Setenv(envCapturedStdout, "")
+	t.Setenv(envCapturedStderr, "")
+	unsetCapturedLogEnv(t)
+
+	truncated, err := daemon.TruncateCapturedLogs()
+	if err != nil {
+		t.Fatalf("TruncateCapturedLogs() = %v, want nil", err)
+	}
+
+	if truncated != 0 {
+		t.Errorf("TruncateCapturedLogs() truncated %d, want 0", truncated)
+	}
+
+	assertSize(t, stdout, seeded.Size())
+	assertSize(t, stderr, seeded.Size())
+}
+
+// TestTruncateCapturedLogs_TruncatesOnlyTheStreamsItWasGiven covers the plist
+// that names one stream and not the other. Half an environment is half the
+// work, not none of it and not all of it.
+func TestTruncateCapturedLogs_TruncatesOnlyTheStreamsItWasGiven(t *testing.T) {
+	dir := t.TempDir()
+	stdout := seedCapturedLog(t, dir, "mimi.out.log")
+	stderr := seedCapturedLog(t, dir, "mimi.err.log")
+
+	seeded, err := os.Stat(stderr)
+	if err != nil {
+		t.Fatalf("stat %s: %v", stderr, err)
+	}
+
+	t.Setenv(envCapturedStdout, stdout)
+	t.Setenv(envCapturedStderr, "")
+
+	truncated, err := daemon.TruncateCapturedLogs()
+	if err != nil {
+		t.Fatalf("TruncateCapturedLogs() = %v, want nil", err)
+	}
+
+	if truncated != 1 {
+		t.Errorf("TruncateCapturedLogs() truncated %d, want 1", truncated)
+	}
+
+	assertSize(t, stdout, 0)
+	assertSize(t, stderr, seeded.Size())
+}
+
+// TestTruncateCapturedLogs_IgnoresAStreamThatIsNotThereYet covers the first
+// run after an install: launchd creates both files when it spawns the daemon,
+// so a missing one means nobody has written to it, and there is nothing to
+// empty. That is not a failure to report.
+func TestTruncateCapturedLogs_IgnoresAStreamThatIsNotThereYet(t *testing.T) {
+	dir := t.TempDir()
+	stderr := seedCapturedLog(t, dir, "mimi.err.log")
+
+	t.Setenv(envCapturedStdout, filepath.Join(dir, "never-written.out.log"))
+	t.Setenv(envCapturedStderr, stderr)
+
+	truncated, err := daemon.TruncateCapturedLogs()
+	if err != nil {
+		t.Fatalf("TruncateCapturedLogs() = %v, want nil", err)
+	}
+
+	if truncated != 1 {
+		t.Errorf("TruncateCapturedLogs() truncated %d, want 1", truncated)
+	}
+
+	assertSize(t, stderr, 0)
+}
+
+// TestTruncateCapturedLogs_ReportsAStreamItCouldNotEmpty pins that a stream
+// this cannot touch is said out loud and costs the other one nothing. The
+// daemon starts either way — a console log that keeps growing is worth
+// complaining about and not worth refusing to run over.
+func TestTruncateCapturedLogs_ReportsAStreamItCouldNotEmpty(t *testing.T) {
+	dir := t.TempDir()
+	stderr := seedCapturedLog(t, dir, "mimi.err.log")
+
+	// A directory where a captured stream should be: present, and nothing this
+	// can empty.
+	blocked := filepath.Join(dir, "mimi.out.log")
+
+	err := os.Mkdir(blocked, 0o755)
+	if err != nil {
+		t.Fatalf("seeding blocking directory: %v", err)
+	}
+
+	t.Setenv(envCapturedStdout, blocked)
+	t.Setenv(envCapturedStderr, stderr)
+
+	truncated, err := daemon.TruncateCapturedLogs()
+	if err == nil {
+		t.Fatal("TruncateCapturedLogs() = nil, want the failure it hit")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeLoggingFailed {
+		t.Errorf(
+			"TruncateCapturedLogs() code = %v, want %v",
+			derrors.GetCode(err),
+			derrors.CodeLoggingFailed,
+		)
+	}
+
+	if truncated != 1 {
+		t.Errorf("TruncateCapturedLogs() truncated %d, want the other stream done", truncated)
+	}
+
+	assertSize(t, stderr, 0)
+}

--- a/internal/service/plist.go
+++ b/internal/service/plist.go
@@ -32,6 +32,19 @@ const defaultServicePath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 // plistTemplate is the launchd plist mimi installs, with the binary, config,
 // captured-stream and PATH values left as tokens for renderPlist to fill in.
+//
+// Each captured-stream token appears twice: once as the path launchd writes
+// that stream to, and once as the MIMI_CAPTURED_STDOUT / MIMI_CAPTURED_STDERR
+// environment entry the daemon reads it back out of. One substitution fills
+// both, so the two can never name different files.
+//
+// Those entries are the whole of what tells a daemon that these files exist
+// and are its to truncate once at startup. A daemon started any other way —
+// `mimi start` by hand, with a terminal on stdout — sees neither and truncates
+// nothing. internal/daemon spells the same two names and deliberately does not
+// import this package to learn them: this is the install-time surface, and the
+// daemon is not its consumer. The golden plist test and the daemon's own test
+// each spell the literals, so a rename on either side fails a test there.
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -63,6 +76,10 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <integer>10</integer>
     <key>EnvironmentVariables</key>
     <dict>
+        <key>MIMI_CAPTURED_STDERR</key>
+        <string>MIMI_STDERR_PATH</string>
+        <key>MIMI_CAPTURED_STDOUT</key>
+        <string>MIMI_STDOUT_PATH</string>
         <key>PATH</key>
         <string>MIMI_SERVICE_PATH</string>
     </dict>

--- a/internal/service/plist_test.go
+++ b/internal/service/plist_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+// The settings.log_file the tests in this package render against, and the
+// captured stdout it puts beside that file. Both are written out here in full
+// rather than derived, so a test using them still disagrees with the code if
+// the code changes how one is placed relative to the other.
+const (
+	testLogFile        = "/Users/test/.local/state/mimi/mimi.log"
+	testCapturedStdout = "/Users/test/.local/state/mimi/mimi.out.log"
+)
+
 // wantGoldenPlist is the full plist renderPlist must produce for binPath
 // "/usr/local/bin/mimi", configPath "/Users/test/.config/mimi/config.toml" and
 // logFile "/Users/test/.local/state/mimi/mimi.log" — written out by hand, not
@@ -13,20 +22,25 @@ import (
 // byte-identical output.
 //
 // It inherits from the pre-refactor cmd/mimi/cmd output, changed in exactly
-// one place: issue #99 moved StandardOutPath/StandardErrorPath off the
-// hardcoded /tmp/mimi.log and /tmp/mimi.err.log and onto log_file's directory.
-const wantGoldenPlist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>com.y3owk1n.mimi</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>/usr/local/bin/mimi</string>\n        <string>start</string>\n        <string>--config</string>\n        <string>/Users/test/.config/mimi/config.toml</string>\n    </array>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>StandardOutPath</key>\n    <string>/Users/test/.local/state/mimi/mimi.out.log</string>\n    <key>StandardErrorPath</key>\n    <string>/Users/test/.local/state/mimi/mimi.err.log</string>\n    <key>ProcessType</key>\n    <string>Interactive</string>\n    <key>LimitLoadToSessionType</key>\n    <string>Aqua</string>\n    <key>Nice</key>\n    <integer>-10</integer>\n    <key>ThrottleInterval</key>\n    <integer>10</integer>\n    <key>EnvironmentVariables</key>\n    <dict>\n        <key>PATH</key>\n        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>\n    </dict>\n</dict>\n</plist>"
+// two places: issue #99 moved StandardOutPath/StandardErrorPath off the
+// hardcoded /tmp/mimi.log and /tmp/mimi.err.log and onto log_file's directory,
+// and issue #157 added the two MIMI_CAPTURED_* environment entries the daemon
+// reads those same paths back out of.
+const wantGoldenPlist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>Label</key>\n    <string>com.y3owk1n.mimi</string>\n    <key>ProgramArguments</key>\n    <array>\n        <string>/usr/local/bin/mimi</string>\n        <string>start</string>\n        <string>--config</string>\n        <string>/Users/test/.config/mimi/config.toml</string>\n    </array>\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>StandardOutPath</key>\n    <string>/Users/test/.local/state/mimi/mimi.out.log</string>\n    <key>StandardErrorPath</key>\n    <string>/Users/test/.local/state/mimi/mimi.err.log</string>\n    <key>ProcessType</key>\n    <string>Interactive</string>\n    <key>LimitLoadToSessionType</key>\n    <string>Aqua</string>\n    <key>Nice</key>\n    <integer>-10</integer>\n    <key>ThrottleInterval</key>\n    <integer>10</integer>\n    <key>EnvironmentVariables</key>\n    <dict>\n        <key>MIMI_CAPTURED_STDERR</key>\n        <string>/Users/test/.local/state/mimi/mimi.err.log</string>\n        <key>MIMI_CAPTURED_STDOUT</key>\n        <string>/Users/test/.local/state/mimi/mimi.out.log</string>\n        <key>PATH</key>\n        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>\n    </dict>\n</dict>\n</plist>"
 
 // TestRenderPlist_MatchesTheGoldenOutputByteForByte pins the plist rendered
-// for a config that sets no service_path. The golden bytes are the ones this
-// rendered before settings.service_path existed, so an unset service_path
-// changes nothing about an installed service — including whether `mimi
-// services install` decides the plist on disk needs replacing at all.
+// for a config that sets no service_path: the whole file, byte for byte,
+// written out by hand.
+//
+// Every byte of it reaches an installed service, and only through `mimi
+// services install` — so this is also what decides whether that command finds
+// the plist on disk stale and replaces it. A change here is a change to every
+// installed service on the next install, and has to be made deliberately.
 func TestRenderPlist_MatchesTheGoldenOutputByteForByte(t *testing.T) {
 	got := renderPlist(
 		"/usr/local/bin/mimi",
 		"/Users/test/.config/mimi/config.toml",
-		"/Users/test/.local/state/mimi/mimi.log",
+		testLogFile,
 		"",
 	)
 	if got != wantGoldenPlist {
@@ -69,7 +83,7 @@ func TestRenderPlist_ServicePath(t *testing.T) {
 			got := renderPlist(
 				"/usr/local/bin/mimi",
 				"/Users/test/.config/mimi/config.toml",
-				"/Users/test/.local/state/mimi/mimi.log",
+				testLogFile,
 				testCase.servicePath,
 			)
 
@@ -87,10 +101,17 @@ func TestRenderPlist_ServicePath(t *testing.T) {
 }
 
 // TestRenderPlist_CapturedStreamPaths pins where launchd is told to write the
-// daemon's stdout and stderr for each shape settings.log_file can arrive in.
-// Every expected value is written out literally rather than derived, and no
-// case may name log_file itself: lumberjack rotates that file, so a second
-// writer appending to it would corrupt the rotation.
+// daemon's stdout and stderr for each shape settings.log_file can arrive in,
+// and that the environment entries the daemon reads those paths back out of
+// name the same two files. Every expected value is written out literally rather
+// than derived, and no case may name log_file itself: lumberjack rotates that
+// file, so a second writer appending to it would corrupt the rotation.
+//
+// The environment is the whole of what tells a daemon those files exist and are
+// its to empty at startup — one started by hand has a terminal on stdout, sees
+// neither entry, and truncates nothing. Its names are spelled literally here,
+// because internal/daemon spells the same two literals and nothing else holds
+// the two sides together: a rename has to fail a test on the side that made it.
 func TestRenderPlist_CapturedStreamPaths(t *testing.T) {
 	// The /tmp paths every fallback case expects — the ones the plist
 	// hardcoded before issue #99 — spelled out here rather than read from the
@@ -109,8 +130,8 @@ func TestRenderPlist_CapturedStreamPaths(t *testing.T) {
 	}{
 		{
 			name:       "derived from log_file's directory with distinct names",
-			logFile:    "/Users/test/.local/state/mimi/mimi.log",
-			wantStdout: "/Users/test/.local/state/mimi/mimi.out.log",
+			logFile:    testLogFile,
+			wantStdout: testCapturedStdout,
 			wantStderr: "/Users/test/.local/state/mimi/mimi.err.log",
 		},
 		{
@@ -199,6 +220,22 @@ func TestRenderPlist_CapturedStreamPaths(t *testing.T) {
 					got,
 				)
 			}
+
+			environment := map[string]string{
+				"MIMI_CAPTURED_STDOUT": testCase.wantStdout,
+				"MIMI_CAPTURED_STDERR": testCase.wantStderr,
+			}
+			for key, want := range environment {
+				wantEntry := "<key>" + key + "</key>\n        <string>" + want + "</string>"
+				if !strings.Contains(got, wantEntry) {
+					t.Errorf(
+						"renderPlist(logFile=%q) does not contain %q:\n%s",
+						testCase.logFile,
+						wantEntry,
+						got,
+					)
+				}
+			}
 		})
 	}
 }
@@ -215,7 +252,7 @@ func TestRenderPlist_Table(t *testing.T) {
 			name:        "typical paths",
 			binPath:     "/opt/homebrew/bin/mimi",
 			configPath:  "~/.config/mimi/config.toml",
-			logFile:     "/Users/test/.local/state/mimi/mimi.log",
+			logFile:     testLogFile,
 			servicePath: "/usr/bin:/bin",
 		},
 		{

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -59,6 +59,31 @@ type Status struct {
 	// ever has, when it was killed by a signal rather than exiting, and
 	// whenever launchd's description could not be read.
 	LastExitStatus OptionalInt
+	// CapturedStdout and CapturedStderr are the console streams the installed
+	// plist captures, as that plist names them. Both are zero when there is no
+	// plist of mimi's to read them from — nothing installed, or a plist another
+	// installer wrote.
+	CapturedStdout CapturedLog
+	CapturedStderr CapturedLog
+}
+
+// CapturedLog is one of the daemon's captured console streams: where the
+// installed plist tells launchd to write it, and how much has been written.
+//
+// The size is the fact worth having. Nothing rotates these two files — launchd
+// holds them open and appends — so the daemon empties them once per start, and
+// a size is therefore one run's console output. A large one under a service
+// that keeps exiting is the crash loop this status exists to expose.
+type CapturedLog struct {
+	// Path is where launchd was told to write this stream. Empty when it could
+	// not be read from the installed plist.
+	Path string
+	// Size is how many bytes the file holds. It means nothing unless Present.
+	Size int64
+	// Present reports whether the file is there at all. launchd creates it when
+	// it first spawns the daemon, so an absent one is a service that has never
+	// run — which is not the same answer as a stream that ran and said nothing.
+	Present bool
 }
 
 // InstallOutcome is what an [Service.Install] did. Install is idempotent, so
@@ -228,17 +253,24 @@ func (s *Service) Restart() error {
 }
 
 // Status reports whether the service is currently loaded, and — when it is —
-// the pid it runs under or the status it last exited with.
+// the pid it runs under or the status it last exited with, plus the captured
+// console streams the installed plist names and how large they have grown.
 //
 // Only the loaded answer is guaranteed. Everything past it comes from
 // `launchctl print`, whose output Apple documents nowhere, so anything that
 // goes wrong there degrades to the answer this returned before it asked:
 // loaded, or not. A status command that fails tells a user less than one that
 // says a little less.
+//
+// The captured streams are read whether or not the service is loaded: they are
+// files on disk, and the run that wrote them is over either way — an unloaded
+// service is one of the states in which their contents matter most.
 func (s *Service) Status() Status {
 	ctx := context.Background()
 
 	status := Status{Loaded: s.launcher.list(ctx, Label) == nil}
+	status.CapturedStdout, status.CapturedStderr = installedCapturedLogs()
+
 	if !status.Loaded {
 		return status
 	}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -187,6 +187,11 @@ func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
+			// A home with no plist in it: these cases are about what launchctl
+			// says, and the captured logs are read from the installed plist,
+			// which the machine running the tests must not supply.
+			t.Setenv("HOME", t.TempDir())
+
 			fake := &fakeLauncher{
 				loaded:      testCase.loaded,
 				printOutput: testCase.printOutput,
@@ -213,6 +218,118 @@ func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+// TestService_Status_ReportsTheCapturedLogsTheInstalledPlistNames covers the
+// half of the status that is not launchctl's to answer. The captured console
+// streams are the only place a crash before the logger exists can surface, and
+// how large they have grown is the question a user asks about them — they are
+// truncated once per launchd start, so a big one is a long run and a growing
+// one under a service that keeps exiting is a crash loop.
+//
+// The paths come from the installed plist rather than from settings.log_file,
+// because the plist is what launchd actually loaded: a log_file changed since
+// the last install has moved the config's answer and not the service's, and
+// the size of a file nothing is writing is the one number that must not be
+// reported here.
+func TestService_Status_ReportsTheCapturedLogsTheInstalledPlistNames(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	logDir := filepath.Join(dir, "state", "mimi")
+	logFile := filepath.Join(logDir, "mimi.log")
+
+	fake := &fakeLauncher{}
+	svc := newTestService(fake)
+
+	_, err := svc.Install(testConfigPath, logFile, "")
+	if err != nil {
+		t.Fatalf("Install() = %v, want nil", err)
+	}
+
+	// The console output of a run, as launchd would have appended it. Only
+	// stdout has anything in it: stderr is the file launchd creates at spawn
+	// and a healthy daemon never writes to.
+	stdoutPath := filepath.Join(logDir, "mimi.out.log")
+
+	err = os.WriteFile(stdoutPath, []byte("0123456789"), filePerm)
+	if err != nil {
+		t.Fatalf("seeding captured stdout: %v", err)
+	}
+
+	stderrPath := filepath.Join(logDir, "mimi.err.log")
+
+	err = os.WriteFile(stderrPath, nil, filePerm)
+	if err != nil {
+		t.Fatalf("seeding captured stderr: %v", err)
+	}
+
+	fake.loaded = true
+	fake.printOutput = "\tstate = running\n\tpid = 1478\n"
+
+	status := svc.Status()
+
+	wantStdout := CapturedLog{Path: stdoutPath, Size: 10, Present: true}
+	if status.CapturedStdout != wantStdout {
+		t.Errorf("Status() stdout = %+v, want %+v", status.CapturedStdout, wantStdout)
+	}
+
+	wantStderr := CapturedLog{Path: stderrPath, Size: 0, Present: true}
+	if status.CapturedStderr != wantStderr {
+		t.Errorf("Status() stderr = %+v, want %+v", status.CapturedStderr, wantStderr)
+	}
+}
+
+// TestService_Status_ReportsACapturedLogThatIsNotThereYet separates a stream
+// of zero bytes from one that does not exist. launchd creates both files when
+// it first spawns the daemon, so a missing one is a service that has never
+// run — a different answer from a stream that ran and said nothing.
+func TestService_Status_ReportsACapturedLogThatIsNotThereYet(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	logDir := filepath.Join(dir, "state", "mimi")
+
+	fake := &fakeLauncher{}
+	svc := newTestService(fake)
+
+	_, err := svc.Install(testConfigPath, filepath.Join(logDir, "mimi.log"), "")
+	if err != nil {
+		t.Fatalf("Install() = %v, want nil", err)
+	}
+
+	fake.loaded = true
+
+	status := svc.Status()
+
+	want := CapturedLog{Path: filepath.Join(logDir, "mimi.out.log")}
+	if status.CapturedStdout != want {
+		t.Errorf("Status() stdout = %+v, want %+v", status.CapturedStdout, want)
+	}
+}
+
+// TestService_Status_ReportsNoCapturedLogsWithoutAPlistOfMimisOwn pins the
+// answer when there is nothing to read the paths out of: an uninstalled
+// service, or a plist another installer wrote — home-manager's is a symlink
+// into the Nix store. Guessing where such a service captures its output is
+// exactly the wrong-file-size answer this reads the plist to avoid.
+func TestService_Status_ReportsNoCapturedLogsWithoutAPlistOfMimisOwn(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{loaded: true}
+	svc := newTestService(fake)
+
+	status := svc.Status()
+
+	var none CapturedLog
+	if status.CapturedStdout != none || status.CapturedStderr != none {
+		t.Errorf(
+			"Status() captured logs = %+v / %+v, want neither",
+			status.CapturedStdout,
+			status.CapturedStderr,
+		)
 	}
 }
 
@@ -583,6 +700,83 @@ func TestService_Install_ReplacesAStalePlistAfterServicePathChanges(t *testing.T
 
 	if !strings.Contains(string(content), "<string>"+wantPath+"</string>") {
 		t.Errorf("installed plist does not carry the configured PATH:\n%s", content)
+	}
+}
+
+// TestService_Install_GivesAnOlderServiceTheCapturedStreamEnvironment is how
+// the truncation reaches a machine where mimi was installed before it existed.
+// The daemon learns which files are its to empty from the plist's environment
+// and from nowhere else, so a service still running the plist of an older mimi
+// truncates nothing until that plist is replaced — and replacing it is what an
+// install does when the rendered bytes differ, which they now do.
+func TestService_Install_GivesAnOlderServiceTheCapturedStreamEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	logFile := filepath.Join(dir, "state", "mimi", "mimi.log")
+
+	fake := &fakeLauncher{}
+	svc := newTestService(fake)
+
+	_, err := svc.Install(testConfigPath, logFile, "")
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	plistPath := filepath.Join(dir, "Library", "LaunchAgents", Label+".plist")
+
+	current, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	// The same plist as an older mimi rendered it: identical in every way but
+	// the two entries this change added, so nothing else can explain a replace.
+	stdoutPath := filepath.Join(dir, "state", "mimi", "mimi.out.log")
+	stderrPath := filepath.Join(dir, "state", "mimi", "mimi.err.log")
+	older := strings.NewReplacer(
+		"        <key>MIMI_CAPTURED_STDERR</key>\n        <string>"+stderrPath+"</string>\n", "",
+		"        <key>MIMI_CAPTURED_STDOUT</key>\n        <string>"+stdoutPath+"</string>\n", "",
+	).Replace(string(current))
+
+	if older == string(current) {
+		t.Fatalf("the installed plist carries no captured-stream environment:\n%s", current)
+	}
+
+	err = os.WriteFile(plistPath, []byte(older), filePerm)
+	if err != nil {
+		t.Fatalf("seeding the older plist: %v", err)
+	}
+
+	fake.loaded = true
+	fake.calls = nil
+
+	outcome, err := svc.Install(testConfigPath, logFile, "")
+	if err != nil {
+		t.Fatalf("second Install() = %v, want nil", err)
+	}
+
+	if outcome != InstallOutcomeReplaced {
+		t.Errorf("second Install() outcome = %v, want %v", outcome, InstallOutcomeReplaced)
+	}
+
+	// Replaced and handed back to launchd: an environment written to a plist
+	// launchd is not reading again reaches no daemon.
+	if got := strings.Join(fake.calls, ","); got != wantReloadCalls {
+		t.Errorf("second Install() calls = %v, want [bootout bootstrap]", fake.calls)
+	}
+
+	after, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading the replaced plist: %v", err)
+	}
+
+	if string(after) != string(current) {
+		t.Errorf(
+			"the replaced plist is not the one mimi renders:\ngot\n%s\nwant\n%s",
+			after,
+			current,
+		)
 	}
 }
 

--- a/internal/service/status.go
+++ b/internal/service/status.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"os"
 	"strconv"
 	"strings"
 )
@@ -89,4 +90,72 @@ func parseLeadingInt(value string) OptionalInt {
 	}
 
 	return OptionalInt{Value: parsed, Known: true}
+}
+
+// installedCapturedLogs describes the two console streams the installed plist
+// captures: where it tells launchd to write each, and how large each has grown.
+//
+// The paths come from the plist on disk rather than from settings.log_file,
+// because the plist is what launchd loaded. A log_file changed since the last
+// install has moved the config's answer without moving the service's, and a
+// size reported for a file nothing is writing is worse than no size at all.
+//
+// Every way of not finding them ends the same way: an unreadable plist, one
+// that is not a file mimi could have written — home-manager's is a symlink into
+// the Nix store — and one whose keys this cannot make sense of all leave both
+// paths empty, and the status simply says nothing about them. It is
+// the same bargain the rest of the status makes — degrade the detail, keep the
+// answer.
+func installedCapturedLogs() (CapturedLog, CapturedLog) {
+	installed, err := readInstalledPlist(plistPath())
+	if err != nil {
+		return CapturedLog{}, CapturedLog{}
+	}
+
+	return describeCapturedLog(plistString(installed.content, "StandardOutPath")),
+		describeCapturedLog(plistString(installed.content, "StandardErrorPath"))
+}
+
+// describeCapturedLog sizes one captured stream. A path that is not there is
+// reported as absent rather than as an error: launchd creates the file when it
+// first spawns the daemon, so a missing one is a service that has never run.
+func describeCapturedLog(path string) CapturedLog {
+	if path == "" {
+		return CapturedLog{}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return CapturedLog{Path: path}
+	}
+
+	return CapturedLog{Path: path, Size: info.Size(), Present: true}
+}
+
+// plistString reads the value of the first key of this name in a plist mimi
+// rendered, at whatever depth it sits, and answers "" for anything it cannot
+// find that way.
+//
+// It is deliberately the smallest reader that works on this one file's shape,
+// rather than a plist parser: the file it reads is the one renderPlist writes,
+// pinned byte for byte by a golden test. A key whose next element is not a
+// <string> — or that another key gets in front of — reads as absent, so a plist
+// of some other shape costs the detail rather than inventing one.
+func plistString(content, key string) string {
+	_, after, found := strings.Cut(content, "<key>"+key+"</key>")
+	if !found {
+		return ""
+	}
+
+	between, after, found := strings.Cut(after, "<string>")
+	if !found || strings.Contains(between, "<key>") {
+		return ""
+	}
+
+	value, _, found := strings.Cut(after, "</string>")
+	if !found {
+		return ""
+	}
+
+	return value
 }

--- a/internal/service/status_test.go
+++ b/internal/service/status_test.go
@@ -123,3 +123,83 @@ func TestParseJobReport(t *testing.T) {
 		})
 	}
 }
+
+// TestPlistString covers reading one key's value back out of a plist mimi
+// wrote, and every shape that must read as "no value" rather than as the wrong
+// one. The status prints a file size next to whatever this returns, so a
+// confident wrong path is the failure worth ruling out.
+func TestPlistString(t *testing.T) {
+	// The key the captured stdout path lives under, spelled here rather than
+	// read from the code that reads it.
+	const testStandardOutKey = "StandardOutPath"
+
+	// A plist in the shape renderPlist produces, trimmed to the keys this test
+	// asks about: one string key, one key whose value is not a string at all,
+	// and one that appears inside the environment dict rather than at the top.
+	const plist = `<dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/test/.local/state/mimi/mimi.out.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/bin:/bin</string>
+    </dict>
+</dict>`
+
+	tests := []struct {
+		name    string
+		content string
+		key     string
+		want    string
+	}{
+		{
+			name:    "a key whose value is a string",
+			content: plist,
+			key:     testStandardOutKey,
+			want:    testCapturedStdout,
+		},
+		{
+			name:    "a key that is not there",
+			content: plist,
+			key:     "StandardErrorPath",
+			want:    "",
+		},
+		{
+			// The next thing after this key is another key, so the first
+			// <string> after it belongs to something else entirely.
+			name:    "a key whose value is not a string",
+			content: plist,
+			key:     "RunAtLoad",
+			want:    "",
+		},
+		{
+			name:    "a nested key still reads its own value",
+			content: plist,
+			key:     "PATH",
+			want:    "/usr/bin:/bin",
+		},
+		{
+			name:    "a value that is never closed",
+			content: "<key>StandardOutPath</key>\n    <string>/tmp/mimi.log",
+			key:     testStandardOutKey,
+			want:    "",
+		},
+		{name: "nothing to read at all", content: "", key: testStandardOutKey, want: ""},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := plistString(testCase.content, testCase.key)
+			if got != testCase.want {
+				t.Errorf(
+					"plistString(_, %q) = %q, want %q",
+					testCase.key,
+					got,
+					testCase.want,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR stops the console output captured from a service-installed daemon from
growing without limit. Those two files sit beside `settings.log_file`, launchd
holds them open from spawn and appends to them for as long as you stay logged
in, and nothing rotates them — the rotating log is deliberately a different
file, and no process can rotate a file whose descriptor launchd owns. The case
they exist to capture, a daemon crash-looping under `KeepAlive` every ten
seconds, is the one that fills them fastest.

The installed plist now tells the daemon where those two files are, and a
daemon that finds them there empties both once at startup, before it writes
anything to them. Each file therefore holds the current run's console output
and nothing older. A daemon started any other way — `mimi start` in a terminal
— is told about no captured streams and empties nothing, so running mimi by
hand never destroys the crash log a service left behind. `mimi services status`
now prints each captured stream's path and how large it has grown.

The deliberate limitation: this is truncation, not rotation, so the previous
run's console output is gone once the service restarts. Copy it aside first if
you need to keep it. Services installed by the Nix modules render their own
plists, carry no such environment, and keep appending exactly as before.

## Related Issues

Closes #157

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## User-visible surface

No config key, command, subcommand, flag, or hook variable is added, renamed,
or removed. Two things a user can see do change.

**The installed plist.** `mimi services install` renders two more entries in
`EnvironmentVariables`, alongside the `PATH` entry `settings.service_path`
fills:

```diff
     <key>EnvironmentVariables</key>
     <dict>
+        <key>MIMI_CAPTURED_STDERR</key>
+        <string>/Users/me/.local/state/mimi/mimi.err.log</string>
+        <key>MIMI_CAPTURED_STDOUT</key>
+        <string>/Users/me/.local/state/mimi/mimi.out.log</string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
```

Both values are the `StandardOutPath` / `StandardErrorPath` the plist already
carried, from the same substitution, so they cannot name a different file. They
are the only thing that tells a daemon those files are its to empty. Because
the rendered bytes now differ from the plist on disk, the first
`mimi services install` after this change reports
`Service plist updated and service reloaded` on a machine that was previously
up to date, and the service is reloaded once. That is how an existing install
picks the behaviour up; nothing else does.

Since the daemon reads these back through its environment, they are also
inherited by every hook command it runs — visible to a hook that dumps its
environment.

**`mimi services status` output.** Before:

```
$ mimi services status
Service loaded and running (pid 1478)
```

After:

```
$ mimi services status
Service loaded and running (pid 1478)
Captured stdout: /Users/me/.local/state/mimi/mimi.out.log (2.0 KB)
Captured stderr: /Users/me/.local/state/mimi/mimi.err.log (not created yet)
```

The first line is unchanged in every case it could print before — `Service
loaded and running (pid N)`, `Service loaded but not running (last exit status
N)`, `Service loaded`, `Service not loaded`. The captured-stream lines are
added under it, one per stream, and only for a stream the installed plist
names: with nothing installed, or with a plist mimi did not write (home-manager
installs a symlink into the Nix store), the output is exactly what it was.

## Potentially breaking

Potentially breaking for a script that consumes the whole of
`mimi services status` rather than its first line. Anything matching on the
first line, or grepping for `Service loaded`/`not loaded`, keeps working
unchanged; anything comparing the command's entire output against a fixed
string now sees up to two extra lines. Exit codes are unchanged. The fix is to
read only the first line (`mimi services status | head -1`).

Not breaking for config files, hooks, or command invocations — none of those
surfaces moved.

## Additional Context

- The daemon deliberately does not ask the install-time module where the
  captured streams are, even though that code could tell it. If it derived the
  paths itself, every hand-started `mimi start` would empty the files too, and
  the crash log from the previous launchd run — the artifact this exists to
  preserve — would be the thing destroyed by looking into it. Learning them
  from the environment makes "launchd started me" the condition, with no way to
  get it wrong. The two environment names are therefore spelled in both
  packages rather than shared through a third; a test on each side spells the
  literals, so a rename fails a test on the side that made it.
- The truncation runs as the first statement of `mimi start`, before the
  config-onboarding alert, before anything is printed, and before the logger
  exists. Its outcome is logged once the logger is up. Running first is also
  what keeps it safe: the process has not yet written through the descriptors
  launchd handed it, so emptying the files cannot leave a write landing past a
  new end of file. That ordering is currently held by a comment — nothing tests
  it, because starting the daemon in a test starts observers and the tray.
- `mimi services status` reads the paths out of the installed plist rather than
  deriving them from `settings.log_file`. The plist is what launchd actually
  loaded, so a `log_file` changed since the last install cannot make the
  command report the size of a file nothing is writing. The reader is a small
  scan for one key's `<string>` value, not a plist parser; anything it cannot
  make sense of costs the two lines rather than inventing a path.
- The plist renderer kept its positional parameters. #156 noted a params struct
  would be right once more values arrived; the captured-stream paths are
  derived from the `log_file` it already takes, so no new parameter arrived and
  the refactor would have been churn in this PR.
- Nix module plists are untouched, so a Nix-installed daemon behaves exactly as
  before. `docs/TROUBLESHOOTING.md` says so.
