### PR TITLE
fix(cli): print the usage block only when the command line was wrong

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -31,7 +31,14 @@ Examples:
   mimi action resize_window left-half
   mimi action resize_window --width 800 --height 600 --anchor cc
   mimi action resize_window --width-percent 50 --height-percent 100 --anchor tl`,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			// The root command silences usage for everything that fails from
+			// its run function, because usage says nothing about a runtime
+			// failure. This failure is the exception: nothing ran, the user is
+			// missing a subcommand, and usage is the only place the four
+			// subcommands are named.
+			cobraCmd.SilenceUsage = false
+
 			return derrors.New(
 				derrors.CodeInvalidInput,
 				"action subcommand required (e.g., mimi action focus_window, mimi action space 1)",

--- a/cmd/mimi/cmd/root.go
+++ b/cmd/mimi/cmd/root.go
@@ -36,8 +36,17 @@ Use "mimi start" to run the background daemon and react to window/space events v
 		// Cobra runs the nearest persistent pre-run it finds walking up from the
 		// command that executes, so resolving here covers every command in the
 		// tree — including leaves under a parent that has no RunE of its own.
-		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		PersistentPreRun: func(cobraCmd *cobra.Command, _ []string) {
 			state.resolveConfigPath()
+
+			// Silencing usage here rather than on the root command is what
+			// keeps usage for the errors it answers. Cobra parses flags and
+			// validates arguments before it reaches any persistent pre-run, so
+			// a bad flag or a rejected argument still prints usage; by the time
+			// this runs the command line was understood, and anything that
+			// fails from here on is a runtime failure whose message should not
+			// be buried under a list of flags.
+			cobraCmd.SilenceUsage = true
 		},
 	}
 

--- a/cmd/mimi/cmd/root_test.go
+++ b/cmd/mimi/cmd/root_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
 
 const (
@@ -108,6 +111,42 @@ func runnableCommandPaths(root *cobra.Command) [][]string {
 	return paths
 }
 
+// runWithStubbedBody runs the command at path against a fresh tree whose body
+// has been replaced by stub, and reports everything the tree printed and how
+// the run ended. Stubbing the body is what lets a test drive the real tree
+// without the command starting a daemon, moving a window or calling launchctl;
+// the stub is handed the tree's root so a test can read what the tree resolved
+// before the body ran.
+func runWithStubbedBody(
+	t *testing.T,
+	path []string,
+	stub func(root *cobra.Command) error,
+) (string, error) {
+	t.Helper()
+
+	var out bytes.Buffer
+
+	root := newRootCmd()
+
+	target, _, err := root.Find(path)
+	if err != nil {
+		t.Fatalf("finding command: %v", err)
+	}
+
+	target.Args = cobra.ArbitraryArgs
+	target.RunE = func(_ *cobra.Command, _ []string) error {
+		return stub(root)
+	}
+
+	root.SetArgs(path)
+	root.SetOut(&out)
+	root.SetErr(&out)
+
+	err = root.Execute()
+
+	return out.String(), err
+}
+
 func TestConfigDump_WithoutConfigFlag_LoadsTheDefaultConfigPath(t *testing.T) {
 	xdg := isolateConfigHome(t)
 	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
@@ -164,6 +203,135 @@ func TestConfigReload_WithoutConfigFlag_GetsPastTheConfigPath(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "reading pid file") {
 		t.Errorf("config reload failed before reaching the PID file: %v", err)
+	}
+}
+
+// TestNewRootCmd_ARuntimeFailurePrintsNoUsage is mimi#175's first half: a
+// command that fails while it runs reports the failure and nothing else. Usage
+// answers a mistyped command line; it says nothing about a daemon that is not
+// running, and ten lines of flags after the sentence explaining the failure
+// bury the sentence.
+func TestNewRootCmd_ARuntimeFailurePrintsNoUsage(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
+
+	// No daemon runs under this test's temporary HOME, so reload fails on the
+	// missing PID file — a real runtime failure rather than a bad command line.
+	out, err := runCommand(t, "config", "reload")
+	if err == nil {
+		t.Fatal("expected config reload to fail without a running daemon")
+	}
+
+	if !strings.Contains(out, err.Error()) {
+		t.Errorf("config reload never printed its failure, got: %s", out)
+	}
+
+	if strings.Contains(out, "Usage:") {
+		t.Errorf("config reload printed usage after a runtime failure, got: %s", out)
+	}
+}
+
+// TestNewRootCmd_AnArgumentFailureStillPrintsUsage is mimi#175's other half:
+// the command lines cobra never understood keep their usage block, because
+// there the list of flags and arguments is the answer to what went wrong.
+func TestNewRootCmd_AnArgumentFailureStillPrintsUsage(t *testing.T) {
+	testCases := []struct {
+		name string
+		argv []string
+	}{
+		{name: "an unknown flag", argv: []string{
+			actionCommandName, focusWindowCommandName, "--not-a-flag",
+		}},
+		{name: "an unparsable flag value", argv: []string{
+			actionCommandName, resizeWindowCommandName, "--width", "abc",
+		}},
+		{name: "a missing argument", argv: []string{
+			actionCommandName, string(action.NameSpace),
+		}},
+		{name: "an extra argument", argv: []string{
+			actionCommandName, string(action.NameSpace), "1", "extra",
+		}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			isolateConfigHome(t)
+
+			out, err := runCommand(t, testCase.argv...)
+			if err == nil {
+				t.Fatalf("%v: expected an error", testCase.argv)
+			}
+
+			if !strings.Contains(out, "Usage:") {
+				t.Errorf("%v printed no usage, got: %s", testCase.argv, out)
+			}
+		})
+	}
+}
+
+// TestActionCommand_WithoutASubcommandStillListsItsSubcommands is the case
+// mimi#175's two halves meet in. `mimi action` fails from its run function, so
+// cobra calls it a runtime failure, but what the user got wrong is the missing
+// subcommand — and the usage block is the only place the CLI names the four
+// subcommands that would fix it.
+func TestActionCommand_WithoutASubcommandStillListsItsSubcommands(t *testing.T) {
+	isolateConfigHome(t)
+
+	out, err := runCommand(t, actionCommandName)
+	if err == nil {
+		t.Fatal("expected mimi action to fail without a subcommand")
+	}
+
+	if !strings.Contains(out, "Usage:") {
+		t.Errorf("mimi action printed no usage, got: %s", out)
+	}
+
+	for _, name := range []string{
+		focusWindowCommandName,
+		resizeWindowCommandName,
+		string(action.NameSpace),
+		string(action.NameMoveWindowToSpace),
+	} {
+		if !strings.Contains(out, name) {
+			t.Errorf("mimi action never named the %q subcommand, got: %s", name, out)
+		}
+	}
+}
+
+// TestNewRootCmd_NoCommandPrintsUsageAfterARuntimeFailure walks the whole tree
+// because mimi#175 changes what every failing command prints, not just the one
+// a test happened to pick. Each command's own work is stubbed out with a
+// failure, so what is under test is the tree's reaction to a body that returned
+// an error rather than the body itself — including for "action", whose real
+// body is a usage failure the test above covers instead.
+func TestNewRootCmd_NoCommandPrintsUsageAfterARuntimeFailure(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
+
+	wantErr := derrors.New(derrors.CodeInternal, "the command failed while running")
+
+	paths := runnableCommandPaths(newRootCmd())
+	if len(paths) == 0 {
+		t.Fatal("found no runnable commands in the tree")
+	}
+
+	for _, path := range paths {
+		t.Run(strings.Join(path, " "), func(t *testing.T) {
+			out, err := runWithStubbedBody(t, path, func(_ *cobra.Command) error {
+				return wantErr
+			})
+			if err == nil {
+				t.Fatalf("%v: expected the stubbed failure", path)
+			}
+
+			if !strings.Contains(out, wantErr.Error()) {
+				t.Errorf("%v never printed its failure, got: %s", path, out)
+			}
+
+			if strings.Contains(out, "Usage:") {
+				t.Errorf("%v printed usage after a runtime failure, got: %s", path, out)
+			}
+		})
 	}
 }
 
@@ -239,27 +407,13 @@ func TestNewRootCmd_EveryCommandResolvesTheConfigPath(t *testing.T) {
 
 	for _, path := range paths {
 		t.Run(strings.Join(path, " "), func(t *testing.T) {
-			root := newRootCmd()
-
-			target, _, err := root.Find(path)
-			if err != nil {
-				t.Fatalf("finding command: %v", err)
-			}
-
 			var seen string
 
-			target.Args = cobra.ArbitraryArgs
-			target.RunE = func(_ *cobra.Command, _ []string) error {
+			_, err := runWithStubbedBody(t, path, func(root *cobra.Command) error {
 				seen = configFlagValue(root)
 
 				return nil
-			}
-
-			root.SetArgs(path)
-			root.SetOut(io.Discard)
-			root.SetErr(io.Discard)
-
-			err = root.Execute()
+			})
 			if err != nil {
 				t.Fatalf("running command: %v", err)
 			}


### PR DESCRIPTION
## Description

This PR stops the CLI printing a command's usage block after a failure that has
nothing to do with how the command was typed. A service that cannot be
restarted, an install that cannot reach launchctl, a config that will not load —
each said something specific and each was then buried under ten lines of flags
and global flags.

Usage is now silenced from the moment the command line has been understood,
which is after flags are parsed and arguments validated. A bad flag, an
unparsable flag value, a missing argument or one too many still prints usage,
because there the usage is the answer. Error text and exit codes are unchanged
in both cases.

One command is deliberately exempt: `mimi action` with no subcommand fails from
its body, but what the user is missing is a subcommand, and the usage block is
the only place the CLI names `focus_window`, `resize_window`, `space`, and
`move_window_to_space`. Its output is unchanged.

## Command surface

No command, subcommand, or flag was added, renamed, or removed. What changed is
the output on failure:

| Failure | Before | After |
| --- | --- | --- |
| Command body returns an error | error line + usage block | error line only |
| Bad flag / bad flag value | error line + usage block | unchanged |
| Missing or extra argument | error line + usage block | unchanged |
| `mimi action` with no subcommand | error line + usage block | unchanged |

Exit codes are unchanged throughout — every failure above still exits 1.

## Before / after

Runtime failure — `mimi config reload -c /nonexistent/mimi.toml`

Before:

```
Error: [INVALID_CONFIG] loading config: [CONFIG_IO_FAILED] reading config: open /nonexistent/mimi.toml: no such file or directory
Usage:
  mimi config reload [flags]

Flags:
  -h, --help   help for reload

Global Flags:
  -c, --config string   path to config file
  -v, --verbose         verbose output

$ echo $?
1
```

After:

```
Error: [INVALID_CONFIG] loading config: [CONFIG_IO_FAILED] reading config: open /nonexistent/mimi.toml: no such file or directory

$ echo $?
1
```

Argument failure — `mimi action space` — byte-for-byte identical before and
after:

```
Error: [INVALID_INPUT] space requires exactly one argument: a 1-based space number, "next", or "prev"
Usage:
  mimi action space <number|next|prev> [flags]

Flags:
  -h, --help   help for space

Global Flags:
  -c, --config string   path to config file
  -v, --verbose         verbose output

$ echo $?
1
```

Both blocks are the real output of binaries built from `main` and from this
branch, not a transcription.

## Related Issues

Closes #175

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no documented command, flag or
      config surface changed, and no doc shows a failure transcript.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The switch lives in the root command's persistent pre-run rather than on the
root command itself. That placement is the whole design: cobra parses flags and
validates arguments before any persistent pre-run, so everything rejected in
those layers still prints usage, and only what fails afterwards is treated as a
runtime failure. Setting the flag on the root command directly would have
silenced usage for bad flags and missing arguments too.

Two consequences worth a reviewer's eye:

- A flag pair that is rejected by the domain layer rather than by cobra —
  `--margin` with `--no-margin`, or `--backward` with a direction flag — is
  validated inside the command body, so those now print their sentence without
  usage. That is deliberate: the repo validates them there so the CLI and the
  socket path share one wording, and the sentence names both flags.
- Cobra checks required flags and flag groups *after* the persistent pre-run, so
  if a command ever marks a flag required through cobra, its usage would be
  silenced too. Nothing in the tree does that today.

Coverage: a real unstubbed runtime failure printing no usage, a table of
argument failures still printing it, `mimi action` keeping its subcommand list,
and a walk over every runnable command in the tree asserting that a body which
returns an error prints no usage.
