### PR TITLE
refactor(service,cli): give the launchd service methods a real context instead of fabricating one

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -61,7 +61,12 @@ func newServicesInstallCmd(state *cliState) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logFile, servicePath := state.plistSettings()
 
-			outcome, err := defaultService.Install(state.configPath, logFile, servicePath)
+			outcome, err := defaultService.Install(
+				cmd.Context(),
+				state.configPath,
+				logFile,
+				servicePath,
+			)
 			if err != nil {
 				return err
 			}
@@ -79,7 +84,7 @@ func newServicesUninstallCmd() *cobra.Command {
 		Short: "Unload and remove the system service",
 		Long:  "Unload the Mimi launchd service and remove its plist file. Mimi will no longer start automatically on login.\n\nA service that is not loaded is uninstalled without complaint. When a loaded service cannot be unloaded, the plist is left in place and this fails, so the uninstall can be retried once whatever blocked the unload is fixed.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := defaultService.Uninstall()
+			err := defaultService.Uninstall(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -97,7 +102,7 @@ func newServicesStartCmd() *cobra.Command {
 		Short: "Start the system service",
 		Long:  "Start the Mimi launchd service. The daemon will begin running in the background.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := defaultService.Start()
+			err := defaultService.Start(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -115,7 +120,7 @@ func newServicesStopCmd() *cobra.Command {
 		Short: "Stop the system service",
 		Long:  "Stop the Mimi launchd service. The daemon process will be terminated.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := defaultService.Stop()
+			err := defaultService.Stop(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -133,7 +138,7 @@ func newServicesRestartCmd() *cobra.Command {
 		Short: "Restart the system service",
 		Long:  "Stop then immediately start the Mimi launchd service. Useful after configuration changes or to recover from an unresponsive state.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := defaultService.Restart()
+			err := defaultService.Restart(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -151,7 +156,7 @@ func newServicesStatusCmd() *cobra.Command {
 		Short: "Check the status of the system service",
 		Long:  "Check whether the Mimi launchd service is currently loaded, and whether it is actually running.\n\nThe two are not the same: the installed plist sets KeepAlive, so a daemon that crashes at startup is relaunched every ten seconds and stays loaded the whole time. A running service reports the pid it runs under; a loaded one that is not running reports the status it last exited with — a repeated non-zero status there is a daemon in a crash loop, and the captured stderr beside settings.log_file says why.\n\nUnder that line come the captured stdout and stderr the installed plist names, with how large each has grown. A daemon launchd started empties both at startup, so each size is one run's console output.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.Println(formatStatus(defaultService.Status()))
+			cmd.Println(formatStatus(defaultService.Status(cmd.Context())))
 
 			return nil
 		},

--- a/internal/service/launcher.go
+++ b/internal/service/launcher.go
@@ -14,7 +14,9 @@ type launcher interface {
 	// it could be asked at all. Its stdout is never surfaced — the answer is
 	// in the exit status — but a launchctl that never ran is not an answer:
 	// only an error returns one, and a false with no error means launchctl
-	// ran and did not find the job.
+	// ran and did not find the job. A call cut short by ctx is an error too,
+	// however far it got: an implementation that stops early knows nothing
+	// about the job.
 	list(ctx context.Context, label string) (bool, error)
 	// printJob runs `launchctl print` against target (e.g.
 	// "gui/501/com.y3owk1n.mimi") and returns what it said. Alone among these
@@ -50,10 +52,21 @@ type execLauncher struct{}
 // with nothing wrong with it. So a launchctl that ran and failed for a reason
 // of its own still reads as "job absent" here — the same answer it gave
 // before, for the one case a process exit cannot separate.
+//
+// The context is the one thing that has to be consulted before any of that.
+// CommandContext kills the process on cancellation, and a killed process
+// exits like any other: without asking the context first, every canceled call
+// would read as launchd saying the job is not there, which is the whole of what
+// this classification exists to prevent.
 func (execLauncher) list(ctx context.Context, label string) (bool, error) {
 	err := exec.CommandContext(ctx, "launchctl", "list", label).Run()
 	if err == nil {
 		return true, nil
+	}
+
+	ctxErr := ctx.Err()
+	if ctxErr != nil {
+		return false, ctxErr
 	}
 
 	var exitErr *exec.ExitError

--- a/internal/service/launcher_test.go
+++ b/internal/service/launcher_test.go
@@ -3,8 +3,15 @@ package service
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 )
+
+// stubPerm is the mode of the stand-in launchctl a cancellation test puts on
+// PATH: executable, because the point of it is being run.
+const stubPerm = 0o755
 
 // TestExecLauncher_List_ReportsALaunchctlThatCouldNotRun covers half of the
 // distinction the rest of this package is built on, in the one place it is
@@ -25,5 +32,87 @@ func TestExecLauncher_List_ReportsALaunchctlThatCouldNotRun(t *testing.T) {
 
 	if loaded {
 		t.Error("list() reported a job loaded on a launchctl that never ran")
+	}
+}
+
+// TestExecLauncher_List_DoesNotReadACanceledCallAsAnAbsentJob covers the one
+// way a launchctl that ran can still be no answer at all.
+//
+// CommandContext kills the process when the context is canceled, and a killed
+// process is an exited process: it comes back as the *exec.ExitError that
+// [execLauncher.list] otherwise reads as launchd saying no such job. Nothing
+// about the error itself separates the two, so a canceled install would
+// otherwise conclude the service is gone and bootstrap over a daemon that is
+// still up — the reading #164 removed, walked back in through the context this
+// package now threads.
+func TestExecLauncher_List_DoesNotReadACanceledCallAsAnAbsentJob(t *testing.T) {
+	dir := t.TempDir()
+
+	// A launchctl that never finishes on its own, so the only thing that can
+	// end this call is the cancellation under test. It reports that it is
+	// running through a fifo, which is what lets the cancel land after the
+	// process exists rather than before it: the two are different errors, and
+	// only the later one is the one this is about.
+	started := filepath.Join(dir, "started")
+
+	err := syscall.Mkfifo(started, filePerm)
+	if err != nil {
+		t.Fatalf("creating the fifo the stub launchctl reports through: %v", err)
+	}
+
+	stub := "#!/bin/sh\necho started > " + started + "\nexec /bin/sleep 30\n"
+
+	err = os.WriteFile(filepath.Join(dir, "launchctl"), []byte(stub), stubPerm)
+	if err != nil {
+		t.Fatalf("writing the stub launchctl: %v", err)
+	}
+
+	t.Setenv("PATH", dir)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	type answer struct {
+		loaded bool
+		err    error
+	}
+
+	answers := make(chan answer, 1)
+
+	go func() {
+		loaded, err := execLauncher{}.list(ctx, Label)
+		answers <- answer{loaded: loaded, err: err}
+	}()
+
+	running := make(chan struct{})
+
+	go func() {
+		// Blocks until the stub opens its end, which it does once it is running.
+		_, _ = os.ReadFile(started)
+
+		close(running)
+	}()
+
+	var got answer
+
+	select {
+	case <-running:
+		cancel()
+
+		got = <-answers
+	case got = <-answers:
+		// Nothing ever started, so nothing was killed, and whatever this
+		// answered is about a launchctl that could not run rather than one
+		// that was canceled. Failing here says so, rather than leaving the
+		// read above waiting for a stub that will never open its end.
+		t.Fatalf("list() = (%v, %v) before the stub launchctl was running", got.loaded, got.err)
+	}
+
+	if got.err == nil {
+		t.Fatal("list() = nil, want the cancellation reported rather than an answer about the job")
+	}
+
+	if got.loaded {
+		t.Error("list() reported a job loaded on a call that was canceled")
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -170,9 +170,15 @@ func New() *Service {
 // "not loaded" would bootstrap over a service that may well be up. Refusing
 // costs nothing that a re-run does not recover: it happens before anything is
 // written, and install is idempotent.
-func (s *Service) Install(configPath, logFile, servicePath string) (InstallOutcome, error) {
-	ctx := context.Background()
-
+//
+// Canceling ctx ends the install, and where it ends is the same place any
+// other failure does: either before the new plist is written, leaving the old
+// one for the next install to disagree with, or after the plist is in place
+// with only the load left to retry. There is no third state.
+func (s *Service) Install(
+	ctx context.Context,
+	configPath, logFile, servicePath string,
+) (InstallOutcome, error) {
 	state, err := s.loadState(ctx)
 	if err != nil {
 		return 0, err
@@ -238,10 +244,10 @@ func (s *Service) Install(configPath, logFile, servicePath string) (InstallOutco
 // Tolerating that failure takes a positive answer that there was nothing to
 // unload, not merely the absence of one. A launchctl that could not run leaves
 // the same question open as a loaded service does, and the safe reading of an
-// open question here is the one that keeps the plist.
-func (s *Service) Uninstall() error {
-	ctx := context.Background()
-
+// open question here is the one that keeps the plist. So does a canceled ctx:
+// it stops the uninstall where a failed unload does, with the plist still on
+// disk and a retry all it takes.
+func (s *Service) Uninstall(ctx context.Context) error {
 	domain, err := guiDomain()
 	if err != nil {
 		return err
@@ -260,6 +266,21 @@ func (s *Service) Uninstall() error {
 	state, _ := s.loadState(ctx)
 
 	err = s.launcher.bootout(ctx, domain+"/"+Label)
+
+	// A canceled uninstall stops here, whatever the bootout reported. Removing
+	// the plist below would finish the very command the caller called off, and
+	// a bootout that a cancellation cut short says nothing about the service
+	// either — both readings below would be about a launchctl that was never
+	// allowed to answer.
+	ctxErr := ctx.Err()
+	if ctxErr != nil {
+		return derrors.Wrapf(
+			ctxErr,
+			derrors.CodeServiceFailed,
+			"uninstall canceled; the plist is kept, so running uninstall again finishes it",
+		)
+	}
+
 	if err != nil && state == LoadStateUnknown {
 		return derrors.Wrapf(
 			err,
@@ -282,8 +303,8 @@ func (s *Service) Uninstall() error {
 }
 
 // Start starts the already-installed service.
-func (s *Service) Start() error {
-	err := s.launcher.start(context.Background(), Label)
+func (s *Service) Start(ctx context.Context) error {
+	err := s.launcher.start(ctx, Label)
 	if err != nil {
 		return derrors.Wrapf(err, derrors.CodeServiceFailed, "starting service")
 	}
@@ -292,8 +313,8 @@ func (s *Service) Start() error {
 }
 
 // Stop stops the running service.
-func (s *Service) Stop() error {
-	err := s.launcher.stop(context.Background(), Label)
+func (s *Service) Stop(ctx context.Context) error {
+	err := s.launcher.stop(ctx, Label)
 	if err != nil {
 		return derrors.Wrapf(err, derrors.CodeServiceFailed, "stopping service")
 	}
@@ -303,10 +324,10 @@ func (s *Service) Stop() error {
 
 // Restart stops then starts the service. A failure to stop (e.g. it was not
 // running) does not prevent the start that follows.
-func (s *Service) Restart() error {
-	_ = s.Stop()
+func (s *Service) Restart(ctx context.Context) error {
+	_ = s.Stop(ctx)
 
-	return s.Start()
+	return s.Start(ctx)
 }
 
 // Status reports whether the service is currently loaded, and — when it is —
@@ -325,9 +346,7 @@ func (s *Service) Restart() error {
 // The captured streams are read whether or not the service is loaded: they are
 // files on disk, and the run that wrote them is over either way — an unloaded
 // service is one of the states in which their contents matter most.
-func (s *Service) Status() Status {
-	ctx := context.Background()
-
+func (s *Service) Status(ctx context.Context) Status {
 	// The reason launchctl could not answer is not carried out of here: this
 	// returns no error by design, and [LoadStateUnknown] is already the whole
 	// of what a caller can do about it.
@@ -432,6 +451,20 @@ func (s *Service) apply(
 		}
 	}
 
+	// The write is the point of no return: everything above it can be undone by
+	// running install again, and nothing below it leaves the old plist behind.
+	// An interrupt that arrived while the unload was being waited on has to
+	// stop on this side of it, or a command the user called off is the one that
+	// replaced their plist.
+	err = ctx.Err()
+	if err != nil {
+		return 0, derrors.Wrapf(
+			err,
+			derrors.CodeServiceFailed,
+			"install canceled before the new plist was written; the previous plist is untouched",
+		)
+	}
+
 	err = writePlist(path, content)
 	if err != nil {
 		return 0, err
@@ -469,10 +502,22 @@ func (s *Service) apply(
 // it gives up instead, and says why. Waiting out the rest of the bound would
 // only spend the timeout to reach the same place with a vaguer reason: the
 // answer failed to arrive, and it is not the daemon that is slow.
+//
+// A canceled ctx ends it too, at the next pause rather than at the bound: this
+// is the one place an install blocks, so a caller who has given up is a caller
+// waiting on this and nothing else.
 func (s *Service) waitForUnload(ctx context.Context) error {
 	for attempt := range unloadPollAttempts {
 		if attempt > 0 {
-			s.pause(unloadPollInterval)
+			err := s.pause(ctx, unloadPollInterval)
+			if err != nil {
+				return derrors.Wrapf(
+					err,
+					derrors.CodeServiceFailed,
+					"canceled while waiting for the previous service to unload; "+
+						"the previous plist is untouched",
+				)
+			}
 		}
 
 		state, err := s.loadState(ctx)
@@ -497,16 +542,31 @@ func (s *Service) waitForUnload(ctx context.Context) error {
 	)
 }
 
-// pause spends the interval between two unload polls. A Service with no sleep
-// of its own — every one outside this package's tests — spends it for real.
-func (s *Service) pause(interval time.Duration) {
-	if s.sleep == nil {
-		time.Sleep(interval)
+// pause spends the interval between two unload polls, and returns why it
+// stopped early when the caller canceled during it. A Service with no sleep of
+// its own — every one outside this package's tests — spends it for real, and
+// gives up on the interval the moment ctx is done rather than at the end of it.
+//
+// The injected sleep is the tests' and costs nothing, so the context is asked
+// after it rather than raced against it: a test that cancels from inside its
+// sleep is describing an interrupt that arrived during the pause, and gets the
+// same answer a real one would.
+func (s *Service) pause(ctx context.Context, interval time.Duration) error {
+	if s.sleep != nil {
+		s.sleep(interval)
 
-		return
+		return ctx.Err()
 	}
 
-	s.sleep(interval)
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // installedPlist is what sits at mimi's plist path when an install starts.

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -61,6 +61,11 @@ type fakeLauncher struct {
 	// now in progress".
 	bootstrappedWhileLoaded bool
 
+	// afterBootout runs once the bootout has been accepted, and is how a test
+	// places an interrupt in the narrowest window an install has: the old
+	// service is already down, and the new plist is not yet written.
+	afterBootout func()
+
 	// calls names the state-changing launchctl calls in the order they
 	// arrived, for the tests where "which, and in what order" is the
 	// behavior under test. The read-only list is deliberately absent: it
@@ -135,6 +140,10 @@ func (f *fakeLauncher) bootout(_ context.Context, _ string) error {
 	// lag left to run down goes on listing as loaded until it does.
 	if f.unloadLag == 0 && !f.neverUnloads {
 		f.loaded = false
+	}
+
+	if f.afterBootout != nil {
+		f.afterBootout()
 	}
 
 	return nil
@@ -240,7 +249,7 @@ func TestService_Status_ReportsWhatTheLauncherSees(t *testing.T) {
 			}
 			svc := newTestService(fake)
 
-			got := svc.Status()
+			got := svc.Status(t.Context())
 			if got != testCase.want {
 				t.Errorf("Status() = %+v, want %+v", got, testCase.want)
 			}
@@ -284,7 +293,7 @@ func TestService_Status_ReportsTheCapturedLogsTheInstalledPlistNames(t *testing.
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, logFile, "")
+	_, err := svc.Install(t.Context(), testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil", err)
 	}
@@ -309,7 +318,7 @@ func TestService_Status_ReportsTheCapturedLogsTheInstalledPlistNames(t *testing.
 	fake.loaded = true
 	fake.printOutput = "\tstate = running\n\tpid = 1478\n"
 
-	status := svc.Status()
+	status := svc.Status(t.Context())
 
 	wantStdout := CapturedLog{Path: stdoutPath, Size: 10, Present: true}
 	if status.CapturedStdout != wantStdout {
@@ -335,14 +344,14 @@ func TestService_Status_ReportsACapturedLogThatIsNotThereYet(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(logDir, "mimi.log"), "")
+	_, err := svc.Install(t.Context(), testConfigPath, filepath.Join(logDir, "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil", err)
 	}
 
 	fake.loaded = true
 
-	status := svc.Status()
+	status := svc.Status(t.Context())
 
 	want := CapturedLog{Path: filepath.Join(logDir, "mimi.out.log")}
 	if status.CapturedStdout != want {
@@ -362,7 +371,7 @@ func TestService_Status_ReportsNoCapturedLogsWithoutAPlistOfMimisOwn(t *testing.
 	fake := &fakeLauncher{loaded: true}
 	svc := newTestService(fake)
 
-	status := svc.Status()
+	status := svc.Status(t.Context())
 
 	var none CapturedLog
 	if status.CapturedStdout != none || status.CapturedStderr != none {
@@ -378,7 +387,7 @@ func TestService_Start_RunsLaunchctlStart(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	err := svc.Start()
+	err := svc.Start(t.Context())
 	if err != nil {
 		t.Fatalf("Start() = %v, want nil", err)
 	}
@@ -392,7 +401,7 @@ func TestService_Start_WrapsTheLauncherErrorWithADerrorsCode(t *testing.T) {
 	fake := &fakeLauncher{startErr: derrors.New(derrors.CodeServiceFailed, "boom")}
 	svc := newTestService(fake)
 
-	err := svc.Start()
+	err := svc.Start(t.Context())
 	if err == nil {
 		t.Fatal("Start() = nil, want an error")
 	}
@@ -406,7 +415,7 @@ func TestService_Stop_RunsLaunchctlStop(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	err := svc.Stop()
+	err := svc.Stop(t.Context())
 	if err != nil {
 		t.Fatalf("Stop() = %v, want nil", err)
 	}
@@ -420,7 +429,7 @@ func TestService_Restart_StopsThenStartsEvenWhenStopFails(t *testing.T) {
 	fake := &fakeLauncher{stopErr: derrors.New(derrors.CodeServiceFailed, "wasn't running")}
 	svc := newTestService(fake)
 
-	err := svc.Restart()
+	err := svc.Restart(t.Context())
 	if err != nil {
 		t.Fatalf("Restart() = %v, want nil (start succeeded)", err)
 	}
@@ -537,7 +546,7 @@ func TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService(t *tes
 			}
 			svc := newTestService(fake)
 
-			err = svc.Uninstall()
+			err = svc.Uninstall(t.Context())
 			if (err != nil) != testCase.wantErr {
 				t.Fatalf("Uninstall() = %v, wantErr %v", err, testCase.wantErr)
 			}
@@ -579,6 +588,56 @@ func TestService_Uninstall_TellsAFailedUnloadFromAnAlreadyUnloadedService(t *tes
 	}
 }
 
+// TestService_Uninstall_KeepsThePlistWhenTheCallerCancels covers the uninstall
+// half of what canceling one of these commands has to mean. Removing the
+// plist is the step after the unload, and running it for a command the caller
+// called off would finish the uninstall they asked to abort — so a canceled
+// one stops where a failed unload stops, with the plist still there and a
+// re-run all it takes.
+func TestService_Uninstall_KeepsThePlistWhenTheCallerCancels(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	path := filepath.Join(dir, "Library", "LaunchAgents", Label+".plist")
+
+	err := os.MkdirAll(filepath.Dir(path), dirPerm)
+	if err != nil {
+		t.Fatalf("creating LaunchAgents directory: %v", err)
+	}
+
+	err = os.WriteFile(path, []byte("installed"), filePerm)
+	if err != nil {
+		t.Fatalf("writing plist: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// The interrupt lands as the bootout goes in: launchctl answered, so
+	// nothing here is in any doubt about the service — only about whether this
+	// uninstall is still wanted.
+	fake := &fakeLauncher{loaded: true, afterBootout: cancel}
+	svc := newTestService(fake)
+
+	err = svc.Uninstall(ctx)
+	if err == nil {
+		t.Fatal("Uninstall() = nil, want the canceled uninstall to fail")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Uninstall() = %v, want it to carry the cancellation", err)
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Uninstall() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	_, statErr := os.Stat(path)
+	if statErr != nil {
+		t.Errorf("a canceled Uninstall() removed the plist: %v", statErr)
+	}
+}
+
 func TestService_Install_WritesThePlistAndBootstraps(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
@@ -591,7 +650,7 @@ func TestService_Install_WritesThePlistAndBootstraps(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	outcome, err := svc.Install(testConfigPath, logFile, "")
+	outcome, err := svc.Install(t.Context(), testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil", err)
 	}
@@ -650,7 +709,7 @@ func TestService_Install_IsANoOpWhenTheLoadedServiceAlreadyMatches(t *testing.T)
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, logFile, "")
+	_, err := svc.Install(t.Context(), testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -660,7 +719,7 @@ func TestService_Install_IsANoOpWhenTheLoadedServiceAlreadyMatches(t *testing.T)
 	fake.loaded = true
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, logFile, "")
+	outcome, err := svc.Install(t.Context(), testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("second Install() = %v, want nil", err)
 	}
@@ -690,7 +749,7 @@ func TestService_Install_ReplacesAStalePlistAndReloadsTheService(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, oldLogFile, "")
+	_, err := svc.Install(t.Context(), testConfigPath, oldLogFile, "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -699,7 +758,7 @@ func TestService_Install_ReplacesAStalePlistAndReloadsTheService(t *testing.T) {
 	fake.loaded = true
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, newLogFile, "")
+	outcome, err := svc.Install(t.Context(), testConfigPath, newLogFile, "")
 	if err != nil {
 		t.Fatalf("second Install() = %v, want nil", err)
 	}
@@ -753,7 +812,7 @@ func TestService_Install_ReplacesAStalePlistAfterServicePathChanges(t *testing.T
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, logFile, "")
+	_, err := svc.Install(t.Context(), testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -763,7 +822,7 @@ func TestService_Install_ReplacesAStalePlistAfterServicePathChanges(t *testing.T
 
 	const wantPath = "/Users/test/.local/bin:/usr/bin:/bin"
 
-	outcome, err := svc.Install(testConfigPath, logFile, wantPath)
+	outcome, err := svc.Install(t.Context(), testConfigPath, logFile, wantPath)
 	if err != nil {
 		t.Fatalf("second Install() = %v, want nil", err)
 	}
@@ -801,7 +860,7 @@ func TestService_Install_GivesAnOlderServiceTheCapturedStreamEnvironment(t *test
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, logFile, "")
+	_, err := svc.Install(t.Context(), testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -834,7 +893,7 @@ func TestService_Install_GivesAnOlderServiceTheCapturedStreamEnvironment(t *test
 	fake.loaded = true
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, logFile, "")
+	outcome, err := svc.Install(t.Context(), testConfigPath, logFile, "")
 	if err != nil {
 		t.Fatalf("second Install() = %v, want nil", err)
 	}
@@ -877,7 +936,12 @@ func TestService_Install_FailsWhenLaunchctlCannotBeAsked(t *testing.T) {
 	fake := &fakeLauncher{listErr: errLaunchctlMissing}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
+	_, err := svc.Install(
+		t.Context(),
+		testConfigPath,
+		filepath.Join(dir, "state", "mimi", "mimi.log"),
+		"",
+	)
 	if err == nil {
 		t.Fatal("Install() = nil, want the launchctl failure")
 	}
@@ -913,7 +977,12 @@ func TestService_Install_FailsWhenLoadedByAnotherInstaller(t *testing.T) {
 	fake := &fakeLauncher{loaded: true}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
+	_, err := svc.Install(
+		t.Context(),
+		testConfigPath,
+		filepath.Join(dir, "state", "mimi", "mimi.log"),
+		"",
+	)
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}
@@ -964,7 +1033,12 @@ func TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err = svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
+	_, err = svc.Install(
+		t.Context(),
+		testConfigPath,
+		filepath.Join(dir, "state", "mimi", "mimi.log"),
+		"",
+	)
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}
@@ -1019,7 +1093,12 @@ func TestService_Install_LoadsAPlistLeftBehindByAPreviousInstall(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	outcome, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
+	outcome, err := svc.Install(
+		t.Context(),
+		testConfigPath,
+		filepath.Join(dir, "state", "mimi", "mimi.log"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil", err)
 	}
@@ -1060,7 +1139,7 @@ func TestService_Install_NeverLeavesAPartialPlist(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+	_, err := svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -1086,7 +1165,7 @@ func TestService_Install_NeverLeavesAPartialPlist(t *testing.T) {
 
 	fake.loaded = true
 
-	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
+	_, err = svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
 	if err == nil {
 		t.Fatal("second Install() = nil, want an error")
 	}
@@ -1129,7 +1208,7 @@ func TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded(t *tes
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+	_, err := svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -1147,7 +1226,7 @@ func TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded(t *tes
 
 	newLogFile := filepath.Join(dir, "new", "mimi.log")
 
-	_, err = svc.Install(testConfigPath, newLogFile, "")
+	_, err = svc.Install(t.Context(), testConfigPath, newLogFile, "")
 	if err == nil {
 		t.Fatal("Install() = nil, want the unload failure")
 	}
@@ -1175,7 +1254,7 @@ func TestService_Install_KeepsTheStalePlistWhenTheServiceCannotBeUnloaded(t *tes
 	fake.bootoutErr = nil
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, newLogFile, "")
+	outcome, err := svc.Install(t.Context(), testConfigPath, newLogFile, "")
 	if err != nil {
 		t.Fatalf("retried Install() = %v, want nil", err)
 	}
@@ -1198,7 +1277,7 @@ func TestService_Install_WaitsForThePreviousServiceToUnloadBeforeBootstrapping(t
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+	_, err := svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -1209,7 +1288,12 @@ func TestService_Install_WaitsForThePreviousServiceToUnloadBeforeBootstrapping(t
 	fake.unloadLag = 2
 	fake.calls = nil
 
-	outcome, err := svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
+	outcome, err := svc.Install(
+		t.Context(),
+		testConfigPath,
+		filepath.Join(dir, "new", "mimi.log"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("second Install() = %v, want nil", err)
 	}
@@ -1238,7 +1322,7 @@ func TestService_Install_FailsWhenThePreviousServiceNeverUnloads(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+	_, err := svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -1261,7 +1345,7 @@ func TestService_Install_FailsWhenThePreviousServiceNeverUnloads(t *testing.T) {
 	fake.neverUnloads = true
 	fake.calls = nil
 
-	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
+	_, err = svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
 	if err == nil {
 		t.Fatal("Install() = nil, want the unload to time out")
 	}
@@ -1295,6 +1379,171 @@ func TestService_Install_FailsWhenThePreviousServiceNeverUnloads(t *testing.T) {
 	}
 }
 
+// TestService_Pause_DoesNotSpendAnIntervalTheCallerHasGivenUpOn covers the
+// pause a real install takes, which is the one no other test here reaches: the
+// wait's promptness is pinned through the injected sleep, and the sleep tests
+// inject is not the thing that has to stop early.
+//
+// The interval it is handed is the whole unload bound, so a pause that waited
+// it out would be a test that spent five seconds — and the point is that it
+// returns without spending any of them.
+func TestService_Pause_DoesNotSpendAnIntervalTheCallerHasGivenUpOn(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// No sleep of its own, so this is the pause every Service outside these
+	// tests takes.
+	svc := &Service{launcher: &fakeLauncher{}}
+
+	err := svc.pause(ctx, unloadTimeout)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("pause() = %v, want the cancellation rather than a spent interval", err)
+	}
+}
+
+// TestService_Install_WritesNoPlistWhenCanceledAfterTheUnload covers the
+// narrowest window an install has: the old service is down, launchctl has
+// confirmed it, and the plist has not been replaced yet. An interrupt landing
+// there must leave the disk where a failed unload leaves it — the old plist,
+// and an install to run again — rather than replacing the plist for a command
+// the user called off.
+func TestService_Install_WritesNoPlistWhenCanceledAfterTheUnload(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{}
+	svc := newTestService(fake)
+
+	_, err := svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	plistPath := filepath.Join(dir, "Library", "LaunchAgents", Label+".plist")
+
+	stale, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// A daemon that is gone the moment bootout returns, so the wait ends on an
+	// answer rather than on the interrupt: what is under test is the step
+	// after it.
+	fake.loaded = true
+	fake.afterBootout = cancel
+	fake.calls = nil
+
+	_, err = svc.Install(ctx, testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
+	if err == nil {
+		t.Fatal("Install() = nil, want the canceled install to fail")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Install() = %v, want it to carry the cancellation", err)
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	if got := strings.Join(fake.calls, ","); got != wantUnloadOnlyCalls {
+		t.Errorf("Install() calls = %v, want [bootout]", fake.calls)
+	}
+
+	after, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading the plist after the canceled install: %v", err)
+	}
+
+	if string(after) != string(stale) {
+		t.Errorf("a canceled install replaced the plist:\ngot\n%s\nwant\n%s", after, stale)
+	}
+
+	assertOnlyThePlist(t, filepath.Dir(plistPath))
+}
+
+// TestService_Install_StopsWaitingForTheUnloadWhenTheCallerCancels covers the
+// wait's other way out. The bound is five seconds of polling, and a caller who
+// has given up should not be held for the rest of it: canceling the context
+// ends the wait at the next pause rather than at the timeout, and — as with
+// every other unload that did not complete — nothing is written.
+func TestService_Install_StopsWaitingForTheUnloadWhenTheCallerCancels(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	fake := &fakeLauncher{}
+	svc := newTestService(fake)
+
+	_, err := svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+	if err != nil {
+		t.Fatalf("first Install() = %v, want nil", err)
+	}
+
+	plistPath := filepath.Join(dir, "Library", "LaunchAgents", Label+".plist")
+
+	stale, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading installed plist: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// The interrupt arrives during the first pause between polls, which is the
+	// only place this wait ever spends time. Counting the pauses is how the
+	// promptness is held to without spending the wall-clock time the bound is
+	// written in.
+	pauses := 0
+
+	svc.sleep = func(time.Duration) {
+		pauses++
+
+		cancel()
+	}
+
+	// A daemon that would hold the wait open for its full bound, so anything
+	// short of that is the cancellation and not the job going away.
+	fake.loaded = true
+	fake.neverUnloads = true
+	fake.calls = nil
+
+	_, err = svc.Install(ctx, testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
+	if err == nil {
+		t.Fatal("Install() = nil, want the canceled wait to fail")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Install() = %v, want it to carry the cancellation", err)
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	if pauses != 1 {
+		t.Errorf("Install() paused %d times after being canceled, want 1", pauses)
+	}
+
+	// The same place any other unload that did not complete leaves the
+	// machine: no bootstrap over a job that may still be loaded, and the old
+	// plist still on disk.
+	if got := strings.Join(fake.calls, ","); got != wantUnloadOnlyCalls {
+		t.Errorf("Install() calls = %v, want [bootout]", fake.calls)
+	}
+
+	after, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("reading the plist after the canceled unload: %v", err)
+	}
+
+	if string(after) != string(stale) {
+		t.Errorf("a canceled unload replaced the plist:\ngot\n%s\nwant\n%s", after, stale)
+	}
+}
+
 // TestService_Install_FailsWhenTheUnloadCannotBeConfirmed covers the wait
 // itself losing its answer. The wait exists because a bootout is a request
 // rather than a result, so ending it on anything other than launchctl saying
@@ -1307,7 +1556,7 @@ func TestService_Install_FailsWhenTheUnloadCannotBeConfirmed(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+	_, err := svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
 	if err != nil {
 		t.Fatalf("first Install() = %v, want nil", err)
 	}
@@ -1326,7 +1575,7 @@ func TestService_Install_FailsWhenTheUnloadCannotBeConfirmed(t *testing.T) {
 	fake.listErrAfterBootout = errLaunchctlMissing
 	fake.calls = nil
 
-	_, err = svc.Install(testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
+	_, err = svc.Install(t.Context(), testConfigPath, filepath.Join(dir, "new", "mimi.log"), "")
 	if err == nil {
 		t.Fatal("Install() = nil, want the unload to fail unconfirmed")
 	}
@@ -1377,7 +1626,12 @@ func TestService_Install_SaysAFailedLoadCanBeRetried(t *testing.T) {
 			fake := &fakeLauncher{}
 			svc := newTestService(fake)
 
-			_, err := svc.Install(testConfigPath, filepath.Join(dir, "old", "mimi.log"), "")
+			_, err := svc.Install(
+				t.Context(),
+				testConfigPath,
+				filepath.Join(dir, "old", "mimi.log"),
+				"",
+			)
 			if err != nil {
 				t.Fatalf("first Install() = %v, want nil", err)
 			}
@@ -1387,7 +1641,7 @@ func TestService_Install_SaysAFailedLoadCanBeRetried(t *testing.T) {
 
 			newLogFile := filepath.Join(dir, "new", "mimi.log")
 
-			_, err = svc.Install(testConfigPath, newLogFile, "")
+			_, err = svc.Install(t.Context(), testConfigPath, newLogFile, "")
 			if err == nil {
 				t.Fatal("Install() = nil, want the failed load")
 			}
@@ -1413,7 +1667,7 @@ func TestService_Install_SaysAFailedLoadCanBeRetried(t *testing.T) {
 			fake.bootstrapErr = nil
 			fake.calls = nil
 
-			_, err = svc.Install(testConfigPath, newLogFile, "")
+			_, err = svc.Install(t.Context(), testConfigPath, newLogFile, "")
 			if err != nil {
 				t.Fatalf("retried Install() = %v, want nil", err)
 			}
@@ -1437,7 +1691,12 @@ func TestService_Install_DoesNotUseTheSystemTempDirectory(t *testing.T) {
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err := svc.Install(testConfigPath, filepath.Join(dir, "state", "mimi", "mimi.log"), "")
+	_, err := svc.Install(
+		t.Context(),
+		testConfigPath,
+		filepath.Join(dir, "state", "mimi", "mimi.log"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Install() = %v, want nil (the plist never goes via TMPDIR)", err)
 	}
@@ -1491,7 +1750,12 @@ func TestService_Install_FailsWhenTheCapturedStreamDirectoryCannotBeCreated(t *t
 	fake := &fakeLauncher{}
 	svc := newTestService(fake)
 
-	_, err = svc.Install(testConfigPath, filepath.Join(blocker, "mimi", "mimi.log"), "")
+	_, err = svc.Install(
+		t.Context(),
+		testConfigPath,
+		filepath.Join(blocker, "mimi", "mimi.log"),
+		"",
+	)
 	if err == nil {
 		t.Fatal("Install() = nil, want an error")
 	}


### PR DESCRIPTION
## Description

This PR reworks the launchd service commands so they can be cancelled. Every one of them used to build its own background context, so nothing a caller did could stop them — harmless while each was a single fast `launchctl` call, and no longer harmless now that installing waits up to five seconds for the old service to unload. All six now take a context, and `mimi services …` hands down the one the command already carries.

Where that matters is the wait. It now ends as soon as the context is done instead of running out its full bound, and an install cut short after the unload stops before the plist is replaced — so it leaves the machine exactly where a failed unload leaves it, with the old plist on disk and a re-run all it takes. A cancelled uninstall keeps the plist for the same reason, rather than finishing the removal for a command that was called off. Cancelling also had to stop being mistaken for an answer: killing a `launchctl list` makes it exit like any other process, which is what the check added in #171 reads as "launchd has no such job", so the context is now consulted before that classification and a cancelled call reports a launchctl that could not answer.

The deliberate limitation: nothing changes for a user yet. The root command still runs on a background context and nothing wires a signal into it, so interrupting `mimi services …` behaves exactly as it did before — the process is killed outright, and none of the new cancellation paths are reached. This lays the mechanism; making Ctrl-C actually cancel needs a signal-derived context at the root, which affects every command and is left for its own change.

## Related Issues

Closes #166

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [x] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-visible behaviour changes, so `docs/CLI.md` would be documenting a path no interrupt can reach yet
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

**Interrupting a `mimi services …` command is unchanged.** SIGINT still kills the process; the threaded context is never cancelled today. That is the honest state of the acceptance criterion about interrupting the work — the plumbing is in place, the trigger is not.

**The cancellation-reads-as-absent trap.** `exec.CommandContext` kills the process on cancel, and a killed process produces the same `*exec.ExitError` as a `launchctl` that ran and reported no such job. Left alone, threading a cancellable context would have quietly reintroduced the bug #171 closed — a cancelled install concluding the service is gone and bootstrapping over a daemon that is still up. The context is checked before the exit-status classification, and a unit test pins it against a real killed process: a stub `launchctl` on PATH that reports through a fifo when it is running, so the cancel is guaranteed to land after the process exists rather than before it. Without the check, that test fails.

**No wall-clock time in the tests.** The unload wait is driven through the injectable sleep added in #165, so the mid-wait cancellation test counts pauses instead of spending them. The production pause — the timer-and-select one no fake reaches — is covered separately by handing it an already-cancelled context and the whole five-second bound, which it returns from without spending any of it.

**Error codes.** Both cancellation paths report `SERVICE_FAILED` rather than the unused `CONTEXT_CANCELED`. A cancellation noticed during a `launchctl` call arrives wrapped as a service failure anyway, so using two codes for one user action would have been the less predictable choice.
