### PR TITLE
fix(nix,daemon): keep the module-installed service's captured console logs bounded

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -219,9 +219,15 @@ Notes on this:
   `Service already up to date` and does nothing when it does not.
 - The Nix modules (`nix/darwin.nix`, `nix/home.nix`) write their own plists,
   which always use `/tmp/mimi.log` and `/tmp/mimi.err.log` regardless of
-  `settings.log_file`. They carry no `MIMI_CAPTURED_*` entries either, so a
-  daemon from one of those modules appends to both files forever and never
-  empties them.
+  `settings.log_file`. Both carry the two `MIMI_CAPTURED_*` entries, filled
+  from the paths their own job writes to, so a module-installed daemon empties
+  those files at startup exactly as an installed one does. A service from a
+  module version before this behaviour existed keeps appending until the next
+  `darwin-rebuild switch` or `home-manager switch` — that is what rewrites the
+  plist. Overriding the job's `StandardOutPath` or `StandardErrorPath` moves
+  the matching environment entry with it; setting either entry through
+  `services.mimi.extraEnvironment` has no effect, since one naming a file the
+  job does not write to would empty the wrong log.
 
 ## Permission prompt keeps appearing
 

--- a/internal/daemon/captured_logs.go
+++ b/internal/daemon/captured_logs.go
@@ -10,18 +10,21 @@ import (
 // The environment entries the installed launchd plist carries the daemon's
 // captured stdout and stderr in.
 //
-// They are set by the plist `mimi services install` renders, and by nothing
-// else. The daemon deliberately does not ask internal/service to derive these
-// paths for it: that package is the install-time surface, and a daemon that
-// derived them itself would truncate files it was never told it owns — every
-// hand-started `mimi start` would empty the previous launchd run's crash log,
-// which is the one artifact the captured streams exist to preserve. Learning
-// them from the environment is what makes "launchd started me" the condition,
-// with no way to get it wrong.
+// They are set by the plist `mimi services install` renders and by the agents
+// the Nix modules render, and by nothing else — every one of them a launchd
+// job of mimi's. The daemon deliberately does not ask internal/service to
+// derive these paths for it: that package is the install-time surface, and a
+// daemon that derived them itself would truncate files it was never told it
+// owns — every hand-started `mimi start` would empty the previous launchd
+// run's crash log, which is the one artifact the captured streams exist to
+// preserve. Learning them from the environment is what makes "launchd started
+// me" the condition, with no way to get it wrong.
 //
 // internal/service spells these same two names in its plist template. Nothing
 // but the names holds the two sides together, so the test on each side spells
-// the literals and a rename fails a test there.
+// the literals and a rename fails a test there. nix/darwin.nix and
+// nix/home.nix spell them a third time, out of reach of any Go test — a rename
+// has to be carried into both by hand.
 const (
 	envCapturedStdout = "MIMI_CAPTURED_STDOUT"
 	envCapturedStderr = "MIMI_CAPTURED_STDERR"

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -8,10 +8,28 @@ let
   cfg = config.services.mimi;
   configFile =
     if cfg.configFile != null then cfg.configFile else pkgs.writeText "config.toml" cfg.config;
+  # The two console streams launchd captures for this job, named for the daemon.
+  #
+  # Nothing rotates them, so the daemon empties both once at startup, and these
+  # two entries are the whole of what tells it which files those are —
+  # internal/daemon/captured_logs.go has the why.
+  #
+  # Both paths are read back out of the job's own `serviceConfig` rather than
+  # written here as a second pair of literals. The daemon empties exactly what
+  # it is pointed at, so an entry naming a file the job does not write to would
+  # destroy one log and leave the real one growing forever. Taking the strings
+  # from the option launchd itself is given means an override of either path
+  # moves its environment entry with it, and the two cannot come to name
+  # different files.
+  capturedStreams = {
+    MIMI_CAPTURED_STDOUT = config.launchd.user.agents.mimi.serviceConfig.StandardOutPath;
+    MIMI_CAPTURED_STDERR = config.launchd.user.agents.mimi.serviceConfig.StandardErrorPath;
+  };
   effectiveEnv = {
     PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
   }
-  // cfg.extraEnvironment;
+  // cfg.extraEnvironment
+  // capturedStreams;
 in
 {
   options = {
@@ -49,6 +67,14 @@ in
           These are merged with defaults such as a {env}`PATH`
           that includes common Nix binary directories.
           Setting {env}`PATH` here will override the default entirely.
+
+          Setting {env}`MIMI_CAPTURED_STDOUT` or {env}`MIMI_CAPTURED_STDERR`
+          here has no effect. The module always fills those two from the paths
+          launchd writes the captured streams to, which is what tells the daemon
+          which files to empty at each start. Move a stream with
+          {option}`launchd.user.agents.mimi.serviceConfig.StandardOutPath` or
+          {option}`launchd.user.agents.mimi.serviceConfig.StandardErrorPath` and
+          its environment entry follows.
 
           To extend the default PATH with additional directories:
           ```nix

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -18,10 +18,28 @@ let
     ]
     ++ lib.optionals pkgs.stdenv.isDarwin [ "/opt/homebrew/bin" ]
   );
+  # The two console streams launchd captures for this job, named for the daemon.
+  #
+  # Nothing rotates them, so the daemon empties both once at startup, and these
+  # two entries are the whole of what tells it which files those are —
+  # internal/daemon/captured_logs.go has the why.
+  #
+  # Both paths are read back out of the job's own config rather than written
+  # here as a second pair of literals. The daemon empties exactly what it is
+  # pointed at, so an entry naming a file the job does not write to would
+  # destroy one log and leave the real one growing forever. Taking the strings
+  # from the option launchd itself is given means an override of either path
+  # moves its environment entry with it, and the two cannot come to name
+  # different files.
+  capturedStreams = {
+    MIMI_CAPTURED_STDOUT = config.launchd.agents.mimi.config.StandardOutPath;
+    MIMI_CAPTURED_STDERR = config.launchd.agents.mimi.config.StandardErrorPath;
+  };
   effectiveEnv = {
     PATH = defaultPath;
   }
-  // cfg.extraEnvironment;
+  // cfg.extraEnvironment
+  // capturedStreams;
 in
 {
   options = {
@@ -87,6 +105,14 @@ in
           These are merged with defaults such as a {env}`PATH`
           that includes common Nix binary directories and the user's Nix profile.
           Setting {env}`PATH` here will override the default entirely.
+
+          Setting {env}`MIMI_CAPTURED_STDOUT` or {env}`MIMI_CAPTURED_STDERR`
+          here has no effect. The module always fills those two from the paths
+          launchd writes the captured streams to, which is what tells the daemon
+          which files to empty at each start. Move a stream with
+          {option}`launchd.agents.mimi.config.StandardOutPath` or
+          {option}`launchd.agents.mimi.config.StandardErrorPath` and its
+          environment entry follows.
 
           To extend the default PATH with additional directories:
           ```nix


### PR DESCRIPTION
## Description

This PR gives a mimi installed through the nix-darwin or home-manager module the same bounded console logs a `mimi services install`-ed one has had since #168. Both modules render their own launchd agent, so neither carried the two environment entries the daemon reads to learn which captured files are its to empty at startup — a module-installed daemon appended to `/tmp/mimi.log` and `/tmp/mimi.err.log` forever, with nothing able to rotate them, and a crash loop under `KeepAlive` filling them fastest of all. Both modules now carry those entries, so such a daemon empties both files once at each start and each file holds one run's console output.

Each entry is read back out of the very option launchd is given for that stream, rather than repeated as a second literal beside it. Override where a stream is written and its environment entry moves with it, so the paths the daemon empties and the paths the job writes to cannot come to name different files.

Deliberate limitation, out of scope here: where those streams land is unchanged. Both modules still capture to `/tmp`, regardless of `settings.log_file` — unlike an installed service, whose captured streams sit beside the configured log file.

## Related Issues

Closes #169

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, the behaviour is in the Nix modules, which no test tier in this repo evaluates; validated by hand instead, see Additional Context.
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Module surface

Nothing a user writes is renamed or removed, and existing configurations keep working unchanged.

Two environment entries are now always present in the agent's `EnvironmentVariables`, in both modules:

| Entry | Value |
| --- | --- |
| `MIMI_CAPTURED_STDOUT` | whatever the job's `StandardOutPath` is — `/tmp/mimi.log` unless overridden |
| `MIMI_CAPTURED_STDERR` | whatever the job's `StandardErrorPath` is — `/tmp/mimi.err.log` unless overridden |

`services.mimi.extraEnvironment` keeps working as before for every other variable, `PATH` included. Setting either of the two entries above through it now has no effect: the module fills them last, since an entry naming a file the job does not write to would empty the wrong log. This is stated in both modules' `extraEnvironment` descriptions.

Anyone who has moved the captured streams — `launchd.user.agents.mimi.serviceConfig.StandardOutPath` on nix-darwin, `launchd.agents.mimi.config.StandardOutPath` on home-manager, and the matching `StandardErrorPath` — needs to change nothing. The entries are taken from those options, so a moved stream is the file the daemon empties.

## What changes for a module user

On the next `darwin-rebuild switch` or `home-manager switch`, the agent's plist gains the two entries, and from the daemon's next start each of the two captured files holds only the current run's console output. Anything already in them at that point is discarded by that start — copy a file aside first if a crash log in it still matters:

```bash
cp /tmp/mimi.err.log /tmp/mimi-crash.log
```

The structured log at `settings.log_file` is untouched by all of this: it has its own size, age, and backup limits and is written by mimi itself.

## Additional Context

The repo has no tier that evaluates the Nix modules — the flake exposes no `checks`, CI runs only the Go gate, and the one Nix workflow publishes to FlakeHub. So the modules were validated out of tree instead, evaluating each against real upstream (`nix-darwin` and `home-manager`) in three configurations: default, with `services.mimi.extraEnvironment` trying to set a captured entry, and with the stream paths overridden via `lib.mkForce`. In all three the two entries matched the job's own paths; the module also still evaluates with the service disabled. `nixfmt --check` passes on both files.

Reading a job's own option back out of the module's config is the construct that would raise `infinite recursion` if the option were merged strictly; it evaluates cleanly against both upstreams today, and that is the part worth a close look.

One comment in the daemon's captured-log code claimed those entries came from the installed plist and nothing else. That is no longer true, so it now names the modules as the other source, and notes that the two names are spelled a third time in the Nix modules where no Go test can catch a rename.
