### PR TITLE
fix(service,cli): restart the service through launchd instead of a discarded stop

### DIFF
--- a/cmd/mimi/cmd/services.go
+++ b/cmd/mimi/cmd/services.go
@@ -136,7 +136,7 @@ func newServicesRestartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restart",
 		Short: "Restart the system service",
-		Long:  "Stop then immediately start the Mimi launchd service. Useful after configuration changes or to recover from an unresponsive state.",
+		Long:  "Restart the Mimi launchd service in one launchctl call: launchd kills the running daemon and spawns it again. Useful after configuration changes or to recover from an unresponsive state.\n\nThere has to be a loaded service to restart. When there is none, this says so and points at `mimi services install`, rather than reporting a failure to start whatever was not there. When launchctl cannot be run at all, that is reported as itself — nothing here knows whether a service is installed, so nothing here recommends installing one.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			err := defaultService.Restart(cmd.Context())
 			if err != nil {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -254,6 +254,21 @@ job either way, and the uninstall finishes.
 
 Control the launchd service directly.
 
+`restart` restarts the loaded job with a single `launchctl kickstart -k`, in
+place of the `stop` whose failure was thrown away followed by a `start`. launchd
+only kickstarts a job it holds, so the restart is preceded by a check that there
+is one — and when there is not, that is what the command says:
+
+```
+$ mimi services restart
+Error: [SERVICE_FAILED] there is no loaded service to restart; run `mimi services install` first
+```
+
+It used to report that same machine as a failure to start the service that was
+not there. `launchctl` failing to run at all is reported as itself and gets no
+such advice — nothing there knows whether a service is installed, and the
+install it would recommend runs through the same `launchctl`.
+
 `status` separates a loaded service from a running one — the installed plist
 sets `KeepAlive`, so a daemon that crashes at startup is relaunched forever
 while staying loaded:

--- a/internal/service/launcher.go
+++ b/internal/service/launcher.go
@@ -31,6 +31,11 @@ type launcher interface {
 	start(ctx context.Context, label string) error
 	// stop stops the already-loaded service named label.
 	stop(ctx context.Context, label string) error
+	// kickstart restarts target (e.g. "gui/501/com.y3owk1n.mimi") in one call:
+	// launchd kills whatever is running under the job and spawns it again. It
+	// takes a domain target rather than a label because it acts on the job
+	// launchd holds, and it fails on a job launchd does not hold at all.
+	kickstart(ctx context.Context, target string) error
 }
 
 // execLauncher is the launcher backed by the real launchctl binary on PATH.
@@ -97,4 +102,11 @@ func (execLauncher) start(ctx context.Context, label string) error {
 
 func (execLauncher) stop(ctx context.Context, label string) error {
 	return exec.CommandContext(ctx, "launchctl", "stop", label).Run()
+}
+
+// kickstart runs `launchctl kickstart -k target`. The -k is what makes it a
+// restart rather than a start: without it launchd leaves a running job alone,
+// and the config a restart exists to pick up would go on being the old one.
+func (execLauncher) kickstart(ctx context.Context, target string) error {
+	return exec.CommandContext(ctx, "launchctl", "kickstart", "-k", target).Run()
 }

--- a/internal/service/launcher_test.go
+++ b/internal/service/launcher_test.go
@@ -9,9 +9,28 @@ import (
 	"testing"
 )
 
-// stubPerm is the mode of the stand-in launchctl a cancellation test puts on
-// PATH: executable, because the point of it is being run.
+// stubPerm is the mode of a stand-in launchctl these tests put on PATH:
+// executable, because the point of one is being run.
 const stubPerm = 0o755
+
+// writeStubLaunchctl puts a launchctl of the test's own in dir and makes dir
+// the whole of PATH, so that what [execLauncher] shells out to is a script the
+// test wrote rather than the machine's real launchd. body is a shell script
+// without its shebang.
+//
+// dir is the caller's rather than this function's because a stub that reports
+// anything back does it through a file beside itself, and the body naming that
+// file has to be written before there is a stub to write.
+func writeStubLaunchctl(t *testing.T, dir, body string) {
+	t.Helper()
+
+	err := os.WriteFile(filepath.Join(dir, "launchctl"), []byte("#!/bin/sh\n"+body), stubPerm)
+	if err != nil {
+		t.Fatalf("writing the stub launchctl: %v", err)
+	}
+
+	t.Setenv("PATH", dir)
+}
 
 // TestExecLauncher_List_ReportsALaunchctlThatCouldNotRun covers half of the
 // distinction the rest of this package is built on, in the one place it is
@@ -32,6 +51,38 @@ func TestExecLauncher_List_ReportsALaunchctlThatCouldNotRun(t *testing.T) {
 
 	if loaded {
 		t.Error("list() reported a job loaded on a launchctl that never ran")
+	}
+}
+
+// TestExecLauncher_Kickstart_RestartsRatherThanStarts pins the one argument
+// that separates the two. `launchctl kickstart` on a job that is already
+// running does nothing at all; only -k kills it first, and a restart that
+// silently left the old process up is a restart that never picked up the
+// config it was run for. The fake launcher elsewhere is handed a target and
+// cannot see the flag, so this is the only place it is checked.
+func TestExecLauncher_Kickstart_RestartsRatherThanStarts(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args")
+
+	// A launchctl that records what it was asked to do and succeeds, so what
+	// this asserts is the command line rather than anything launchd did.
+	writeStubLaunchctl(t, dir, "printf '%s\\n' \"$@\" > "+argsFile+"\n")
+
+	target := "gui/501/" + Label
+
+	err := execLauncher{}.kickstart(context.Background(), target)
+	if err != nil {
+		t.Fatalf("kickstart() = %v, want nil", err)
+	}
+
+	recorded, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("reading what the stub launchctl was asked: %v", err)
+	}
+
+	want := "kickstart\n-k\n" + target + "\n"
+	if string(recorded) != want {
+		t.Errorf("kickstart() ran launchctl with %q, want %q", string(recorded), want)
 	}
 }
 
@@ -60,14 +111,7 @@ func TestExecLauncher_List_DoesNotReadACanceledCallAsAnAbsentJob(t *testing.T) {
 		t.Fatalf("creating the fifo the stub launchctl reports through: %v", err)
 	}
 
-	stub := "#!/bin/sh\necho started > " + started + "\nexec /bin/sleep 30\n"
-
-	err = os.WriteFile(filepath.Join(dir, "launchctl"), []byte(stub), stubPerm)
-	if err != nil {
-		t.Fatalf("writing the stub launchctl: %v", err)
-	}
-
-	t.Setenv("PATH", dir)
+	writeStubLaunchctl(t, dir, "echo started > "+started+"\nexec /bin/sleep 30\n")
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -248,7 +248,7 @@ func (s *Service) Install(
 // it stops the uninstall where a failed unload does, with the plist still on
 // disk and a retry all it takes.
 func (s *Service) Uninstall(ctx context.Context) error {
-	domain, err := guiDomain()
+	target, err := serviceTarget()
 	if err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func (s *Service) Uninstall(ctx context.Context) error {
 	// both halves of this run through.
 	state, _ := s.loadState(ctx)
 
-	err = s.launcher.bootout(ctx, domain+"/"+Label)
+	err = s.launcher.bootout(ctx, target)
 
 	// A canceled uninstall stops here, whatever the bootout reported. Removing
 	// the plist below would finish the very command the caller called off, and
@@ -322,12 +322,51 @@ func (s *Service) Stop(ctx context.Context) error {
 	return nil
 }
 
-// Restart stops then starts the service. A failure to stop (e.g. it was not
-// running) does not prevent the start that follows.
+// Restart restarts the loaded service in a single launchd call.
+//
+// It used to be a stop whose error was discarded followed by a start, and the
+// discard was not the worst of it: on a machine with nothing installed both
+// halves fail at nothing, and the one failure that survived reported "starting
+// service" — the symptom of the absent service rather than the absent service.
+// A kickstart is the whole restart, so there is no first error left to throw
+// away and no way to name the second one's problem instead of the real one.
+//
+// That is also why the loaded check comes first and refuses on anything but a
+// loaded job. launchd will not kickstart a job it does not hold, so the check
+// costs a command that would have failed anyway and buys the one thing the
+// failure could never say: that the fix is `mimi services install` and not
+// anything about restarting. [LoadStateUnknown] is not that answer — a
+// launchctl that could not run has said nothing about whether a service is
+// installed, and it is returned as itself rather than turned into advice to
+// install over a service that may be running perfectly well.
+//
+// Start and Stop are left as they are. Each is a command of its own, and a
+// launchctl start on an unloaded job is a different thing from a restart of
+// one.
 func (s *Service) Restart(ctx context.Context) error {
-	_ = s.Stop(ctx)
+	state, err := s.loadState(ctx)
+	if err != nil {
+		return err
+	}
 
-	return s.Start(ctx)
+	if state == LoadStateNotLoaded {
+		return derrors.New(
+			derrors.CodeServiceFailed,
+			"there is no loaded service to restart; run `mimi services install` first",
+		)
+	}
+
+	target, err := serviceTarget()
+	if err != nil {
+		return err
+	}
+
+	err = s.launcher.kickstart(ctx, target)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeServiceFailed, "restarting service")
+	}
+
+	return nil
 }
 
 // Status reports whether the service is currently loaded, and — when it is —
@@ -359,12 +398,12 @@ func (s *Service) Status(ctx context.Context) Status {
 		return status
 	}
 
-	domain, err := guiDomain()
+	target, err := serviceTarget()
 	if err != nil {
 		return status
 	}
 
-	output, err := s.launcher.printJob(ctx, domain+"/"+Label)
+	output, err := s.launcher.printJob(ctx, target)
 	if err != nil {
 		return status
 	}
@@ -436,7 +475,7 @@ func (s *Service) apply(
 	if loaded {
 		outcome = InstallOutcomeReplaced
 
-		err = s.launcher.bootout(ctx, domain+"/"+Label)
+		err = s.launcher.bootout(ctx, targetIn(domain))
 		if err != nil {
 			return 0, derrors.Wrapf(
 				err,
@@ -707,6 +746,28 @@ func guiDomain() (string, error) {
 	}
 
 	return "gui/" + currentUser.Uid, nil
+}
+
+// targetIn is mimi's job as launchctl names it, under a domain already in
+// hand. Every call that takes a domain target — bootout, print, kickstart —
+// names the same job, so none of them spells it out for itself.
+//
+// It is not what launchctl start and stop take: those two predate domain
+// targets and take the bare label.
+func targetIn(domain string) string {
+	return domain + "/" + Label
+}
+
+// serviceTarget is [targetIn] for the caller that has no domain yet, which is
+// every one of them but [Service.apply] — that one holds the domain already,
+// because bootstrap is the one call that takes it bare.
+func serviceTarget() (string, error) {
+	domain, err := guiDomain()
+	if err != nil {
+		return "", err
+	}
+
+	return targetIn(domain), nil
 }
 
 // binaryPath resolves the real, symlink-free path to the running mimi

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -86,6 +86,11 @@ type fakeLauncher struct {
 	printOutput string
 	printErr    error
 	printedFor  string
+
+	kickstartErr error
+	// kickstartedFor is the target the restart named, which is the domain one
+	// rather than the bare label start and stop take.
+	kickstartedFor string
 }
 
 func (f *fakeLauncher) list(_ context.Context, _ string) (bool, error) {
@@ -161,6 +166,13 @@ func (f *fakeLauncher) stop(_ context.Context, _ string) error {
 	f.calls = append(f.calls, "stop")
 
 	return f.stopErr
+}
+
+func (f *fakeLauncher) kickstart(_ context.Context, target string) error {
+	f.kickstartedFor = target
+	f.calls = append(f.calls, "kickstart")
+
+	return f.kickstartErr
 }
 
 // newTestService is a [Service] whose waiting costs nothing. The interval
@@ -425,17 +437,133 @@ func TestService_Stop_RunsLaunchctlStop(t *testing.T) {
 	}
 }
 
-func TestService_Restart_StopsThenStartsEvenWhenStopFails(t *testing.T) {
-	fake := &fakeLauncher{stopErr: derrors.New(derrors.CodeServiceFailed, "wasn't running")}
+// TestService_Stop_WrapsTheLauncherErrorWithADerrorsCode is the other half of
+// stop still being a command of its own. Restart no longer runs it, so a stop
+// that fails is now only ever a `mimi services stop` that failed, and its
+// failure has to reach the user as one.
+func TestService_Stop_WrapsTheLauncherErrorWithADerrorsCode(t *testing.T) {
+	fake := &fakeLauncher{stopErr: derrors.New(derrors.CodeServiceFailed, "boom")}
+	svc := newTestService(fake)
+
+	err := svc.Stop(t.Context())
+	if err == nil {
+		t.Fatal("Stop() = nil, want an error")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Stop() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+}
+
+// TestService_Restart_ReportsThatNothingIsInstalled covers the failure restart
+// used to name wrongly. A service that is not loaded has nothing to stop and
+// nothing to start, and the old pair reported the second of those as "starting
+// service" — the symptom, over a machine where the actual answer is that no
+// service was ever installed.
+func TestService_Restart_ReportsThatNothingIsInstalled(t *testing.T) {
+	fake := &fakeLauncher{loaded: false}
+	svc := newTestService(fake)
+
+	err := svc.Restart(t.Context())
+	if err == nil {
+		t.Fatal("Restart() = nil, want the absent service reported")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Restart() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	// The advice is the whole point of the message: a user reaching for restart
+	// has something wrong already, and install is what fixes this one.
+	if !strings.Contains(err.Error(), "mimi services install") {
+		t.Errorf("Restart() = %q, want it to point at `mimi services install`", err)
+	}
+
+	if len(fake.calls) != 0 {
+		t.Errorf(
+			"Restart() made %v, want nothing run against a service that is not there",
+			fake.calls,
+		)
+	}
+}
+
+// TestService_Restart_DoesNotReadAnUnaskableLaunchctlAsNothingInstalled is the
+// third answer [LoadState] exists for, on the command with the most to lose by
+// collapsing it into the second. A launchctl that could not run says nothing
+// about whether a service is installed, and sending that user off to install
+// one is wrong advice twice over: it names a problem the machine may not have,
+// and the install it recommends would fail on the very same launchctl.
+func TestService_Restart_DoesNotReadAnUnaskableLaunchctlAsNothingInstalled(t *testing.T) {
+	fake := &fakeLauncher{listErr: errLaunchctlMissing}
+	svc := newTestService(fake)
+
+	err := svc.Restart(t.Context())
+	if err == nil {
+		t.Fatal("Restart() = nil, want the launchctl that could not be run reported")
+	}
+
+	if strings.Contains(err.Error(), "mimi services install") {
+		t.Errorf(
+			"Restart() = %q, want no install advice over a service nobody could ask about",
+			err,
+		)
+	}
+
+	if !errors.Is(err, errLaunchctlMissing) {
+		t.Errorf("Restart() = %q, want it to carry why launchctl could not answer", err)
+	}
+
+	if len(fake.calls) != 0 {
+		t.Errorf("Restart() made %v, want nothing run on an unanswered load state", fake.calls)
+	}
+}
+
+// TestService_Restart_RestartsALoadedServiceInOneLaunchdCall pins what replaced
+// the stop-then-start pair. The pair had two failures where a restart has one,
+// and it discarded the first of them; one kickstart is the whole restart, so
+// there is no error left to throw away.
+func TestService_Restart_RestartsALoadedServiceInOneLaunchdCall(t *testing.T) {
+	fake := &fakeLauncher{loaded: true}
 	svc := newTestService(fake)
 
 	err := svc.Restart(t.Context())
 	if err != nil {
-		t.Fatalf("Restart() = %v, want nil (start succeeded)", err)
+		t.Fatalf("Restart() = %v, want nil", err)
 	}
 
-	if !fake.stopped || !fake.started {
-		t.Errorf("Restart() stopped=%v started=%v, want both true", fake.stopped, fake.started)
+	if got := strings.Join(fake.calls, ","); got != "kickstart" {
+		t.Errorf("Restart() made %q, want a single kickstart", got)
+	}
+
+	// kickstart takes a domain target, not the bare label launchctl start and
+	// stop take.
+	if !strings.HasSuffix(fake.kickstartedFor, "/"+Label) {
+		t.Errorf(
+			"Restart() kickstarted %q, want a domain target for %q",
+			fake.kickstartedFor,
+			Label,
+		)
+	}
+}
+
+// TestService_Restart_WrapsAFailedKickstartWithADerrorsCode covers the failure
+// the old pair could not report at all: a loaded service launchd refused to
+// restart used to be reported as a failure to start.
+func TestService_Restart_WrapsAFailedKickstartWithADerrorsCode(t *testing.T) {
+	fake := &fakeLauncher{loaded: true, kickstartErr: errKickstartRefused}
+	svc := newTestService(fake)
+
+	err := svc.Restart(t.Context())
+	if err == nil {
+		t.Fatal("Restart() = nil, want the refused kickstart reported")
+	}
+
+	if derrors.GetCode(err) != derrors.CodeServiceFailed {
+		t.Errorf("Restart() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
+	}
+
+	if !errors.Is(err, errKickstartRefused) {
+		t.Errorf("Restart() = %q, want it to carry why launchd refused", err)
 	}
 }
 
@@ -453,6 +581,10 @@ var (
 // has not finished letting go of, in the same plain shape a real launchctl
 // failure arrives in.
 var errBootstrapInProgress = errors.New("operation now in progress")
+
+// errKickstartRefused is a restart launchd would not perform on a job it does
+// hold, in the plain shape exec hands such a failure back.
+var errKickstartRefused = errors.New("operation not permitted")
 
 // errLaunchctlMissing is launchctl failing to run at all, in the shape exec
 // reports it: not a job launchd denies having, but a question that never


### PR DESCRIPTION
## Description

This PR fixes `mimi services restart` naming the wrong problem when there is nothing to restart. Restart was a stop whose failure was thrown away followed by a start, so on a machine with no service installed both halves failed at nothing and the one surviving failure said "starting service" — the symptom of the absent service rather than the absent service. Restart is what someone reaches for when something is already wrong, so it is the command that can least afford to misreport why.

Restart is now a single launchd restart of the loaded job, preceded by a check that there is one. launchd will not restart a job it does not hold, so that check costs a call that would have failed anyway and buys the advice the old failure could never give: install the service. A `launchctl` that could not be run at all is deliberately not that answer — nothing there knows whether a service is installed, and the install it would recommend runs through the same `launchctl` — so it is reported as itself.

One call is also one error, so the discarded stop is gone by construction rather than by remembering to check it. `mimi services start` and `mimi services stop` are untouched and remain commands of their own.

## Related Issues

Closes #155

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Command surface

No commands, flags, config keys, or hook variables are added, removed, or renamed. `mimi services restart` takes the same (no) arguments it always did; `start`, `stop`, `install`, `uninstall`, and `status` are unchanged. What changes is what `restart` prints and when — see below. The command's `--help` text is rewritten to match.

## Changed user-visible output

Exit codes are unchanged: every case below exited 1 before and exits 1 now. Only the message changes, and only on the failing paths.

**Nothing installed** — the case the issue is about:

```
# before
Error: [SERVICE_FAILED] starting service: exit status 3

# after
Error: [SERVICE_FAILED] there is no loaded service to restart; run `mimi services install` first
```

**`launchctl` not runnable at all** (not on `PATH`, or unable to be spawned):

```
# before
Error: [SERVICE_FAILED] starting service: exec: "launchctl": executable file not found in $PATH

# after
Error: [SERVICE_FAILED] asking launchctl whether the service is loaded: exec: "launchctl": executable file not found in $PATH
```

Neither of those gets the install advice, on purpose: an unanswerable `launchctl` is not a missing service, and sending that user to reinstall a service that may be running perfectly well would be wrong twice over.

**A loaded service that restarts** prints `Service restarted` and exits 0, exactly as before.

**A loaded service launchd refuses to restart** now reports `restarting service: <reason>` where it previously reported a failure to start. Nothing scripted around the old wording, since the old wording was already the wrong description of the failure.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

`just vet` also passes. No Objective-C was touched, but `just fmt` ran its formatter regardless.

## Additional Context

**On the issue's fourth acceptance criterion.** "The launchd user domain string is built in one place rather than repeated per command" was already satisfied before this branch: the issue was written against the code as it stood at `81f1b44`, where `"gui/" + currentUser.Uid` was assembled inline in both install and uninstall, and #159 extracted that into one helper on its way past. What was still repeated was the full job target — the domain with the label under it — spelled out separately by unload, describe, and now restart. Since the new restart needed the same string, this PR gives that one builder too and routes the existing three through it. That is the only part of the diff touching code outside restart.

**Why a loaded-check before the restart rather than after a failure.** launchd's restart errors on a job it does not hold, so the failure alone could have been translated into the advice. It is not, because the error text is undocumented and its exit codes are not promised — the same reasoning the load-state check already applies elsewhere in this package. Asking first costs one cheap call and does not depend on parsing anything.

**Deliberate limitation.** The check distinguishes loaded from not-loaded, so a service whose plist is on disk but not loaded is reported as "no loaded service to restart". Pointing that user at install is still the right fix — install is idempotent and loads what it finds — but the message says "loaded" rather than "installed" so that it is not claiming more than it checked.

**Tests.** The new behaviour is covered through the existing launcher fake: nothing installed, an unanswerable `launchctl`, the single-call restart of a loaded service, and a refused restart. One test uses a stub `launchctl` on `PATH` instead, because the flag that makes this a restart rather than a start is invisible to the fake, which only ever sees a target. Stop gained the failure test its sibling start already had, now that restart no longer exercises that path incidentally.
