### PR TITLE
fix(service): stop the installed plist mangling a path named after one of its placeholders

### DIFF
--- a/internal/service/plist.go
+++ b/internal/service/plist.go
@@ -103,19 +103,24 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 // each one is a path the user chose, and any of them may legally be named with
 // something that is markup here. Escaping changes nothing about an ordinary
 // path, which is why the golden test still pins the same bytes.
+//
+// It fills every token in one pass, over the template and never over its own
+// output, so that a substituted value is text the rendering is finished with.
+// A chain of passes could not promise that: a path is free to be named after
+// one of these tokens, and a later pass scanning an earlier pass's output would
+// find that name inside the user's path and replace it there too. See issue
+// #177, where a config path of "/Users/test/MIMI_SERVICE_PATH/config.toml"
+// rendered with the service PATH spliced into the middle of it.
 func renderPlist(binPath, configPath, logFile, servicePath string) string {
 	streams := capturedStreamsFor(logFile)
 
-	content := strings.ReplaceAll(plistTemplate, "MIMI_BINARY_PATH", escapeXMLText(binPath))
-	content = strings.ReplaceAll(content, "MIMI_CONFIG_PATH", escapeXMLText(configPath))
-	content = strings.ReplaceAll(content, "MIMI_STDOUT_PATH", escapeXMLText(streams.stdout))
-	content = strings.ReplaceAll(content, "MIMI_STDERR_PATH", escapeXMLText(streams.stderr))
-
-	return strings.ReplaceAll(
-		content,
-		"MIMI_SERVICE_PATH",
-		escapeXMLText(servicePathFor(servicePath)),
-	)
+	return strings.NewReplacer(
+		"MIMI_BINARY_PATH", escapeXMLText(binPath),
+		"MIMI_CONFIG_PATH", escapeXMLText(configPath),
+		"MIMI_STDOUT_PATH", escapeXMLText(streams.stdout),
+		"MIMI_STDERR_PATH", escapeXMLText(streams.stderr),
+		"MIMI_SERVICE_PATH", escapeXMLText(servicePathFor(servicePath)),
+	).Replace(plistTemplate)
 }
 
 // escapeXMLText renders a value as the XML text node it is substituted into, so

--- a/internal/service/plist_test.go
+++ b/internal/service/plist_test.go
@@ -371,6 +371,104 @@ func TestRenderPlist_EscapesEveryValueItSubstitutes(t *testing.T) {
 	}
 }
 
+// TestRenderPlist_SubstitutedValueNamedAfterAnotherToken pins that a path which
+// happens to be named after one of the template's *other* tokens reaches the
+// plist literally. Issue #177 demonstrated it with a config path of
+// "/Users/test/MIMI_SERVICE_PATH/config.toml", which rendered as
+// "/Users/test//opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin/config.toml" —
+// the service PATH spliced into the middle of the user's path, so the plist
+// pointed launchd at a file that does not exist.
+//
+// This is not the case TestRenderPlist_Table's "path containing the token-like
+// substring MIMI" covers. There each value carries only its *own* token name,
+// which survives however the substitution is arranged: by the time such a value
+// is in place, whatever would have matched it has already run. The names that
+// break are the ones belonging to a *later* value, and only a substitution that
+// rescans what it has already inserted can break them. Neither test subsumes
+// the other, and the cross-value one is the one that failed before #177.
+//
+// Every case is checked against every token name, including its own, so that
+// the property under test is the whole of it: no substituted value is ever
+// rescanned, whichever token name it happens to contain.
+func TestRenderPlist_SubstitutedValueNamedAfterAnotherToken(t *testing.T) {
+	// Every token renderPlist fills in, spelled out here rather than read from
+	// the template, so a token this test has stopped covering is a token the
+	// code has to have renamed.
+	tokens := []string{
+		"MIMI_BINARY_PATH",
+		"MIMI_CONFIG_PATH",
+		"MIMI_STDOUT_PATH",
+		"MIMI_STDERR_PATH",
+		"MIMI_SERVICE_PATH",
+	}
+
+	tests := []struct {
+		name string
+		// render renders a plist in which the one input this case is about
+		// names dir as a directory component and every other input is ordinary,
+		// and returns it alongside the values that input must produce verbatim.
+		render func(dir string) (plist string, wantValues []string)
+	}{
+		{
+			name: "the binary path",
+			render: func(dir string) (string, []string) {
+				binPath := "/Users/test/" + dir + "/mimi"
+
+				return renderPlist(binPath, testConfigPath, testLogFile, ""), []string{binPath}
+			},
+		},
+		{
+			name: "the config path",
+			render: func(dir string) (string, []string) {
+				configPath := "/Users/test/" + dir + "/config.toml"
+
+				return renderPlist(testBinPath, configPath, testLogFile, ""), []string{configPath}
+			},
+		},
+		{
+			// log_file yields two values, substituted for two different tokens,
+			// so each of them also has to survive the other's name.
+			name: "the captured stream paths derived from log_file",
+			render: func(dir string) (string, []string) {
+				logFile := "/Users/test/" + dir + "/mimi.log"
+
+				return renderPlist(testBinPath, testConfigPath, logFile, ""), []string{
+					"/Users/test/" + dir + "/mimi.out.log",
+					"/Users/test/" + dir + "/mimi.err.log",
+				}
+			},
+		},
+		{
+			name: "the service PATH",
+			render: func(dir string) (string, []string) {
+				servicePath := "/Users/test/" + dir + "/bin:/usr/bin"
+
+				return renderPlist(
+					testBinPath,
+					testConfigPath,
+					testLogFile,
+					servicePath,
+				), []string{servicePath}
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		for _, token := range tokens {
+			t.Run(testCase.name+" named after "+token, func(t *testing.T) {
+				got, wantValues := testCase.render(token)
+
+				for _, wantValue := range wantValues {
+					want := "<string>" + wantValue + "</string>"
+					if !strings.Contains(got, want) {
+						t.Errorf("renderPlist() does not contain %q:\n%s", want, got)
+					}
+				}
+			})
+		}
+	}
+}
+
 // parsePlistStrings decodes a rendered plist with a real XML parser and returns
 // every <string> value it holds. Failing to parse fails the test: that is the
 // whole of what launchd rejects a plist for, and the only check that a value


### PR DESCRIPTION
## Description

This PR fixes `mimi services install` writing a launchd plist with a corrupted path in it, whenever one of the paths it installs contains a directory named after one of the plist's own placeholders.

The plist was filled in one replacement at a time, each pass scanning the output of the pass before it. A path substituted early was therefore still on the table when a later pass ran, so a name inside the *user's* path that matched a later placeholder got replaced there too. A config path of `/Users/test/MIMI_SERVICE_PATH/config.toml` reached the plist with the service PATH spliced into the middle of it, which points launchd at a file that does not exist — after an install that reported success.

Every placeholder is now filled in a single pass over the template, which never rescans what it has already inserted, so a path reaches the plist exactly as configured whichever placeholder name it happens to contain. Rendering is otherwise unchanged: the golden test pinning the default plist still passes byte for byte, so no existing install renders differently and no one has a plist replaced as stale on their next install.

## Related Issues

Closes #177

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing config, command or hook surface changes.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The new table test renders each substituted value — binary path, config path, the two captured stream paths derived from `log_file`, and the service PATH — with a directory named after each of the five placeholders in turn, and asserts the value reaches the plist verbatim. Nine of those twenty combinations fail on `main`, including the one the issue demonstrated; all twenty pass here.

It deliberately sits beside the existing case in `TestRenderPlist_Table` that renders each value carrying its *own* placeholder name. That case passes by construction — by the time such a value is in place, whatever would have matched it has already run — and so could never have caught this. Both tests carry a note saying which is which, so neither gets deleted later as a duplicate of the other.

The escaping added in #176 is untouched; escaping and substitution stay separate concerns.
