### PR TITLE
fix(service,cli): stop reading a launchctl that cannot run as a service that is not loaded

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -9,6 +9,12 @@ import (
 	"github.com/y3owk1n/mimi/internal/service"
 )
 
+// unknownStateLine is what a status prints when launchctl could not be run at
+// all, and so could not be asked whether the service is loaded. It names
+// launchctl because that, and not the service, is what has to be fixed before
+// any of these commands can say anything.
+const unknownStateLine = "Service state unknown: launchctl could not be run"
+
 // defaultService is what the services commands run on: there is one launchd
 // service mimi manages on this machine.
 //
@@ -218,11 +224,31 @@ func formatStatus(status service.Status) string {
 
 // loadedLine is the first line of a status: whether the service is loaded, and
 // the one number that says whether it is up.
+//
+// Whether it is loaded has a third answer, and it gets a line of its own rather
+// than being folded into either of the other two. "Service not loaded" over a
+// service nobody could ask about is the reading this command used to print, and
+// it is the one that sends a user off to reinstall something that may be
+// running perfectly well.
 func loadedLine(status service.Status) string {
-	if !status.Loaded {
+	switch status.State {
+	case service.LoadStateLoaded:
+		return runningLine(status)
+	case service.LoadStateNotLoaded:
 		return "Service not loaded"
+	case service.LoadStateUnknown:
+		return unknownStateLine
+	default:
+		// A state added later with no line of its own. Saying nothing is known
+		// is true of every state this cannot name, and it is the only one of
+		// these lines that is safe over a service whose state was never read.
+		return unknownStateLine
 	}
+}
 
+// runningLine is the loaded half of that first line: launchd holds the job, and
+// the one number available says whether it is actually up.
+func runningLine(status service.Status) string {
 	switch {
 	case status.PID.Known:
 		return fmt.Sprintf("Service loaded and running (pid %d)", status.PID.Value)

--- a/cmd/mimi/cmd/services_test.go
+++ b/cmd/mimi/cmd/services_test.go
@@ -128,15 +128,15 @@ func TestFormatStatus(t *testing.T) {
 		{
 			name: "loaded and running",
 			status: service.Status{
-				Loaded: true,
-				PID:    service.OptionalInt{Value: 1478, Known: true},
+				State: service.LoadStateLoaded,
+				PID:   service.OptionalInt{Value: 1478, Known: true},
 			},
 			want: "Service loaded and running (pid 1478)",
 		},
 		{
 			name: "loaded but respawning after a crash",
 			status: service.Status{
-				Loaded:         true,
+				State:          service.LoadStateLoaded,
 				LastExitStatus: service.OptionalInt{Value: 1, Known: true},
 			},
 			want: "Service loaded but not running (last exit status 1)",
@@ -146,7 +146,7 @@ func TestFormatStatus(t *testing.T) {
 			// back: the number is what separates it from a crash.
 			name: "loaded, exited cleanly",
 			status: service.Status{
-				Loaded:         true,
+				State:          service.LoadStateLoaded,
 				LastExitStatus: service.OptionalInt{Value: 0, Known: true},
 			},
 			want: "Service loaded but not running (last exit status 0)",
@@ -156,7 +156,7 @@ func TestFormatStatus(t *testing.T) {
 			// was restarted. The pid is the fact worth printing.
 			name: "loaded and running, having exited before",
 			status: service.Status{
-				Loaded:         true,
+				State:          service.LoadStateLoaded,
 				PID:            service.OptionalInt{Value: 1478, Known: true},
 				LastExitStatus: service.OptionalInt{Value: 1, Known: true},
 			},
@@ -166,10 +166,38 @@ func TestFormatStatus(t *testing.T) {
 			// launchd's description could not be read, so the command falls
 			// back to everything it has ever said.
 			name:   "loaded, with nothing else known",
-			status: service.Status{Loaded: true},
+			status: service.Status{State: service.LoadStateLoaded},
 			want:   "Service loaded",
 		},
-		{name: "not loaded", status: service.Status{Loaded: false}, want: "Service not loaded"},
+		{
+			name:   "not loaded",
+			status: service.Status{State: service.LoadStateNotLoaded},
+			want:   "Service not loaded",
+		},
+		{
+			// The state that used to print as "Service not loaded": launchctl
+			// could not be run, so nothing here knows whether the service is
+			// up. Saying so names the thing to fix, where the old line sent a
+			// user to reinstall a service that may be running fine.
+			name:   "launchctl could not be asked",
+			status: service.Status{State: service.LoadStateUnknown},
+			want:   "Service state unknown: launchctl could not be run",
+		},
+		{
+			// The captured streams are files on disk, so they are still worth
+			// printing under a load state nobody could read.
+			name: "launchctl could not be asked, with a captured stream",
+			status: service.Status{
+				State: service.LoadStateUnknown,
+				CapturedStderr: service.CapturedLog{
+					Path:    "/tmp/mimi.err.log",
+					Size:    12,
+					Present: true,
+				},
+			},
+			want: "Service state unknown: launchctl could not be run\n" +
+				"Captured stderr: /tmp/mimi.err.log (12 B)",
+		},
 		{
 			// Nothing rotates the captured streams, so the daemon empties them
 			// once per start and a size is one run's console output. Printing
@@ -177,8 +205,8 @@ func TestFormatStatus(t *testing.T) {
 			// something a user can act on without going looking first.
 			name: "loaded and running, with both captured streams",
 			status: service.Status{
-				Loaded: true,
-				PID:    service.OptionalInt{Value: 1478, Known: true},
+				State: service.LoadStateLoaded,
+				PID:   service.OptionalInt{Value: 1478, Known: true},
 				CapturedStdout: service.CapturedLog{
 					Path:    "/Users/test/.local/state/mimi/mimi.out.log",
 					Size:    2048,
@@ -200,7 +228,7 @@ func TestFormatStatus(t *testing.T) {
 			// from an empty one, and said differently.
 			name: "loaded, with a captured stream that does not exist yet",
 			status: service.Status{
-				Loaded: true,
+				State: service.LoadStateLoaded,
 				CapturedStdout: service.CapturedLog{
 					Path: "/Users/test/.local/state/mimi/mimi.out.log",
 				},
@@ -213,6 +241,7 @@ func TestFormatStatus(t *testing.T) {
 			// service is one of the states in which their contents matter most.
 			name: "not loaded, with the plist still naming its captured streams",
 			status: service.Status{
+				State: service.LoadStateNotLoaded,
 				CapturedStderr: service.CapturedLog{
 					Path:    "/tmp/mimi.err.log",
 					Size:    1288490189,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -214,7 +214,9 @@ actually be gone before handing launchd the new one: `launchctl bootout`
 returns as soon as launchd accepts the request, not once the daemon has
 finished exiting, and a load fired into that window fails. The wait is bounded
 at five seconds, after which the install fails with the old plist untouched —
-stop whatever is holding the service and run it again.
+stop whatever is holding the service and run it again. It ends the same way,
+without waiting out the bound, if `launchctl` stops answering while it waits:
+an unload nothing can confirm is not an unload.
 
 A load that fails for any other reason leaves the new plist on disk, so the
 config change is already made and only the load is missing; that error says so,
@@ -226,6 +228,12 @@ home-manager installs — or a loaded `com.y3owk1n.mimi` with no plist of mimi's
 behind it. Both errors name nix-darwin and home-manager, because the fix is in
 their configuration.
 
+It also refuses when `launchctl` itself cannot be run at all — missing from
+`PATH`, or unable to be spawned. Both of the checks above
+rest on knowing whether the service is loaded, so an install that guessed would
+be loading a plist over a service that may well be up. Nothing is written; fix
+`launchctl` and run it again.
+
 ### `mimi services uninstall`
 
 Remove the launchd agent.
@@ -235,6 +243,12 @@ nothing to unload, and the leftover plist is removed. When a loaded service
 cannot be unloaded, the plist is left in place and the command fails, because a
 service that keeps running until logout with no plist behind it is one nothing
 can uninstall any more. Fix what blocked the unload and run it again.
+
+Forgiving a failed unload takes knowing there was nothing to unload. If
+`launchctl` could not be asked whether the service was loaded, an unload that
+then fails is reported as a failure and the plist is kept — the same as for a
+service known to be loaded. An unload that succeeds is unaffected: it did the
+job either way, and the uninstall finishes.
 
 ### `mimi services start` / `stop` / `restart` / `status`
 
@@ -249,7 +263,13 @@ Service loaded and running (pid 1478)
 Service loaded but not running (last exit status 1)
 Service loaded
 Service not loaded
+Service state unknown: launchctl could not be run
 ```
+
+The last line is not the same as `Service not loaded`: it means `launchctl`
+itself could not be run — missing from `PATH`, or unable to be spawned — so
+nothing here knows whether the service is up. The captured stream lines below it
+are still printed, since those are files on disk.
 
 The bare `Service loaded` is the fallback, printed whenever neither number is
 available — the daemon has never run, it was killed by a signal rather than

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -126,6 +126,7 @@ relaunched forever and stays loaded the whole time.
 | `Service loaded but not running (last exit status 1)` | launchd is respawning it. A non-zero status that stays put is a crash loop — the captured stderr below says why.             |
 | `Service loaded`                                      | Neither number was available: the daemon has never run, it was killed by a signal rather than exiting, or launchd's description of the job could not be read. That output is undocumented, so an unreadable one costs the detail, never the answer. |
 | `Service not loaded`                                  | No service installed, or it was unloaded.                                                                                   |
+| `Service state unknown: launchctl could not be run`   | `launchctl` could not be run at all: missing from `PATH`, or unable to be spawned. Nothing was learned about the service — it may well be running. `mimi services install` refuses to run at all in this state, and `uninstall` stops forgiving an unload that fails. |
 
 `launchctl print gui/$(id -u)/com.y3owk1n.mimi` is the same description mimi
 reads, in full, when a bare `Service loaded` leaves a question open.

--- a/internal/service/launcher.go
+++ b/internal/service/launcher.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 )
 
@@ -9,9 +10,12 @@ import (
 // implementation shells out; tests fake it so install/uninstall/start/stop/
 // status can be exercised without a real launchctl underneath them.
 type launcher interface {
-	// list reports whether label is currently loaded. Every caller here only
-	// cares whether it succeeded, so its stdout is never surfaced.
-	list(ctx context.Context, label string) error
+	// list reports whether label is currently loaded, and separately whether
+	// it could be asked at all. Its stdout is never surfaced — the answer is
+	// in the exit status — but a launchctl that never ran is not an answer:
+	// only an error returns one, and a false with no error means launchctl
+	// ran and did not find the job.
+	list(ctx context.Context, label string) (bool, error)
 	// printJob runs `launchctl print` against target (e.g.
 	// "gui/501/com.y3owk1n.mimi") and returns what it said. Alone among these
 	// calls, its stdout is the reason for making it: that text is where a
@@ -30,8 +34,34 @@ type launcher interface {
 // execLauncher is the launcher backed by the real launchctl binary on PATH.
 type execLauncher struct{}
 
-func (execLauncher) list(ctx context.Context, label string) error {
-	return exec.CommandContext(ctx, "launchctl", "list", label).Run()
+// list runs `launchctl list label`, whose exit status is the answer: zero for
+// a job launchd holds, non-zero for one it does not.
+//
+// Only a non-zero exit says that, though. Everything else Run reports — a
+// launchctl that is not on PATH, one that could not be spawned — is the
+// command failing to ask rather than launchd answering no, and the two have to
+// leave here as different things. *exec.ExitError is what tells them apart: it
+// is returned only once the process has run and exited.
+//
+// The line is drawn there, and not at the exit status, on purpose. launchctl
+// answers an absent job with 113 and an unreachable domain with 112, and
+// neither number is documented or promised; reading a job as present because
+// this one did not recognize its exit code would refuse installs on a machine
+// with nothing wrong with it. So a launchctl that ran and failed for a reason
+// of its own still reads as "job absent" here — the same answer it gave
+// before, for the one case a process exit cannot separate.
+func (execLauncher) list(ctx context.Context, label string) (bool, error) {
+	err := exec.CommandContext(ctx, "launchctl", "list", label).Run()
+	if err == nil {
+		return true, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return false, nil
+	}
+
+	return false, err
 }
 
 func (execLauncher) printJob(ctx context.Context, target string) (string, error) {

--- a/internal/service/launcher_integration_test.go
+++ b/internal/service/launcher_integration_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+//nolint:testpackage // execLauncher is unexported; the seam under test is intentionally internal.
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+// TestExecLauncher_List_ReportsAnAbsentJob is the other half of
+// [TestExecLauncher_List_ReportsALaunchctlThatCouldNotRun], and it takes the
+// real launchctl: only launchd can produce the exit status that means "no such
+// job", which this must read as an answer rather than as a failure to ask.
+func TestExecLauncher_List_ReportsAnAbsentJob(t *testing.T) {
+	// A label no launchd domain can be holding, rather than mimi's own: the
+	// machine running this may well have mimi installed.
+	loaded, err := execLauncher{}.list(
+		context.Background(),
+		Label+".test-label-that-is-not-installed",
+	)
+	if err != nil {
+		t.Fatalf("list() = %v, want a launchctl that ran and said no", err)
+	}
+
+	if loaded {
+		t.Error("list() reported a label nothing could have loaded as loaded")
+	}
+}

--- a/internal/service/launcher_test.go
+++ b/internal/service/launcher_test.go
@@ -1,0 +1,29 @@
+//nolint:testpackage // execLauncher is unexported; the seam under test is intentionally internal.
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+// TestExecLauncher_List_ReportsALaunchctlThatCouldNotRun covers half of the
+// distinction the rest of this package is built on, in the one place it is
+// actually drawn: everywhere else a fake launcher supplies the three states
+// directly, and here a failed `launchctl list` has to be read as two different
+// things. The other half — launchctl running and reporting no such job — needs
+// a real launchctl, and lives in the integration tier.
+func TestExecLauncher_List_ReportsALaunchctlThatCouldNotRun(t *testing.T) {
+	// No PATH, so there is no launchctl to run and nothing ever asks launchd
+	// anything. Answering "not loaded" here is the bug this whole change is
+	// about.
+	t.Setenv("PATH", "")
+
+	loaded, err := execLauncher{}.list(context.Background(), Label)
+	if err == nil {
+		t.Fatal("list() = nil, want the failure to run launchctl at all")
+	}
+
+	if loaded {
+		t.Error("list() reported a job loaded on a launchctl that never ran")
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -40,17 +40,41 @@ const (
 // the fix is always in their configuration and never in mimi.
 const foreignInstallAdvice = "check for existing installations (e.g., nix-darwin, home-manager) and uninstall them first"
 
+// LoadState is what asking launchd whether the service is loaded produced.
+//
+// It exists because that question has three answers and not two. `launchctl
+// list` exits non-zero both for a job launchd does not hold and for a
+// launchctl that could not run at all, and reading the second as the first is
+// how a service that is still up gets treated as gone.
+type LoadState int
+
+// These count from zero, where [InstallOutcome] counts from one, and the zero
+// value is why: a load state nobody set must not read as the service being
+// gone. Every caller here does something safe with "I do not know" and
+// something destructive with a wrong "no".
+const (
+	// LoadStateUnknown is launchctl never having run: not on PATH, or unable
+	// to be spawned.
+	LoadStateUnknown LoadState = iota
+	// LoadStateLoaded is a job launchd currently holds.
+	LoadStateLoaded
+	// LoadStateNotLoaded is launchctl running and reporting no such job.
+	LoadStateNotLoaded
+)
+
 // Status is what checking the launchd service reports: a typed result a
 // caller can act on, in place of a formatted string only a human can read.
 //
-// Loaded is the only field always answered. The installed plist sets KeepAlive
-// with a ten second ThrottleInterval, so a daemon that crashes at startup is
-// relaunched forever and stays as loaded as a healthy one — the other two
-// fields are what tell them apart, and both are optional because launchd's own
-// description of the job is undocumented text that may not carry them.
+// State is the only field always answered, and even it may be
+// [LoadStateUnknown]. The installed plist sets KeepAlive with a ten second
+// ThrottleInterval, so a daemon that crashes at startup is relaunched forever
+// and stays as loaded as a healthy one — the other two fields are what tell
+// them apart, and both are optional because launchd's own description of the
+// job is undocumented text that may not carry them.
 type Status struct {
-	// Loaded reports whether launchctl currently has the service loaded.
-	Loaded bool
+	// State is what launchctl said when asked whether the service is loaded,
+	// including its having been unable to say.
+	State LoadState
 	// PID is the process id of the running daemon. It is unknown whenever the
 	// service is not loaded, is not currently running, or launchd's
 	// description could not be read.
@@ -138,10 +162,23 @@ func New() *Service {
 // the plist has always carried. It is baked in here and nowhere else, which is
 // what makes it reinstall-only
 // (docs/adr/0003-a-setting-the-daemon-never-reads-is-reinstall-only.md).
+//
+// It refuses outright when launchctl cannot say whether the service is loaded.
+// That answer is what both of its safety checks rest on — whether this label
+// already belongs to another installer, and whether the running job has to be
+// unloaded before launchd will read a new plist — and an install that assumed
+// "not loaded" would bootstrap over a service that may well be up. Refusing
+// costs nothing that a re-run does not recover: it happens before anything is
+// written, and install is idempotent.
 func (s *Service) Install(configPath, logFile, servicePath string) (InstallOutcome, error) {
 	ctx := context.Background()
 
-	loaded := s.launcher.list(ctx, Label) == nil
+	state, err := s.loadState(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	loaded := state == LoadStateLoaded
 	expandedPlist := plistPath()
 
 	installed, err := readInstalledPlist(expandedPlist)
@@ -197,6 +234,11 @@ func (s *Service) Install(configPath, logFile, servicePath string) (InstallOutco
 // still running, and it keeps running until logout. Removing its plist there
 // would take away the only thing an uninstall can still act on, so the file
 // stays and the failure is returned for the caller to retry.
+//
+// Tolerating that failure takes a positive answer that there was nothing to
+// unload, not merely the absence of one. A launchctl that could not run leaves
+// the same question open as a loaded service does, and the safe reading of an
+// open question here is the one that keeps the plist.
 func (s *Service) Uninstall() error {
 	ctx := context.Background()
 
@@ -209,10 +251,25 @@ func (s *Service) Uninstall() error {
 	// makes this uninstall report a failure the retry will not see again.
 	// Sampling after would be worse: the bootout's own success is what empties
 	// it, so every unload would look like it had nothing to unload.
-	loaded := s.launcher.list(ctx, Label) == nil
+	//
+	// Why it could not be sampled is deliberately not returned: the bootout
+	// that follows may well succeed, and an uninstall that worked has nothing
+	// to report. It changes what a failure says, though — "unloading failed,
+	// try again" is the wrong advice when what is broken is the launchctl
+	// both halves of this run through.
+	state, _ := s.loadState(ctx)
 
 	err = s.launcher.bootout(ctx, domain+"/"+Label)
-	if err != nil && loaded {
+	if err != nil && state == LoadStateUnknown {
+		return derrors.Wrapf(
+			err,
+			derrors.CodeServiceFailed,
+			"unloading service; launchctl could not say whether it was loaded, "+
+				"so the plist is kept and this failure stands",
+		)
+	}
+
+	if err != nil && state == LoadStateLoaded {
 		return derrors.Wrapf(err, derrors.CodeServiceFailed, "unloading service")
 	}
 
@@ -256,11 +313,14 @@ func (s *Service) Restart() error {
 // the pid it runs under or the status it last exited with, plus the captured
 // console streams the installed plist names and how large they have grown.
 //
-// Only the loaded answer is guaranteed. Everything past it comes from
-// `launchctl print`, whose output Apple documents nowhere, so anything that
-// goes wrong there degrades to the answer this returned before it asked:
-// loaded, or not. A status command that fails tells a user less than one that
-// says a little less.
+// Nothing here is guaranteed, and the load state least of all: it is the one
+// thing this always reports, and [LoadStateUnknown] is one of the things it can
+// report. That is the same bargain the rest of the status makes — everything
+// past the load state comes from `launchctl print`, whose output Apple
+// documents nowhere, so anything that goes wrong there degrades to the answer
+// this returned before it asked. A status command that fails tells a user less
+// than one that says a little less, and that holds for a launchctl that could
+// not run too: unknown is a thing to report, not a reason to report nothing.
 //
 // The captured streams are read whether or not the service is loaded: they are
 // files on disk, and the run that wrote them is over either way — an unloaded
@@ -268,10 +328,15 @@ func (s *Service) Restart() error {
 func (s *Service) Status() Status {
 	ctx := context.Background()
 
-	status := Status{Loaded: s.launcher.list(ctx, Label) == nil}
+	// The reason launchctl could not answer is not carried out of here: this
+	// returns no error by design, and [LoadStateUnknown] is already the whole
+	// of what a caller can do about it.
+	state, _ := s.loadState(ctx)
+
+	status := Status{State: state}
 	status.CapturedStdout, status.CapturedStderr = installedCapturedLogs()
 
-	if !status.Loaded {
+	if status.State != LoadStateLoaded {
 		return status
 	}
 
@@ -290,6 +355,37 @@ func (s *Service) Status() Status {
 	status.LastExitStatus = report.lastExitStatus
 
 	return status
+}
+
+// loadState asks launchd whether the service is loaded, and is the only place
+// in this package that asks.
+//
+// Everything that reads it — install, uninstall, status, and the wait between
+// an unload and the load after it — used to take a failed `launchctl list` for
+// a job that is not there. They want different things from the third state, so
+// what they share is this: one call that names it, and no caller left able to
+// miss it.
+//
+// The error is returned alongside because it is the whole of what
+// [LoadStateUnknown] means, and it is non-nil exactly then. A caller that
+// refuses to act without an answer returns it and says why launchctl could not
+// give one; a caller that only needs to know whether it has one reads the
+// state and lets the error go.
+func (s *Service) loadState(ctx context.Context) (LoadState, error) {
+	loaded, err := s.launcher.list(ctx, Label)
+	if err != nil {
+		return LoadStateUnknown, derrors.Wrapf(
+			err,
+			derrors.CodeServiceFailed,
+			"asking launchctl whether the service is loaded",
+		)
+	}
+
+	if loaded {
+		return LoadStateLoaded, nil
+	}
+
+	return LoadStateNotLoaded, nil
 }
 
 // apply makes the installed service be content: it unloads whatever is
@@ -366,16 +462,29 @@ func (s *Service) apply(
 // "Operation now in progress" — a real failure, over a service that was only
 // slow. Waiting here is what turns the common case of a daemon taking a
 // moment back into an install that simply works.
+//
+// Only launchctl saying the job is gone ends the wait. A launchctl that cannot
+// run says nothing about the job, and taking that for the job being gone would
+// hand the bootstrap straight back into the window this exists to close — so
+// it gives up instead, and says why. Waiting out the rest of the bound would
+// only spend the timeout to reach the same place with a vaguer reason: the
+// answer failed to arrive, and it is not the daemon that is slow.
 func (s *Service) waitForUnload(ctx context.Context) error {
 	for attempt := range unloadPollAttempts {
 		if attempt > 0 {
 			s.pause(unloadPollInterval)
 		}
 
-		// Same reading of a failed list as everywhere else here: launchctl
-		// could not find the job, so it is gone.
-		loaded := s.launcher.list(ctx, Label) == nil
-		if !loaded {
+		state, err := s.loadState(ctx)
+		if err != nil {
+			return derrors.Wrapf(
+				err,
+				derrors.CodeServiceFailed,
+				"waiting for the previous service to unload",
+			)
+		}
+
+		if state == LoadStateNotLoaded {
 			return nil
 		}
 	}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -23,11 +23,29 @@ const testConfigPath = "/Users/test/.config/mimi/config.toml"
 // the job is loaded again, and it cannot while the old one is loaded.
 const wantReloadCalls = "bootout,bootstrap"
 
+// wantUnloadOnlyCalls is the launchctl sequence of an install that unloaded
+// the old service and then stopped, whatever stopped it: nothing was written,
+// so there was nothing to bootstrap and the old plist is still the one on
+// disk.
+const wantUnloadOnlyCalls = "bootout"
+
 // fakeLauncher is a launcher made of plain values: every call it sees lands
 // in a field a test can assert against, and every call it returns is a field
 // a test can set up in advance.
 type fakeLauncher struct {
 	loaded bool
+
+	// listErr is launchctl not running at all — missing from PATH, or unable
+	// to reach the domain. It is the state a launcher could not express
+	// before: an exit status says whether the job is there, and this says
+	// there is no exit status to read. Set, it outranks loaded, because a
+	// launchctl that never ran cannot have found anything.
+	listErr error
+	// listErrAfterBootout is the same thing arriving mid-install: launchctl
+	// answered the question install opens with, and stops answering once the
+	// bootout has gone in. It is the only way to reach the unload wait with
+	// no answer available to it.
+	listErrAfterBootout error
 
 	// unloadLag is how many launchctl list calls after a successful bootout
 	// still report the job loaded. A real bootout returns once launchd has
@@ -65,9 +83,17 @@ type fakeLauncher struct {
 	printedFor  string
 }
 
-func (f *fakeLauncher) list(_ context.Context, _ string) error {
+func (f *fakeLauncher) list(_ context.Context, _ string) (bool, error) {
+	if f.listErr != nil {
+		return false, f.listErr
+	}
+
+	if f.listErrAfterBootout != nil && f.booted {
+		return false, f.listErrAfterBootout
+	}
+
 	if !f.loaded {
-		return derrors.New(derrors.CodeServiceFailed, "not loaded")
+		return false, nil
 	}
 
 	// A job on its way out is still a loaded job to launchctl: each list
@@ -80,7 +106,7 @@ func (f *fakeLauncher) list(_ context.Context, _ string) error {
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 func (f *fakeLauncher) printJob(_ context.Context, target string) (string, error) {
@@ -145,6 +171,7 @@ func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
 	tests := []struct {
 		name        string
 		loaded      bool
+		listErr     error
 		printOutput string
 		printErr    error
 		want        Status
@@ -153,13 +180,16 @@ func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
 			name:        "loaded and running",
 			loaded:      true,
 			printOutput: "\tstate = running\n\tpid = 1478\n\tlast exit code = (never exited)\n",
-			want:        Status{Loaded: true, PID: OptionalInt{Value: 1478, Known: true}},
+			want:        Status{State: LoadStateLoaded, PID: OptionalInt{Value: 1478, Known: true}},
 		},
 		{
 			name:        "loaded but respawning after a crash",
 			loaded:      true,
 			printOutput: "\tstate = spawn scheduled\n\tlast exit code = 1\n",
-			want:        Status{Loaded: true, LastExitStatus: OptionalInt{Value: 1, Known: true}},
+			want: Status{
+				State:          LoadStateLoaded,
+				LastExitStatus: OptionalInt{Value: 1, Known: true},
+			},
 		},
 		{
 			// launchctl print is undocumented text with no promise behind it,
@@ -168,20 +198,30 @@ func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
 			name:        "loaded, with output nothing can be read from",
 			loaded:      true,
 			printOutput: "some future launchctl saying something else entirely",
-			want:        Status{Loaded: true},
+			want:        Status{State: LoadStateLoaded},
 		},
 		{
 			name:     "loaded, with launchctl print failing outright",
 			loaded:   true,
 			printErr: derrors.New(derrors.CodeServiceFailed, "no such process"),
-			want:     Status{Loaded: true},
+			want:     Status{State: LoadStateLoaded},
 		},
 		{
 			// Nothing to describe, so nothing is asked.
 			name:        "not loaded",
 			loaded:      false,
 			printOutput: "\tpid = 1478\n",
-			want:        Status{Loaded: false},
+			want:        Status{State: LoadStateNotLoaded},
+		},
+		{
+			// The one thing a status must not do is answer a question it did
+			// not get an answer to. launchctl never ran, so the service is
+			// neither loaded nor not loaded here — it is unknown, and it says
+			// so rather than reporting the shape of a service that is gone.
+			name:        "launchctl could not say",
+			listErr:     errLaunchctlMissing,
+			printOutput: "\tpid = 1478\n",
+			want:        Status{State: LoadStateUnknown},
 		},
 	}
 
@@ -194,6 +234,7 @@ func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
 
 			fake := &fakeLauncher{
 				loaded:      testCase.loaded,
+				listErr:     testCase.listErr,
 				printOutput: testCase.printOutput,
 				printErr:    testCase.printErr,
 			}
@@ -404,6 +445,11 @@ var (
 // failure arrives in.
 var errBootstrapInProgress = errors.New("operation now in progress")
 
+// errLaunchctlMissing is launchctl failing to run at all, in the shape exec
+// reports it: not a job launchd denies having, but a question that never
+// reached launchd.
+var errLaunchctlMissing = errors.New(`exec: "launchctl": executable file not found in $PATH`)
+
 // TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService pins
 // the difference [Service.Uninstall] draws between the two reasons a bootout
 // fails, which mean opposite things: see its doc comment. Every case expects
@@ -413,9 +459,14 @@ func TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService(t *tes
 	tests := []struct {
 		name       string
 		loaded     bool
+		listErr    error
 		bootoutErr error
 		wantErr    bool
-		wantPlist  bool
+		// wantErrSays is a phrase the failure has to carry, for the cases
+		// where why the uninstall failed is as much of the answer as that it
+		// did.
+		wantErrSays string
+		wantPlist   bool
 	}{
 		{
 			name:       "not loaded, so a bootout that fails failed at nothing",
@@ -423,6 +474,29 @@ func TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService(t *tes
 			bootoutErr: errBootoutNotFound,
 			wantErr:    false,
 			wantPlist:  false,
+		},
+		{
+			// The tolerance is earned by knowing there was nothing to unload.
+			// Without that, a bootout failure is a service that may well still
+			// be running, and removing its plist would take away the only
+			// thing a later uninstall could act on.
+			name:       "launchctl could not say, and the bootout failed",
+			listErr:    errLaunchctlMissing,
+			bootoutErr: errBootoutRefused,
+			wantErr:    true,
+			// Retrying the unload is the advice a plain unload failure comes
+			// with, and it is the wrong advice against a launchctl that is
+			// itself broken. The failure has to name which of the two it is.
+			wantErrSays: "could not say whether it was loaded",
+			wantPlist:   true,
+		},
+		{
+			// Nothing had to be known: the unload it could not justify
+			// tolerating is the one that failed, and this one succeeded.
+			name:      "launchctl could not say, and the bootout succeeded",
+			listErr:   errLaunchctlMissing,
+			wantErr:   false,
+			wantPlist: false,
 		},
 		{
 			name:       "loaded, and the bootout failed",
@@ -456,7 +530,11 @@ func TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService(t *tes
 				t.Fatalf("writing plist: %v", err)
 			}
 
-			fake := &fakeLauncher{loaded: testCase.loaded, bootoutErr: testCase.bootoutErr}
+			fake := &fakeLauncher{
+				loaded:     testCase.loaded,
+				listErr:    testCase.listErr,
+				bootoutErr: testCase.bootoutErr,
+			}
 			svc := newTestService(fake)
 
 			err = svc.Uninstall()
@@ -481,6 +559,11 @@ func TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService(t *tes
 
 				if !errors.Is(err, errBootoutRefused) {
 					t.Errorf("Uninstall() = %v, want it to carry the bootout failure", err)
+				}
+
+				if testCase.wantErrSays != "" &&
+					!strings.Contains(err.Error(), testCase.wantErrSays) {
+					t.Errorf("Uninstall() = %v, want it to say %q", err, testCase.wantErrSays)
 				}
 			}
 
@@ -780,6 +863,46 @@ func TestService_Install_GivesAnOlderServiceTheCapturedStreamEnvironment(t *test
 	}
 }
 
+// TestService_Install_FailsWhenLaunchctlCannotBeAsked covers the state install
+// cannot proceed without an answer to. Whether the service is loaded decides
+// both of install's safety checks — whether this label already belongs to
+// another installer, and whether the old job has to be unloaded before launchd
+// will read the new plist — so guessing "not loaded" would bootstrap over a
+// service that may well be up. Install is idempotent, so refusing before it
+// touches anything costs no more than running it again once launchctl works.
+func TestService_Install_FailsWhenLaunchctlCannotBeAsked(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{listErr: errLaunchctlMissing}
+	svc := newTestService(fake)
+
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
+	if err == nil {
+		t.Fatal("Install() = nil, want the launchctl failure")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	if !errors.Is(err, errLaunchctlMissing) {
+		t.Errorf("Install() = %v, want it to carry why launchctl could not be asked", err)
+	}
+
+	if len(fake.calls) != 0 {
+		t.Errorf("Install() drove launchctl: %v, want no calls", fake.calls)
+	}
+
+	_, statErr := os.Stat(filepath.Join(dir, "Library", "LaunchAgents", Label+".plist"))
+	if !os.IsNotExist(statErr) {
+		t.Errorf(
+			"Install() wrote a plist without knowing what it was replacing, stat = %v",
+			statErr,
+		)
+	}
+}
+
 // TestService_Install_FailsWhenLoadedByAnotherInstaller pins the refusal that
 // survives idempotence: a loaded service with no plist of mimi's behind it is
 // nix-darwin's or home-manager's, and mimi must not adopt it.
@@ -1034,7 +1157,7 @@ func TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded(t *tes
 	}
 
 	// Nothing was written, so nothing was bootstrapped over the old service.
-	if got := strings.Join(fake.calls, ","); got != "bootout" {
+	if got := strings.Join(fake.calls, ","); got != wantUnloadOnlyCalls {
 		t.Errorf("Install() calls = %v, want [bootout]", fake.calls)
 	}
 
@@ -1158,7 +1281,7 @@ func TestService_Install_FailsWhenThePreviousServiceNeverUnloads(t *testing.T) {
 	// Never bootstrapped over a job launchd still holds, and — as with any
 	// other failure to unload — the old plist is still the one on disk for
 	// the next install to disagree with.
-	if got := strings.Join(fake.calls, ","); got != "bootout" {
+	if got := strings.Join(fake.calls, ","); got != wantUnloadOnlyCalls {
 		t.Errorf("Install() calls = %v, want [bootout]", fake.calls)
 	}
 
@@ -1169,6 +1292,66 @@ func TestService_Install_FailsWhenThePreviousServiceNeverUnloads(t *testing.T) {
 
 	if string(after) != string(stale) {
 		t.Errorf("a timed-out unload replaced the plist:\ngot\n%s\nwant\n%s", after, stale)
+	}
+}
+
+// TestService_Install_FailsWhenTheUnloadCannotBeConfirmed covers the wait
+// itself losing its answer. The wait exists because a bootout is a request
+// rather than a result, so ending it on anything other than launchctl saying
+// the job is gone puts the bootstrap back in the window #160 closed — and a
+// launchctl that cannot run says nothing about the job at all.
+func TestService_Install_FailsWhenTheUnloadCannotBeConfirmed(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{}
+	svc := newTestService(fake)
+
+	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	plistPath := filepath.Join(dir, "Library", "LaunchAgents", Label+".plist")
+
+	stale, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	// launchctl answers the question install opens with, and stops answering
+	// once the bootout has gone in: the daemon may be on its way out or may
+	// be staying exactly where it is, and nothing here can tell.
+	fake.loaded = true
+	fake.listErrAfterBootout = errLaunchctlMissing
+	fake.calls = nil
+
+	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
+	if err == nil {
+		t.Fatal("Install() = nil, want the unload to fail unconfirmed")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	if !errors.Is(err, errLaunchctlMissing) {
+		t.Errorf("Install() = %v, want it to carry why the unload could not be confirmed", err)
+	}
+
+	// The whole point: no bootstrap over a job that may still be loaded, and
+	// the old plist still on disk for the next install to disagree with.
+	if got := strings.Join(fake.calls, ","); got != wantUnloadOnlyCalls {
+		t.Errorf("Install() calls = %v, want [bootout]", fake.calls)
+	}
+
+	after, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading the plist after the unconfirmed unload: %v", err)
+	}
+
+	if string(after) != string(stale) {
+		t.Errorf("an unconfirmed unload replaced the plist:\ngot\n%s\nwant\n%s", after, stale)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes mimi reading a `launchctl` that could not run at all as a service
that is not loaded. Asking launchd whether the service is loaded has three
answers — loaded, not loaded, and "could not ask" — and until now the third was
silently folded into the second at all four places that asked.

That quietly reopened two shipped fixes. `mimi services uninstall` forgives an
unload that failed only when there was nothing to unload, so a `launchctl` that
cannot run made it forgive a failure it could not justify and delete the plist
of a service that keeps running until logout. The wait `mimi services install`
does between unloading the old service and loading the new one ends when the job
stops being listed, so the same broken `launchctl` ended it immediately and
bootstrapped into exactly the window that wait exists to close.

Each of the four now decides for itself: install refuses before writing
anything, uninstall forgives a failed unload only on a known-absent service,
the unload wait ends only on the job being gone, and status reports the state it
could not read. One deliberate limitation: a `launchctl` that runs and then
fails for a reason of its own — an unreachable domain, say — still reads as an
absent job, because the exit codes that would separate those are undocumented
and guessing wrong would refuse installs on a machine with nothing wrong with it.

## Related Issues

Closes #164

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command output changes

No config key, command, subcommand, or flag changes. What the `mimi services`
commands print and exit with does change, but only in the state where
`launchctl` cannot be run at all — every other case is byte-for-byte what it
was. Captured below by running the built binary with an empty `PATH`.

### `mimi services status`

| | Before | After |
| --- | --- | --- |
| Output | `Service not loaded` | `Service state unknown: launchctl could not be run` |
| Exit code | `0` | `0` (unchanged) |

The captured stdout/stderr lines still print under it — those are files on disk,
and are worth having whether or not launchd could be asked anything.

### `mimi services install`

| | Before | After |
| --- | --- | --- |
| Output | `Error: [SERVICE_FAILED] loading service; the new plist is already in place, so running install again retries the load: …` | `Error: [SERVICE_FAILED] asking launchctl whether the service is loaded: …` |
| Exit code | `1` | `1` (unchanged) |
| Side effect | Plist written, foreign-install refusal skipped, no unload attempted | Nothing written |

Same refusal, with a different message, when `launchctl` stops answering during
the unload wait: `waiting for the previous service to unload: …`, with the old
plist untouched. Before, that wait ended immediately and the install bootstrapped
over a job that may still have been loaded.

### `mimi services uninstall`

Only when the unload also fails — an unload that succeeds is unaffected and the
uninstall finishes as it always did.

| | Before | After |
| --- | --- | --- |
| Output | *(none)* | `Error: [SERVICE_FAILED] unloading service; launchctl could not say whether it was loaded, so the plist is kept and this failure stands: …` |
| Exit code | `0` | `1` |
| Side effect | Plist removed | Plist kept |

## Potentially breaking

`mimi services uninstall` now exits non-zero, and keeps the plist, in one case
where it used to exit zero and remove it: `launchctl` could not be run *and* the
unload failed. That is the guarantee #154 was merged for — an uninstall that
cannot show the service was unloaded must not throw away the only thing a retry
can act on — so scripts that ran uninstall against a machine with a broken
`launchctl` and took a zero exit for success were being told the wrong thing.
Anything scripting uninstall in that state should fix `launchctl` and re-run.

## Additional Context

The repeated "is it loaded?" check is now a single internal call, which is where
the third state is handled once instead of at four sites — issue #164's fourth
acceptance criterion, and the reason it asked for the extraction as part of this
change rather than on its own.

The launcher fake could already express "not loaded" as a typed error, which is
why no existing test could catch this class of bug; it now expresses "could not
run" as a distinct state, and there is a test for each of the four callers in
it. The real launcher gets two tests of its own: an empty `PATH` in the unit
tier, and a label no launchd domain can hold in the integration tier, since only
a real `launchctl` produces the exit status that means "no such job".

Empirically, `launchctl list` answers an absent job with 113 and an unreachable
domain with 112 on the machine this was written on — neither documented nor
promised, which is why the
split is drawn at "the process ran" rather than at the exit code. Narrowing it
further would be a separate change with its own risk of refusing installs on a
healthy machine.

The service methods still build their own `context.Background()`; threading real
contexts through them is #166 and is left alone here.
