### PR TITLE
fix(service): escape every value substituted into the launchd plist

### DIFF
--- a/internal/service/plist.go
+++ b/internal/service/plist.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"encoding/xml"
+	"errors"
+	"io"
 	"path/filepath"
 	"strings"
 )
@@ -131,15 +133,11 @@ func renderPlist(binPath, configPath, logFile, servicePath string) string {
 // escapeXMLText writes it as &#xD;, along with the tab and newline that have
 // the same problem in weaker form.
 //
-// The price is that it also escapes the quote and apostrophe an XML text node
-// does not require escaped. Those render as &#34; and &#39;, which every parser
-// resolves back to the character itself; a path carrying one is rendered more
-// verbosely than it strictly needs, never wrongly.
-//
-// A path that is not valid UTF-8 has no XML representation at all, and
-// encoding/xml substitutes U+FFFD. Such a path cannot reach launchd intact by
-// any escaping; what this buys is a plist launchd still parses, failing at a
-// path that does not exist rather than at a file it will not read.
+// The price is the quote and apostrophe it escapes that a text node does not
+// require escaped, and the U+FFFD it substitutes for a byte sequence that is
+// not valid UTF-8 — which no escaping could have carried into XML anyway. Both
+// cost a path that is written more verbosely, or a path launchd cannot open;
+// neither costs a plist it refuses to read.
 func escapeXMLText(value string) string {
 	var escaped strings.Builder
 
@@ -148,6 +146,55 @@ func escapeXMLText(value string) string {
 	_ = xml.EscapeText(&escaped, []byte(value))
 
 	return escaped.String()
+}
+
+// unescapeXMLText resolves the text of a <string> back to the value it stands
+// for, undoing escapeXMLText for the status that reads an installed plist back.
+// It sits beside its inverse and is encoding/xml doing the work, so that the
+// two sides cannot drift: whatever the escaper learns to write, this reads.
+//
+// Anything that is not escaped text comes back exactly as it was read: text
+// this cannot parse, and equally text it can — markup escapeXMLText would never
+// have written parses cleanly, and resolving it would drop the tags and hand
+// back a shorter path that names nothing. That is a plist mimi did not write —
+// home-manager's, or a hand-edited one — and the reader's bargain everywhere
+// else is to degrade the detail rather than invent one, so the text on disk is
+// the better answer.
+func unescapeXMLText(value string) string {
+	var (
+		decoder = xml.NewDecoder(strings.NewReader("<v>" + value + "</v>"))
+		decoded strings.Builder
+		depth   int
+	)
+
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return decoded.String()
+		}
+
+		if err != nil {
+			return value
+		}
+
+		switch typed := token.(type) {
+		case xml.CharData:
+			decoded.Write(typed)
+		case xml.StartElement:
+			// The wrapper this reads the value inside of is the only element
+			// escaped text can hold.
+			depth++
+			if depth > 1 {
+				return value
+			}
+		case xml.EndElement:
+			depth--
+		default:
+			// A comment, processing instruction or directive is not text
+			// either, and dropping it would shorten the value just as quietly.
+			return value
+		}
+	}
 }
 
 // servicePathFor is the PATH value the plist gets for a given

--- a/internal/service/plist.go
+++ b/internal/service/plist.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/xml"
 	"path/filepath"
 	"strings"
 )
@@ -95,40 +96,69 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 // servicePath is settings.service_path, and is optional: an empty one renders
 // the PATH the plist hardcoded before that setting existed, so a config that
 // never mentions it produces the same bytes as ever.
+//
+// Every value it substitutes goes through escapeXMLText, without exception:
+// each one is a path the user chose, and any of them may legally be named with
+// something that is markup here. Escaping changes nothing about an ordinary
+// path, which is why the golden test still pins the same bytes.
 func renderPlist(binPath, configPath, logFile, servicePath string) string {
 	streams := capturedStreamsFor(logFile)
 
-	content := strings.ReplaceAll(plistTemplate, "MIMI_BINARY_PATH", binPath)
-	content = strings.ReplaceAll(content, "MIMI_CONFIG_PATH", configPath)
-	content = strings.ReplaceAll(content, "MIMI_STDOUT_PATH", streams.stdout)
-	content = strings.ReplaceAll(content, "MIMI_STDERR_PATH", streams.stderr)
+	content := strings.ReplaceAll(plistTemplate, "MIMI_BINARY_PATH", escapeXMLText(binPath))
+	content = strings.ReplaceAll(content, "MIMI_CONFIG_PATH", escapeXMLText(configPath))
+	content = strings.ReplaceAll(content, "MIMI_STDOUT_PATH", escapeXMLText(streams.stdout))
+	content = strings.ReplaceAll(content, "MIMI_STDERR_PATH", escapeXMLText(streams.stderr))
 
-	return strings.ReplaceAll(content, "MIMI_SERVICE_PATH", servicePathFor(servicePath))
+	return strings.ReplaceAll(
+		content,
+		"MIMI_SERVICE_PATH",
+		escapeXMLText(servicePathFor(servicePath)),
+	)
 }
 
-// xmlTextEscaper escapes the characters that end an XML text node, so a value
-// carrying one cannot break out of the <string> it is rendered into. A plist
-// that is not well-formed is one launchd silently refuses at login, which is
-// the failure mode furthest from where it would be noticed.
+// escapeXMLText renders a value as the XML text node it is substituted into, so
+// that a value carrying markup cannot break out of the <string> around it. A
+// plist that is not well-formed is one launchd silently refuses at login, which
+// is the failure mode furthest from where it would be noticed — the install
+// that wrote it has already reported success.
 //
-// It is applied to service_path only, because that is the value this render
-// gained. The binary, config and captured-stream paths have always been
-// substituted raw and still are; a directory named with an XML metacharacter
-// breaks the plist there too, and fixing that is its own change rather than a
-// side effect of adding a setting.
+// It is encoding/xml's own escaper rather than a replacer over "&", "<" and
+// ">", because the set of characters a path must not carry into XML raw is
+// larger than those three and is not obvious from reading the file. A carriage
+// return is the one that matters: it is legal in a macOS path, well-formed in a
+// text node, and rewritten to a newline by every conformant parser — so a raw
+// one would hand launchd a different path than the user configured, silently.
+// escapeXMLText writes it as &#xD;, along with the tab and newline that have
+// the same problem in weaker form.
 //
-//nolint:gochecknoglobals // an immutable replacer, built once
-var xmlTextEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+// The price is that it also escapes the quote and apostrophe an XML text node
+// does not require escaped. Those render as &#34; and &#39;, which every parser
+// resolves back to the character itself; a path carrying one is rendered more
+// verbosely than it strictly needs, never wrongly.
+//
+// A path that is not valid UTF-8 has no XML representation at all, and
+// encoding/xml substitutes U+FFFD. Such a path cannot reach launchd intact by
+// any escaping; what this buys is a plist launchd still parses, failing at a
+// path that does not exist rather than at a file it will not read.
+func escapeXMLText(value string) string {
+	var escaped strings.Builder
+
+	// EscapeText fails only when its writer does, and a strings.Builder never
+	// does.
+	_ = xml.EscapeText(&escaped, []byte(value))
+
+	return escaped.String()
+}
 
 // servicePathFor is the PATH value the plist gets for a given
-// settings.service_path: the configured one, escaped for XML, or the default
-// when the setting is unset.
+// settings.service_path: the configured one or, when the setting is unset, the
+// default. Escaping is renderPlist's, applied to every substituted value alike.
 func servicePathFor(servicePath string) string {
 	if servicePath == "" {
 		return defaultServicePath
 	}
 
-	return xmlTextEscaper.Replace(servicePath)
+	return servicePath
 }
 
 // capturedStreams is where launchd writes the daemon's stdout and stderr. The

--- a/internal/service/plist_test.go
+++ b/internal/service/plist_test.go
@@ -2,6 +2,10 @@
 package service
 
 import (
+	"encoding/xml"
+	"errors"
+	"io"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -14,6 +18,13 @@ const (
 	testLogFile        = "/Users/test/.local/state/mimi/mimi.log"
 	testCapturedStdout = "/Users/test/.local/state/mimi/mimi.out.log"
 )
+
+// testBinPath is the installed binary the tests in this file render against.
+// It is an input rather than an expectation: a case exercising some other
+// value passes this one so that nothing but the value under test is unusual.
+// testConfigPath, its counterpart for the config path, lives in
+// service_test.go.
+const testBinPath = "/usr/local/bin/mimi"
 
 // wantGoldenPlist is the full plist renderPlist must produce for binPath
 // "/usr/local/bin/mimi", configPath "/Users/test/.config/mimi/config.toml" and
@@ -38,8 +49,8 @@ const wantGoldenPlist = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE p
 // installed service on the next install, and has to be made deliberately.
 func TestRenderPlist_MatchesTheGoldenOutputByteForByte(t *testing.T) {
 	got := renderPlist(
-		"/usr/local/bin/mimi",
-		"/Users/test/.config/mimi/config.toml",
+		testBinPath,
+		testConfigPath,
 		testLogFile,
 		"",
 	)
@@ -81,8 +92,8 @@ func TestRenderPlist_ServicePath(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			got := renderPlist(
-				"/usr/local/bin/mimi",
-				"/Users/test/.config/mimi/config.toml",
+				testBinPath,
+				testConfigPath,
 				testLogFile,
 				testCase.servicePath,
 			)
@@ -186,8 +197,8 @@ func TestRenderPlist_CapturedStreamPaths(t *testing.T) {
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			got := renderPlist(
-				"/usr/local/bin/mimi",
-				"/Users/test/.config/mimi/config.toml",
+				testBinPath,
+				testConfigPath,
 				testCase.logFile,
 				"",
 			)
@@ -238,6 +249,167 @@ func TestRenderPlist_CapturedStreamPaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRenderPlist_EscapesEveryValueItSubstitutes pins that a path carrying an
+// XML metacharacter reaches the plist escaped, whichever of the substituted
+// values carries it. A directory may legally be named with "&", "<" or ">", and
+// a plist that is not well-formed XML is one launchd refuses to load at login —
+// long after the install that wrote it reported success.
+//
+// Each case asserts both halves of that: the exact escaped bytes, so the
+// escaping cannot quietly change, and the value read back out of a real XML
+// parse, so escaping that produced something a parser resolves to a different
+// path would fail here rather than at login.
+func TestRenderPlist_EscapesEveryValueItSubstitutes(t *testing.T) {
+	// The PATH the service-path case configures, named because the case both
+	// passes it in and expects it back out of the parse — the whole point being
+	// that those are the same string.
+	const markupServicePath = "/Users/test/bin & tools/<x>:/usr/bin"
+
+	tests := []struct {
+		name        string
+		binPath     string
+		configPath  string
+		logFile     string
+		servicePath string
+		// wantEscaped are the rendered fragments, spelled out with the
+		// escapes the plist must carry.
+		wantEscaped []string
+		// wantDecoded are the values an XML parser must hand back, spelled
+		// out raw — what launchd ends up executing, opening or exporting.
+		wantDecoded []string
+	}{
+		{
+			name:        "binary path",
+			binPath:     "/Users/test/bin & <tools>/mimi",
+			configPath:  testConfigPath,
+			logFile:     testLogFile,
+			servicePath: "",
+			wantEscaped: []string{"<string>/Users/test/bin &amp; &lt;tools&gt;/mimi</string>"},
+			wantDecoded: []string{"/Users/test/bin & <tools>/mimi"},
+		},
+		{
+			name:        "config path",
+			binPath:     testBinPath,
+			configPath:  "/Users/test/.config/mimi & <x>/config.toml",
+			logFile:     testLogFile,
+			servicePath: "",
+			wantEscaped: []string{
+				"<string>/Users/test/.config/mimi &amp; &lt;x&gt;/config.toml</string>",
+			},
+			wantDecoded: []string{"/Users/test/.config/mimi & <x>/config.toml"},
+		},
+		{
+			// Both captured-stream paths are derived from log_file, and each is
+			// substituted twice: once for launchd to write to, once for the
+			// environment entry the daemon reads it back out of.
+			name:        "captured stream paths derived from log_file",
+			binPath:     testBinPath,
+			configPath:  testConfigPath,
+			logFile:     "/Users/test/logs & <x>/mimi.log",
+			servicePath: "",
+			wantEscaped: []string{
+				"<key>StandardOutPath</key>\n    <string>/Users/test/logs &amp; &lt;x&gt;/mimi.out.log</string>",
+				"<key>StandardErrorPath</key>\n    <string>/Users/test/logs &amp; &lt;x&gt;/mimi.err.log</string>",
+				"<key>MIMI_CAPTURED_STDOUT</key>\n        <string>/Users/test/logs &amp; &lt;x&gt;/mimi.out.log</string>",
+				"<key>MIMI_CAPTURED_STDERR</key>\n        <string>/Users/test/logs &amp; &lt;x&gt;/mimi.err.log</string>",
+			},
+			wantDecoded: []string{
+				"/Users/test/logs & <x>/mimi.out.log",
+				"/Users/test/logs & <x>/mimi.err.log",
+			},
+		},
+		{
+			name:        "service path",
+			binPath:     testBinPath,
+			configPath:  testConfigPath,
+			logFile:     testLogFile,
+			servicePath: markupServicePath,
+			wantEscaped: []string{
+				"<key>PATH</key>\n        <string>/Users/test/bin &amp; tools/&lt;x&gt;:/usr/bin</string>",
+			},
+			wantDecoded: []string{markupServicePath},
+		},
+		{
+			// A carriage return is legal in a macOS path and well-formed in an
+			// XML text node, but every parser rewrites a raw one to a newline —
+			// so launchd would be handed a path the user never configured. It
+			// has to reach the plist as a character reference.
+			name:        "path carrying a carriage return an XML parser would rewrite",
+			binPath:     testBinPath,
+			configPath:  "/Users/test/.config/mi\rmi/config.toml",
+			logFile:     testLogFile,
+			servicePath: "",
+			wantEscaped: []string{"<string>/Users/test/.config/mi&#xD;mi/config.toml</string>"},
+			wantDecoded: []string{"/Users/test/.config/mi\rmi/config.toml"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := renderPlist(
+				testCase.binPath,
+				testCase.configPath,
+				testCase.logFile,
+				testCase.servicePath,
+			)
+
+			for _, want := range testCase.wantEscaped {
+				if !strings.Contains(got, want) {
+					t.Errorf("renderPlist() does not contain %q:\n%s", want, got)
+				}
+			}
+
+			decoded := parsePlistStrings(t, got)
+			for _, want := range testCase.wantDecoded {
+				if !slices.Contains(decoded, want) {
+					t.Errorf("parsed plist has no <string> %q, only %q", want, decoded)
+				}
+			}
+		})
+	}
+}
+
+// parsePlistStrings decodes a rendered plist with a real XML parser and returns
+// every <string> value it holds. Failing to parse fails the test: that is the
+// whole of what launchd rejects a plist for, and the only check that a value
+// this package escaped by hand is a value a parser agrees with.
+func parsePlistStrings(t *testing.T, content string) []string {
+	t.Helper()
+
+	var (
+		decoder  = xml.NewDecoder(strings.NewReader(content))
+		values   []string
+		inString bool
+	)
+
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("rendered plist is not well-formed XML: %v\n%s", err, content)
+		}
+
+		switch typed := token.(type) {
+		case xml.StartElement:
+			inString = typed.Name.Local == "string"
+			if inString {
+				values = append(values, "")
+			}
+		case xml.CharData:
+			if inString {
+				values[len(values)-1] += string(typed)
+			}
+		case xml.EndElement:
+			inString = false
+		}
+	}
+
+	return values
 }
 
 func TestRenderPlist_Table(t *testing.T) {

--- a/internal/service/status.go
+++ b/internal/service/status.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"encoding/xml"
+	"errors"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -141,6 +144,11 @@ func describeCapturedLog(path string) CapturedLog {
 // pinned byte for byte by a golden test. A key whose next element is not a
 // <string> — or that another key gets in front of — reads as absent, so a plist
 // of some other shape costs the detail rather than inventing one.
+//
+// What it does not skimp on is the escaping, because renderPlist escapes every
+// path it writes: a directory named with XML markup sits in the file as markup,
+// and handing that straight back would name a file that does not exist and
+// report it missing. The value is resolved back to the path it stands for.
 func plistString(content, key string) string {
 	_, after, found := strings.Cut(content, "<key>"+key+"</key>")
 	if !found {
@@ -157,5 +165,36 @@ func plistString(content, key string) string {
 		return ""
 	}
 
-	return value
+	return unescapeXMLText(value)
+}
+
+// unescapeXMLText resolves the text of a <string> back to the value it stands
+// for, undoing escapeXMLText. It is encoding/xml doing it, so that the two
+// sides cannot drift: whatever the escaper learns to write, this reads.
+//
+// A value it cannot resolve comes back exactly as it was read. That is a plist
+// mimi did not write — home-manager's, or a hand-edited one — and this reader's
+// bargain everywhere else is to degrade the detail rather than invent one, so
+// the text on disk is a better answer than a partially decoded path.
+func unescapeXMLText(value string) string {
+	var (
+		decoder = xml.NewDecoder(strings.NewReader("<v>" + value + "</v>"))
+		decoded strings.Builder
+	)
+
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return decoded.String()
+		}
+
+		if err != nil {
+			return value
+		}
+
+		chars, isText := token.(xml.CharData)
+		if isText {
+			decoded.Write(chars)
+		}
+	}
 }

--- a/internal/service/status.go
+++ b/internal/service/status.go
@@ -1,9 +1,6 @@
 package service
 
 import (
-	"encoding/xml"
-	"errors"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -166,35 +163,4 @@ func plistString(content, key string) string {
 	}
 
 	return unescapeXMLText(value)
-}
-
-// unescapeXMLText resolves the text of a <string> back to the value it stands
-// for, undoing escapeXMLText. It is encoding/xml doing it, so that the two
-// sides cannot drift: whatever the escaper learns to write, this reads.
-//
-// A value it cannot resolve comes back exactly as it was read. That is a plist
-// mimi did not write — home-manager's, or a hand-edited one — and this reader's
-// bargain everywhere else is to degrade the detail rather than invent one, so
-// the text on disk is a better answer than a partially decoded path.
-func unescapeXMLText(value string) string {
-	var (
-		decoder = xml.NewDecoder(strings.NewReader("<v>" + value + "</v>"))
-		decoded strings.Builder
-	)
-
-	for {
-		token, err := decoder.Token()
-		if errors.Is(err, io.EOF) {
-			return decoded.String()
-		}
-
-		if err != nil {
-			return value
-		}
-
-		chars, isText := token.(xml.CharData)
-		if isText {
-			decoded.Write(chars)
-		}
-	}
 }

--- a/internal/service/status_test.go
+++ b/internal/service/status_test.go
@@ -186,6 +186,26 @@ func TestPlistString(t *testing.T) {
 			key:     testStandardOutKey,
 			want:    "",
 		},
+		{
+			// renderPlist escapes every path it writes, so a directory named
+			// with XML markup arrives here as markup. Handing that back
+			// unresolved would print a path no such file has and size it as
+			// missing — the confident wrong answer this reader exists to avoid.
+			name: "a value carrying the escapes renderPlist writes",
+			content: "<key>StandardOutPath</key>\n" +
+				"    <string>/Users/test/logs &amp; &lt;x&gt;/mi&#xD;mi.out.log</string>",
+			key:  testStandardOutKey,
+			want: "/Users/test/logs & <x>/mi\rmi.out.log",
+		},
+		{
+			// A plist mimi did not write may hold anything. One this cannot
+			// resolve comes back exactly as it was read, which is what this
+			// reader did before it resolved anything at all.
+			name:    "a value that is not resolvable comes back unchanged",
+			content: "<key>StandardOutPath</key>\n    <string>/tmp/mi&nosuch;mi.log</string>",
+			key:     testStandardOutKey,
+			want:    "/tmp/mi&nosuch;mi.log",
+		},
 		{name: "nothing to read at all", content: "", key: testStandardOutKey, want: ""},
 	}
 

--- a/internal/service/status_test.go
+++ b/internal/service/status_test.go
@@ -206,6 +206,15 @@ func TestPlistString(t *testing.T) {
 			key:     testStandardOutKey,
 			want:    "/tmp/mi&nosuch;mi.log",
 		},
+		{
+			// Markup renderPlist would never write parses, but it is not
+			// escaped text and resolving it would drop the tags — naming a
+			// shorter path that exists nowhere. It comes back as it was read.
+			name:    "a value that is markup rather than escaped text comes back unchanged",
+			content: "<key>StandardOutPath</key>\n    <string>/tmp/a<b>c</b>d.log</string>",
+			key:     testStandardOutKey,
+			want:    "/tmp/a<b>c</b>d.log",
+		},
 		{name: "nothing to read at all", content: "", key: testStandardOutKey, want: ""},
 	}
 


### PR DESCRIPTION
## Description

This PR fixes `mimi services install` writing a launchd job file that launchd
silently refuses. A binary path, config path or log directory whose name
contains `&`, `<` or `>` was written into that file as-is, which made it
malformed: the install still reported success, the service never started at
login, and nothing said why. Only the configurable service `PATH` was ever
written safely; every value is now written the same way, and such a service
loads and runs.

The escaping is the standard library's, so it also covers a carriage return in
a path — legal on macOS, and something an XML reader would otherwise turn into
a newline, handing launchd a path the user never configured. An ordinary path
is written exactly as before, so the file every existing install has on disk is
byte-for-byte unchanged and no service is disturbed by this.

`mimi services status` reads the captured log paths back out of that file to
size those logs, so it now resolves what the installer wrote rather than
printing a path no such file has and calling the log missing.

## Related Issues

Closes #170

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changes; no config key, command or output format moves.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The escaping is `encoding/xml`'s own rather than a hand-written replacer over
`&`, `<` and `>`. Those three are what an install trips over in practice, but
they are not the whole set, and the difference is not obvious from reading the
code: a raw carriage return is well-formed and gets rewritten to a newline by
every conformant reader, so it would go wrong silently — the same failure this
issue is about, one step further from where anyone would look. The trade is
that the quote and apostrophe come out as numeric references too, which every
reader resolves back to the character; a path carrying one is written more
verbosely than it needs to be, never wrongly.

The rendered output was checked against macOS's own parser, not just the tests:
`plutil -lint` accepts a file rendered with `&`, `<`, `>`, a carriage return, a
quote and an apostrophe in the paths, and `plutil -extract` hands every one of
them back unchanged.

Reading the captured log paths back is included because this change is what
first puts an escaped value where that reader looks — leaving it out would have
traded a service that will not start for a status that reports the wrong file.
That reader stays conservative: a file mimi did not write — a hand-edited one,
or Nix's — may hold something that is not escaped text at all, and anything of
that kind is reported exactly as it appears rather than resolved into a
shorter path that names nothing.

Two related things were left alone deliberately. A path containing one of the
template's own placeholder words is still mangled by a later substitution pass
— a separate bug, older than this change, and a separate fix. And a service
installed through the Nix module is unaffected either way: that file is built
by Nix, which handles this itself.
