### PR TITLE
fix(service): stop the install refusal naming installs it never checked for

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -224,9 +224,11 @@ and running install again retries just the load.
 
 Install refuses rather than replaces when what it finds is not a plist it
 wrote: a symlink at `~/Library/LaunchAgents/com.y3owk1n.mimi.plist` — the shape
-home-manager installs — or a loaded `com.y3owk1n.mimi` with no plist of mimi's
-behind it. Both errors name nix-darwin and home-manager, because the fix is in
-their configuration.
+a plist linked out of the Nix store has — or a loaded `com.y3owk1n.mimi` with
+no plist of mimi's behind it. Both look at that one label and nothing else, and
+both errors say so. An installation under any other label is invisible to them,
+and the nix-darwin and home-manager modules each register one of their own —
+[INSTALLATION.md](INSTALLATION.md#post-installation) has what to check by hand.
 
 It also refuses when `launchctl` itself cannot be run at all — missing from
 `PATH`, or unable to be spawned. Both of the checks above

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -389,7 +389,17 @@ mimi services install
 ```
 
 > [!NOTE]
-> If Mimi is already installed via nix-darwin, home-manager, or other methods, `services install` will detect the conflict and refuse to install. Check your existing configurations first.
+> `services install` checks one launchd label, Mimi's own `com.y3owk1n.mimi`. It
+> refuses when that label is already loaded with no plist of Mimi's behind it,
+> and when `~/Library/LaunchAgents/com.y3owk1n.mimi.plist` is not a file Mimi
+> wrote.
+>
+> It cannot see an installation registered under any other label, and the
+> nix-darwin and home-manager modules above register one of their own — so if
+> you installed Mimi that way, check for yourself before running it.
+> `launchctl list | grep -i mimi` lists every agent launchd holds whose label
+> mentions Mimi, which both modules' labels do; if one is already there, keep it
+> and skip `services install` rather than ending up with two daemons.
 
 ### 3. Verify (OPTIONAL)
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -36,9 +36,20 @@ const (
 )
 
 // foreignInstallAdvice is the tail of every refusal to touch a service mimi
-// did not install. It names the tools that install one of their own, because
-// the fix is always in their configuration and never in mimi.
-const foreignInstallAdvice = "check for existing installations (e.g., nix-darwin, home-manager) and uninstall them first"
+// did not install. It claims exactly the reach the checks in front of it have,
+// which is one launchd label: mimi's own.
+//
+// It used to send the user looking for a nix-darwin or home-manager install,
+// and those two are the installs it can never be reporting. Both checks only
+// ever ask about [Label] — the plist at its path, and the job launchd holds
+// under it — while the modules in this repo register their agent under labels
+// of their own: nix/darwin.nix through launchd.user.agents.mimi, nix/home.nix
+// through launchd.agents.mimi. Naming them promised a conflict check that was
+// never performed, so what fires is a stale mimi install or a hand-written
+// plist. Saying what was looked at leaves the rest of the search where it can
+// actually be described, in docs/INSTALLATION.md.
+const foreignInstallAdvice = "remove it with whatever installed it, then run install again — " +
+	"only mimi's own label (" + Label + ") was checked, so an installation under another label is not seen"
 
 // LoadState is what asking launchd whether the service is loaded produced.
 //
@@ -615,8 +626,8 @@ type installedPlist struct {
 	// present reports whether there is anything at path at all.
 	present bool
 	// regular reports whether what is there is a plain file. It is a weaker
-	// claim than "mimi wrote it" and deliberately so: a symlink is
-	// home-manager's link into the Nix store, and that is the shape mimi can
+	// claim than "mimi wrote it" and deliberately so: a symlink is the shape a
+	// plist linked out of the Nix store has, and that is the shape mimi can
 	// actually tell apart. Anything else at mimi's own path is treated as
 	// mimi's to replace.
 	regular bool

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1100,8 +1100,9 @@ func TestService_Install_FailsWhenLaunchctlCannotBeAsked(t *testing.T) {
 }
 
 // TestService_Install_FailsWhenLoadedByAnotherInstaller pins the refusal that
-// survives idempotence: a loaded service with no plist of mimi's behind it is
-// nix-darwin's or home-manager's, and mimi must not adopt it.
+// survives idempotence: a job launchd holds under mimi's own label with no
+// plist of mimi's behind it was installed by something else — a stale install
+// or a hand-written plist — and mimi must not adopt it.
 func TestService_Install_FailsWhenLoadedByAnotherInstaller(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
@@ -1123,20 +1124,16 @@ func TestService_Install_FailsWhenLoadedByAnotherInstaller(t *testing.T) {
 		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
 	}
 
-	for _, tool := range []string{"nix-darwin", "home-manager"} {
-		if !strings.Contains(err.Error(), tool) {
-			t.Errorf("Install() error %q does not name %s", err, tool)
-		}
-	}
+	assertRefusalScopedToMimisLabel(t, err)
 
 	if len(fake.calls) != 0 {
 		t.Errorf("Install() drove launchctl: %v, want no calls", fake.calls)
 	}
 }
 
-// TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote covers the plist
-// home-manager installs: a symlink into the Nix store. Replacing it would
-// break its link and lose to the next rebuild anyway.
+// TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote covers a plist
+// linked out of the Nix store: a symlink where mimi's own file would be.
+// Replacing it would break its link and lose to the next rebuild anyway.
 func TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
@@ -1179,11 +1176,7 @@ func TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote(t *testing.T) {
 		t.Errorf("Install() code = %v, want %v", derrors.GetCode(err), derrors.CodeServiceFailed)
 	}
 
-	for _, tool := range []string{"nix-darwin", "home-manager"} {
-		if !strings.Contains(err.Error(), tool) {
-			t.Errorf("Install() error %q does not name %s", err, tool)
-		}
-	}
+	assertRefusalScopedToMimisLabel(t, err)
 
 	if len(fake.calls) != 0 {
 		t.Errorf("Install() drove launchctl: %v, want no calls", fake.calls)
@@ -1197,6 +1190,26 @@ func TestService_Install_FailsWhenThePlistIsNotAFileMimiWrote(t *testing.T) {
 
 	if info.Mode()&os.ModeSymlink == 0 {
 		t.Error("Install() replaced the foreign plist symlink with a file")
+	}
+}
+
+// assertRefusalScopedToMimisLabel fails unless a foreign-install refusal claims
+// the reach the check behind it has and no more: the label is what it must
+// name, and nix-darwin and home-manager are what it must not, both messages
+// having named them until [foreignInstallAdvice] stopped — see the why there.
+// This pins it from both sides, because either half alone lets the old promise
+// back in.
+func assertRefusalScopedToMimisLabel(t *testing.T, err error) {
+	t.Helper()
+
+	if !strings.Contains(err.Error(), Label) {
+		t.Errorf("Install() error %q does not name the label it checked, %s", err, Label)
+	}
+
+	for _, tool := range []string{"nix-darwin", "home-manager"} {
+		if strings.Contains(err.Error(), tool) {
+			t.Errorf("Install() error %q names %s, which neither check can see", err, tool)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes `mimi services install` telling users to go looking for an installation it never checked for. Both of its refusals ended with advice to find and uninstall an existing nix-darwin or home-manager install — the two cases the check cannot see. Install asks about one launchd label, mimi's own `com.y3owk1n.mimi`, while the modules in this repo register their agent under labels of their own, so what actually trips the refusal is a stale mimi install or a hand-written plist. A user who followed the advice, found no nix-darwin or home-manager entry, and installed anyway ended up with two agents running.

Both messages now name the label that was checked and say that an installation under any other label is not seen. `docs/INSTALLATION.md` drops the promise that the conflict is detected, describes the single label install looks at, and tells module users to check for themselves with a command that finds an agent whatever it is called. `docs/CLI.md`, which documented the old wording, follows.

Deliberate limitation: no cross-label conflict check was added. Finding a mimi registered under an arbitrary label needs more than the label lookup that exists today, and that decision is left open — this change only stops the promise.

## Related Issues

Closes #161

## User-visible message change

Both refusals share one tail, so both change. The heads are unchanged.

**Before** (loaded under mimi's label, no plist of mimi's behind it):

```text
service is already loaded but mimi did not install it; check for existing installations (e.g., nix-darwin, home-manager) and uninstall them first
```

**Before** (something at mimi's plist path that mimi could not have written):

```text
/Users/me/Library/LaunchAgents/com.y3owk1n.mimi.plist is not a file mimi wrote; check for existing installations (e.g., nix-darwin, home-manager) and uninstall them first
```

**After**:

```text
service is already loaded but mimi did not install it; remove it with whatever installed it, then run install again — only mimi's own label (com.y3owk1n.mimi) was checked, so an installation under another label is not seen
```

```text
/Users/me/Library/LaunchAgents/com.y3owk1n.mimi.plist is not a file mimi wrote; remove it with whatever installed it, then run install again — only mimi's own label (com.y3owk1n.mimi) was checked, so an installation under another label is not seen
```

Only these two refusals change. The separate refusal for a `launchctl` that cannot be run at all is untouched, and the new wording does not describe it — it is accurate for the loaded state it fires on.

## Documentation note change

`docs/INSTALLATION.md`, under Post-Installation.

**Before**:

> If Mimi is already installed via nix-darwin, home-manager, or other methods, `services install` will detect the conflict and refuse to install. Check your existing configurations first.

**After**:

> `services install` checks one launchd label, Mimi's own `com.y3owk1n.mimi`. It refuses when that label is already loaded with no plist of Mimi's behind it, and when `~/Library/LaunchAgents/com.y3owk1n.mimi.plist` is not a file Mimi wrote.
>
> It cannot see an installation registered under any other label, and the nix-darwin and home-manager modules above register one of their own — so if you installed Mimi that way, check for yourself before running it. `launchctl list | grep -i mimi` lists every agent launchd holds whose label mentions Mimi, which both modules' labels do; if one is already there, keep it and skip `services install` rather than ending up with two daemons.

`docs/CLI.md` carried the same claim from the other side — "Both errors name nix-darwin and home-manager, because the fix is in their configuration" — and now says both errors look at that one label and nothing else, pointing at the installation note for what to check by hand.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The two tests covering these refusals asserted that each message named both nix-darwin and home-manager. They now assert the opposite in both directions through a shared helper: the message must name the label that was checked, and must not name either tool. Either half alone would let the old promise back in.

Comments elsewhere in the package still offer home-manager's Nix-store symlink as the example of a plist mimi cannot read (`internal/service/status.go`, `internal/service/plist.go`, and one test comment on the status side). Those describe the plist *reader* rather than the install refusal, and are the same overstatement in a different place; they are left for a follow-up rather than folded in here.
