### PR TITLE
feat(cli): cancel the running command on Ctrl-C instead of only killing the process

### DIFF
--- a/cmd/mimi/cmd/interrupt.go
+++ b/cmd/mimi/cmd/interrupt.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// interruptBufferSize is how many interrupts the watch can hold at once. Two,
+// because the second is the one that ends the process and signal delivery drops
+// what a full channel cannot take: an interrupt that lands while the first is
+// still being taken has to have somewhere to sit, or a user pressing Ctrl-C
+// twice in quick succession would be pressing it once.
+const interruptBufferSize = 2
+
+// interruptExitCode is what mimi exits with when a second interrupt ends it:
+// the 128 + SIGINT a shell reports for a process the signal killed, which is
+// what every mimi command reported on the first Ctrl-C before this watch
+// existed.
+const interruptExitCode = 130
+
+// exitProcess ends the process the way the second interrupt asks it to, with no
+// deferred cleanup and nothing left to finish. It is the forceExit [Execute]
+// hands the watch, and is a function of its own only so that a test can be
+// handed something that returns.
+func exitProcess() {
+	os.Exit(interruptExitCode)
+}
+
+// runUnderInterrupts runs root under a context that the first interrupt on
+// signals cancels, and hands the second to forceExit.
+//
+// The context reaches the command through cobra, which passes the one given to
+// ExecuteContext down to whatever it runs. Nothing about when cobra parses
+// flags, validates arguments or runs a persistent pre-run moves: ExecuteContext
+// only records the context before handing over to the same Execute the tree
+// used to run under, so the boundary mimi#175 put between a bad command line
+// and a runtime failure stays exactly where it was.
+func runUnderInterrupts(
+	root *cobra.Command,
+	signals <-chan os.Signal,
+	forceExit func(),
+) error {
+	ctx, release := interruptContext(context.Background(), signals, forceExit)
+	defer release()
+
+	return root.ExecuteContext(ctx)
+}
+
+// interruptContext derives a context from parent that the first signal on
+// signals cancels, arms the second to run forceExit, and returns the function
+// that releases the watch.
+//
+// The two stages exist because watching a signal takes Go's own response to it
+// away. Every mimi command used to die on the first Ctrl-C, whatever it was
+// doing, because nothing in the process was watching SIGINT and the runtime
+// terminated it; a watch that only canceled would leave every command that
+// does not read its context — most of `mimi action` and `mimi config`, per the
+// audit in interrupt_audit_test.go — running with no way left to stop it. So
+// the first interrupt asks the command to stop and the second stops the
+// process, and the guarantee the CLI gives is unchanged in the only terms a
+// user cares about: Ctrl-C ends the command.
+//
+// The release function cancels the context and returns only once the watch has
+// stopped, so nothing it drives can fire after it has returned. An interrupt
+// that lands as the release does can still win the race and end the process,
+// which is the outcome that interrupt asks for either way.
+func interruptContext(
+	parent context.Context,
+	signals <-chan os.Signal,
+	forceExit func(),
+) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(parent)
+
+	released := make(chan struct{})
+	stopped := make(chan struct{})
+
+	go func() {
+		defer close(stopped)
+
+		select {
+		case <-signals:
+			cancel()
+		case <-released:
+			return
+		}
+
+		select {
+		case <-signals:
+			forceExit()
+		case <-released:
+		}
+	}()
+
+	return ctx, func() {
+		close(released)
+		<-stopped
+		cancel()
+	}
+}

--- a/cmd/mimi/cmd/interrupt_audit_test.go
+++ b/cmd/mimi/cmd/interrupt_audit_test.go
@@ -1,0 +1,290 @@
+//nolint:testpackage
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// interruptResponse is what the first Ctrl-C does to one command.
+//
+// It is a string rather than a counter because the value is read by whoever is
+// reading the audit, and a number would send them back here to find out which
+// of three things it meant.
+type interruptResponse string
+
+const (
+	// interruptStopsTheWork is a command that reads the context it was given.
+	// The interrupt reaches the work in progress and ends it, and the command
+	// reports why it stopped.
+	interruptStopsTheWork interruptResponse = "stops the work in progress"
+	// interruptShutsDownTheDaemon is `mimi start`, which has watched SIGINT
+	// itself since long before the CLI did. The root's watch does not take
+	// that away — signal delivery goes to every channel registered for it — so
+	// the daemon still shuts down gracefully on the first Ctrl-C.
+	interruptShutsDownTheDaemon interruptResponse = "shuts the daemon down through its own signal handler"
+	// interruptRunsOn is a command that does not read its context. The first
+	// interrupt does not reach it and it finishes what it started; the second
+	// ends the process. Every entry recorded this way carries what the command
+	// is doing instead, which is what a reader needs to judge whether the
+	// second Ctrl-C is an acceptable answer for it.
+	interruptRunsOn interruptResponse = "runs on; the second interrupt ends the process"
+)
+
+// auditEntry is one command's line in the audit.
+type auditEntry struct {
+	// command is the command as it is typed, without the leading "mimi".
+	command string
+	// response is what the first interrupt does.
+	response interruptResponse
+	// why is the finding: what the command actually does with the interrupt,
+	// and — for interruptRunsOn — why running on is acceptable. It is what
+	// makes this an audit rather than a list, and it is checked by a person,
+	// not by the test below.
+	why string
+}
+
+// audited is one line of the audit, written as a call so that each line reads
+// as the sentence it is.
+func audited(command string, response interruptResponse, why string) auditEntry {
+	return auditEntry{command: command, response: response, why: why}
+}
+
+// interruptAudit is the audit the ticket (mimi#173) asks be recorded rather
+// than assumed: every runnable command in the tree, read for what it does with
+// the context [Execute] now hands it.
+//
+// It is recorded here, next to a test that fails when the tree and the audit
+// disagree, because a command added later inherits this wiring whether or not
+// anyone thinks about it — and the failure mode it inherits, an interrupt that
+// no longer reaches the work, is invisible from the command's own code.
+//
+// What the audit found: six commands honor the context, one runs its own
+// signal handler, and eleven ignore it. Nine of those eleven are local file
+// work or one-shot syscalls, over before an interrupt could be typed. The two
+// that are not are in the action family — `action space` on the direct path
+// pumps the run loop for a stretch proportional to the spaces it crosses, and
+// any action on the daemon path waits for a reply that ipc.TryExecute reads
+// with no deadline, so a daemon that accepts the connection and then goes quiet
+// hangs it indefinitely. Neither is a wait a Go context could shorten from
+// here: the first is inside Objective-C, and the second wants a read deadline
+// in internal/ipc rather than a cancellation in the CLI. Both are why the
+// second stage exists, and neither is made worse by this change — before it,
+// one Ctrl-C ended them; after it, two do.
+//
+//nolint:gochecknoglobals // the audit is one fact about the tree, read by one test
+var interruptAudit = []auditEntry{
+	audited("action", interruptRunsOn,
+		"the body only reports the missing subcommand and returns; "+
+			"there is no window in which an interrupt could arrive"),
+	audited("action focus_window", interruptRunsOn,
+		"runAction consults no context on either path: the daemon path "+
+			"writes a request and waits for the reply, the direct path calls "+
+			"into Objective-C that runs to completion"),
+	audited("action space", interruptRunsOn,
+		"as focus_window, and the direct path's synthetic dock swipe "+
+			"pumps the run loop for a stretch proportional to the spaces it "+
+			"crosses — time inside C that a canceled Go context could not "+
+			"shorten even if runAction read one"),
+	audited("action move_window_to_space", interruptRunsOn,
+		"as space; the SkyLight move likewise runs to completion"),
+	audited("action resize_window", interruptRunsOn,
+		"as focus_window; the Accessibility resize runs to completion"),
+	audited("config dump", interruptRunsOn,
+		"reads and parses one local file and prints it"),
+	audited("config init", interruptRunsOn,
+		"writes one local file"),
+	audited("config reload", interruptRunsOn,
+		"reads the config and the PID file and sends one SIGHUP; "+
+			"nothing here waits for the daemon to finish reloading"),
+	audited("config validate", interruptRunsOn,
+		"reads and parses one local file and reports on it"),
+	audited("services install", interruptStopsTheWork,
+		"Service.Install threads the context through every launchctl call "+
+			"and checks it again before the plist is written, so a canceled "+
+			"install stops on whichever side of that write it had reached"),
+	audited("services uninstall", interruptStopsTheWork,
+		"Service.Uninstall checks the context after the bootout and keeps "+
+			"the plist, so the uninstall can be run again"),
+	audited("services start", interruptStopsTheWork,
+		"the launchctl call runs under the context and is killed with it"),
+	audited("services stop", interruptStopsTheWork,
+		"the launchctl call runs under the context and is killed with it"),
+	audited("services restart", interruptStopsTheWork,
+		"the launchctl calls run under the context and are killed with it"),
+	audited("services status", interruptStopsTheWork,
+		"the launchctl calls run under the context; a canceled status "+
+			"stops asking and prints the unknown state rather than failing, "+
+			"which is what it prints for every launchctl it cannot reach"),
+	audited("start", interruptShutsDownTheDaemon,
+		"daemon.Run watches SIGINT on a channel of its own and shuts down "+
+			"on it. Before the daemon reaches that watch — while the config "+
+			"onboarding alert is up, say — the first interrupt does nothing "+
+			"and the second ends the process"),
+	audited("status", interruptRunsOn,
+		"reads the PID file, asks the Accessibility API whether mimi is "+
+			"trusted, and stats the socket; none of the three blocks"),
+	audited("stop", interruptRunsOn,
+		"reads the PID file and sends one SIGTERM"),
+}
+
+// TestNewRootCmd_EveryCommandsInterruptResponseIsAudited is the ticket's second
+// acceptance criterion, kept true rather than written down once: the tree and
+// the audit have to name the same commands.
+//
+// A command missing from the audit is the case this exists for. It has been
+// given a context by [Execute] and taken Go's default response to Ctrl-C away
+// in exchange, and nobody has said what it does with either.
+func TestNewRootCmd_EveryCommandsInterruptResponseIsAudited(t *testing.T) {
+	paths := runnableCommandPaths(newRootCmd())
+	if len(paths) == 0 {
+		t.Fatal("found no runnable commands in the tree")
+	}
+
+	findings := make(map[string]auditEntry, len(interruptAudit))
+
+	for _, entry := range interruptAudit {
+		_, duplicate := findings[entry.command]
+		if duplicate {
+			t.Errorf("the interrupt audit records %q twice", entry.command)
+		}
+
+		findings[entry.command] = entry
+	}
+
+	inTree := make(map[string]bool, len(paths))
+
+	for _, path := range paths {
+		name := strings.Join(path, " ")
+		inTree[name] = true
+
+		entry, ok := findings[name]
+		if !ok {
+			t.Errorf(
+				"%q is not in the interrupt audit; record what the first Ctrl-C does to it",
+				name,
+			)
+
+			continue
+		}
+
+		if entry.why == "" {
+			t.Errorf("%q is in the interrupt audit with no finding recorded", name)
+		}
+
+		switch entry.response {
+		case interruptStopsTheWork, interruptShutsDownTheDaemon, interruptRunsOn:
+		default:
+			t.Errorf("%q records the unknown interrupt response %q", name, entry.response)
+		}
+	}
+
+	// A stale entry is worth failing on too: an audit that outlives the command
+	// it describes is one nobody has re-read.
+	var stale []string
+
+	for name := range findings {
+		if !inTree[name] {
+			stale = append(stale, name)
+		}
+	}
+
+	sort.Strings(stale)
+
+	for _, name := range stale {
+		t.Errorf("the interrupt audit records %q, which is not a command in the tree", name)
+	}
+}
+
+// TestNewRootCmd_EveryCommandIsGivenTheCallersContext is the audit's
+// precondition. Every finding above is about what a command does with the
+// context it was handed, which is worth nothing unless every command is in fact
+// handed it — including the leaves under `action`, `config` and `services`,
+// whose parents have no body of their own for cobra to reach them through.
+func TestNewRootCmd_EveryCommandIsGivenTheCallersContext(t *testing.T) {
+	xdg := isolateConfigHome(t)
+	writeConfig(t, filepath.Join(xdg, "mimi", "config.toml"), "/marker/default.log")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	paths := runnableCommandPaths(newRootCmd())
+	if len(paths) == 0 {
+		t.Fatal("found no runnable commands in the tree")
+	}
+
+	for _, path := range paths {
+		t.Run(strings.Join(path, " "), func(t *testing.T) {
+			var seen error
+
+			err := runStubbedWithContext(t, ctx, path, func(cobraCmd *cobra.Command) error {
+				seen = cobraCmd.Context().Err()
+
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("running command: %v", err)
+			}
+
+			if seen == nil {
+				t.Error("the command ran on a context of its own, not the caller's")
+			}
+		})
+	}
+}
+
+// TestServicesCommands_UnderACanceledContextChangeNothing is the ticket's
+// fourth acceptance criterion where the CLI can reach it: an interrupt that
+// arrives before a services command has done anything leaves the disk as it
+// found it, and reports a failure rather than a success.
+//
+// What it does not cover is the interrupt that arrives partway through an
+// install, between the unload and the write — that one belongs to the service
+// itself and is covered there, by
+// TestService_Install_WritesNoPlistWhenCanceledAfterTheUnload.
+//
+// What it adds over those is the real launcher. Nothing here fakes launchctl
+// and nothing here runs it either: exec refuses to start a process under a
+// context that is already done, which is exactly the shape the classification
+// in execLauncher.list has to survive. A killed launchctl exits like a
+// launchctl that looked and found no job, and reading the one as the other is
+// what would let an interrupted install bootstrap over a service that is still
+// up. Until this wiring existed, only a synthetic context ever put that guard
+// under a real *exec.ExitError.
+func TestServicesCommands_UnderACanceledContextChangeNothing(t *testing.T) {
+	// Written as one string so that the subcommand names are not five more
+	// bare literals in this package for goconst to count.
+	names := strings.FieldsSeq("install uninstall start stop restart")
+
+	for name := range names {
+		t.Run(name, func(t *testing.T) {
+			isolateConfigHome(t)
+
+			plist := filepath.Join(
+				os.Getenv("HOME"),
+				"Library",
+				"LaunchAgents",
+				"com.y3owk1n.mimi.plist",
+			)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := runWithContext(t, ctx, "services", name)
+			if err == nil {
+				t.Fatalf("mimi services %s reported success under a canceled context", name)
+			}
+
+			_, statErr := os.Stat(plist)
+			if statErr == nil {
+				t.Errorf("mimi services %s wrote a plist under a canceled context", name)
+			}
+		})
+	}
+}

--- a/cmd/mimi/cmd/interrupt_test.go
+++ b/cmd/mimi/cmd/interrupt_test.go
@@ -1,0 +1,254 @@
+//nolint:testpackage
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// runWithContext runs args against a fresh command tree under ctx and reports
+// how the run ended. It is runCommand with a context, for the tests about what
+// a canceled one does to a command that runs for real.
+func runWithContext(t *testing.T, ctx context.Context, args ...string) error {
+	t.Helper()
+
+	root := newRootCmd()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs(args)
+
+	return root.ExecuteContext(ctx)
+}
+
+// runStubbedWithContext runs the command at path against a fresh tree under
+// ctx, with that command's body replaced by stub. Unlike runWithStubbedBody the
+// stub is handed the command cobra is running rather than the tree's root,
+// because what these tests read is the context that command was given.
+func runStubbedWithContext(
+	t *testing.T,
+	ctx context.Context,
+	path []string,
+	stub func(cobraCmd *cobra.Command) error,
+) error {
+	t.Helper()
+
+	root := newRootCmd()
+
+	target, _, err := root.Find(path)
+	if err != nil {
+		t.Fatalf("finding command: %v", err)
+	}
+
+	target.Args = cobra.ArbitraryArgs
+	target.RunE = func(cobraCmd *cobra.Command, _ []string) error {
+		return stub(cobraCmd)
+	}
+
+	root.SetArgs(path)
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+
+	return root.ExecuteContext(ctx)
+}
+
+// TestInterruptContext_TheFirstInterruptCancelsTheContext is the whole point of
+// the wiring: an interrupt has to reach the command as a canceled context, not
+// only as a dead process.
+func TestInterruptContext_TheFirstInterruptCancelsTheContext(t *testing.T) {
+	signals := make(chan os.Signal, 1)
+
+	ctx, release := interruptContext(context.Background(), signals, func() {
+		t.Error("the first interrupt ended the process instead of canceling")
+	})
+	defer release()
+
+	if ctx.Err() != nil {
+		t.Fatalf("the context was canceled before any interrupt: %v", ctx.Err())
+	}
+
+	signals <- os.Interrupt
+
+	<-ctx.Done()
+}
+
+// TestInterruptContext_TheSecondInterruptEndsTheProcess is the promise that
+// keeps a command which ignores its context from becoming unkillable. Before
+// this wiring every command died on the first Ctrl-C, because Go terminated the
+// process; watching the signal takes that away, and the second one gives it
+// back.
+func TestInterruptContext_TheSecondInterruptEndsTheProcess(t *testing.T) {
+	signals := make(chan os.Signal, 2)
+	forced := make(chan struct{})
+
+	ctx, release := interruptContext(context.Background(), signals, func() {
+		close(forced)
+	})
+	defer release()
+
+	signals <- os.Interrupt
+
+	// The first interrupt has to have been taken before the second is sent, or
+	// a watch that read both from the buffer at once would pass this without
+	// ever having staged them.
+	<-ctx.Done()
+
+	signals <- os.Interrupt
+
+	<-forced
+}
+
+// TestInterruptContext_ReleasingEndsTheWatchWithoutForcingAnExit covers the
+// ordinary end of every mimi run: the command finished, and the interrupt watch
+// has to go with it. A watch that outlived the release would turn the next
+// Ctrl-C at the shell prompt into an exit from a process that is already done.
+func TestInterruptContext_ReleasingEndsTheWatchWithoutForcingAnExit(t *testing.T) {
+	testCases := []struct {
+		name       string
+		interrupts int
+	}{
+		{name: "with no interrupt at all", interrupts: 0},
+		{name: "with one interrupt already taken", interrupts: 1},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			signals := make(chan os.Signal, 1)
+
+			ctx, release := interruptContext(context.Background(), signals, func() {
+				t.Error("releasing the watch ended the process")
+			})
+
+			for range testCase.interrupts {
+				signals <- os.Interrupt
+
+				<-ctx.Done()
+			}
+
+			// Release returns only once the watch has stopped, so anything it
+			// could still have done has been done by the time this returns.
+			release()
+
+			if ctx.Err() == nil {
+				t.Error("releasing the watch left the context uncanceled")
+			}
+		})
+	}
+}
+
+// TestRunUnderInterrupts_AnInterruptCancelsTheRunningCommand is the ticket's
+// first acceptance criterion end to end: the command mimi is running sees the
+// user's interrupt as a canceled context, and the run ends because the command
+// stopped rather than because the process was killed under it.
+func TestRunUnderInterrupts_AnInterruptCancelsTheRunningCommand(t *testing.T) {
+	isolateConfigHome(t)
+
+	signals := make(chan os.Signal, 1)
+	entered := make(chan struct{})
+
+	// Any command in the tree would do; this one is picked for having no
+	// effect of its own, since its body is replaced below either way.
+	path := strings.Fields("config dump")
+
+	root := newRootCmd()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs(path)
+
+	target, _, err := root.Find(path)
+	if err != nil {
+		t.Fatalf("finding command: %v", err)
+	}
+
+	// Blocking on the context is what a command that honors it does; the real
+	// one this stands in for is the unload wait inside `mimi services install`,
+	// which cannot be driven from here without a launchctl underneath it.
+	target.RunE = func(cobraCmd *cobra.Command, _ []string) error {
+		close(entered)
+		<-cobraCmd.Context().Done()
+
+		return cobraCmd.Context().Err()
+	}
+
+	go func() {
+		<-entered
+
+		signals <- os.Interrupt
+	}()
+
+	err = runUnderInterrupts(root, signals, func() {
+		t.Error("one interrupt ended the process instead of canceling the command")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("the interrupted command returned %v, want a canceled context", err)
+	}
+}
+
+// TestRunUnderInterrupts_ASecondInterruptEndsACommandThatIgnoresItsContext is
+// the ticket's third acceptance criterion, for the eleven commands the audit
+// records as not reading their context.
+//
+// Watching SIGINT takes Go's own response to it away, so for those commands the
+// first interrupt is the one that now does nothing. This is what stops that
+// from making them unkillable, driven through the same runUnderInterrupts the
+// CLI runs every command under.
+func TestRunUnderInterrupts_ASecondInterruptEndsACommandThatIgnoresItsContext(t *testing.T) {
+	isolateConfigHome(t)
+
+	signals := make(chan os.Signal, interruptBufferSize)
+	entered := make(chan struct{})
+	ended := make(chan struct{})
+
+	path := strings.Fields("config dump")
+
+	root := newRootCmd()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs(path)
+
+	target, _, err := root.Find(path)
+	if err != nil {
+		t.Fatalf("finding command: %v", err)
+	}
+
+	// canceledWhenEnded is read by the assertion below, and written by a body
+	// that stands in for a command which ignores its context: it consults the
+	// context nowhere, and nothing short of the process ending stops it.
+	var canceledWhenEnded bool
+
+	target.RunE = func(cobraCmd *cobra.Command, _ []string) error {
+		close(entered)
+		<-ended
+
+		canceledWhenEnded = cobraCmd.Context().Err() != nil
+
+		return nil
+	}
+
+	go func() {
+		<-entered
+
+		signals <- os.Interrupt
+
+		signals <- os.Interrupt
+	}()
+
+	// Standing in for os.Exit, which a test cannot be handed. Releasing the
+	// command is what the real one does to it, only harder.
+	err = runUnderInterrupts(root, signals, func() { close(ended) })
+	if err != nil {
+		t.Fatalf("the command reported %v", err)
+	}
+
+	// The command was still running when the second interrupt arrived, and the
+	// first had already canceled the context it was ignoring. Both halves of
+	// the criterion, in one fact.
+	if !canceledWhenEnded {
+		t.Error("the process was ended before the first interrupt had canceled anything")
+	}
+}

--- a/cmd/mimi/cmd/root.go
+++ b/cmd/mimi/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
 
 	"github.com/spf13/cobra"
 )
@@ -74,7 +76,24 @@ Use "mimi start" to run the background daemon and react to window/space events v
 	return root
 }
 
-// Execute runs the root command and returns any error.
+// Execute runs the root command under a context the user's interrupt cancels,
+// and returns any error.
+//
+// Watching SIGINT here is what takes Go's default response to it away —
+// terminating the process — from every command at once, which is why the
+// second interrupt ends the process instead. What each command does with the
+// first one is recorded, command by command, in the audit in
+// interrupt_audit_test.go.
+//
+// Only SIGINT is watched. SIGTERM keeps Go's default, which is what it has
+// always had here: nothing in the CLI is written to be shut down politely by a
+// supervisor, and taking a killing signal away from one would be the change
+// this makes to Ctrl-C without the second stage that pays for it.
 func Execute() error {
-	return RootCmd.Execute()
+	signals := make(chan os.Signal, interruptBufferSize)
+
+	signal.Notify(signals, os.Interrupt)
+	defer signal.Stop(signals)
+
+	return runUnderInterrupts(RootCmd, signals, exitProcess)
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,6 +7,7 @@ mimi is a macOS window and space utility. Use `mimi action` for immediate comman
 ## Table of Contents
 
 - [Global Flags](#global-flags)
+- [Interrupting a Command](#interrupting-a-command)
 - [Window & Space Actions](#window--space-actions)
 - [Hook Daemon](#hook-daemon)
 - [Service Management](#service-management)
@@ -21,6 +22,44 @@ mimi is a macOS window and space utility. Use `mimi action` for immediate comman
 | `--config, -c`  |           | auto    | Path to config file    |
 | `--verbose, -v` |           | `false` | Verbose output         |
 | `--version`     |           |         | Print version and exit |
+
+---
+
+## Interrupting a Command
+
+Ctrl-C ends any mimi command. What the **first** one does depends on the
+command; the **second** always ends the process immediately, with exit status
+130.
+
+| Command                      | First Ctrl-C                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------- |
+| `mimi services install`      | Stops the work in progress and says where it stopped.                           |
+| `mimi services uninstall`    | Stops, keeping the plist, exactly as a failed unload does.                      |
+| `mimi services start`/`stop`/`restart` | Stops before or during the `launchctl` call, and says so.             |
+| `mimi services status`       | Stops asking `launchctl` and prints the unknown state. Exits 0.                 |
+| `mimi start`                 | Shuts the daemon down gracefully, as it always has.                             |
+| `mimi action *`              | Does not reach the action; it finishes. Press Ctrl-C again to end the process.   |
+| `mimi config *`              | Does not reach the command; it finishes. Each is one local file read or write.   |
+| `mimi status`, `mimi stop`   | Does not reach the command; it finishes. Each is a file read and one syscall.    |
+
+A command in the bottom three rows that the first Ctrl-C did not reach still
+succeeds and exits 0, because it did in fact finish — `mimi config init`
+interrupted once has still written the file. Press Ctrl-C twice to be sure a
+command did not run.
+
+[`mimi services install`](#mimi-services-install) is the command where this is
+worth knowing about: it is the only one that waits, and the only one that
+replaces a file another program reads. An interrupt leaves it exactly where a
+failure does, on either side of that replacement and never in between.
+
+`mimi start` is unchanged in the case that matters: the daemon has always
+watched `SIGINT` itself and still does, so one Ctrl-C shuts it down gracefully.
+Two exceptions are worth knowing. Before the daemon reaches that watch — while
+the first-run config alert is up, say — the first Ctrl-C does nothing and the
+second is what ends it. And a second Ctrl-C during a shutdown that has stalled
+now ends the process where it used to be ignored; that skips the daemon's own
+cleanup, so a PID file may be left behind. `mimi status` reports such a file as
+stale, and the next `mimi start` overwrites it.
 
 ---
 
@@ -217,6 +256,16 @@ at five seconds, after which the install fails with the old plist untouched —
 stop whatever is holding the service and run it again. It ends the same way,
 without waiting out the bound, if `launchctl` stops answering while it waits:
 an unload nothing can confirm is not an unload.
+
+Ctrl-C is the third way out of that wait, and the only one a user chooses. It
+ends at the next poll rather than at the bound, and leaves the install exactly
+where the other two do: old plist untouched, service unloaded, nothing to undo
+before running it again. The same holds anywhere else in the install — every
+`launchctl` call is cut short with it, and the context is checked once more
+immediately before the new plist is written, so an interrupted install never
+replaces a plist on its way out. An interrupted `mimi services uninstall`
+likewise keeps the plist, which is what a failed unload does, and what makes
+the uninstall re-runnable.
 
 A load that fails for any other reason leaves the new plist on disk, so the
 config change is already made and only the load is missing; that error says so,


### PR DESCRIPTION
## Description

This PR makes Ctrl-C stop the work a mimi command is doing, instead of only killing the process. The launchd service methods have taken a context and honoured cancellation for two releases, and none of it was reachable: the CLI ran every command on a background context, so an interrupted `mimi services install` was a process killed mid-run rather than an install that stopped.

The CLI now runs the whole command tree under a context the first Ctrl-C cancels. Watching the signal is what takes Go's own response to it — killing the process — away from every command at once, so the second Ctrl-C ends the process. The guarantee a user has is unchanged in the terms they care about: Ctrl-C ends the command.

The deliberate limitation is that guarantee's cost: for the eleven commands that ignore their context, ending the command now takes two presses instead of one. The alternative was to leave them uninterruptible, which the ticket rules out.

## What pressing Ctrl-C does, before and after

`mimi services install` — a command that honours its context.

| | Before | After |
| --- | --- | --- |
| One Ctrl-C | Process dies wherever it was, including between the unload and the plist write. | The install stops at the next `launchctl` call or the next poll of the unload wait, and says where it stopped. Exit 1. |
| Two Ctrl-C | As above. | As above; the second is not needed. |

`mimi config init` — a command that does not.

| | Before | After |
| --- | --- | --- |
| One Ctrl-C | Process dies immediately. | Nothing reaches the command. It finishes writing the file, reports success, exits 0. |
| Two Ctrl-C | Process dies on the first. | Process ends on the second, exit 130. |

## Interrupt audit

The ticket asks that every command either honour the context or be documented as not needing to, recorded rather than assumed. Both approaches it offers are here, because neither is sufficient alone:

- **The audit** is recorded in `cmd/mimi/cmd/interrupt_audit_test.go`, one line per command with the finding behind it, and a test walks the live command tree and fails when a command is missing from it or an entry outlives its command. A command added later cannot inherit this wiring silently.
- **The two-stage handler** is what the audit made necessary. Eleven of the eighteen commands ignore their context, and two of those can genuinely block: `mimi action space` on the direct path spends real time inside Objective-C, and any action routed to a daemon that accepts the connection and then goes quiet waits on a socket read with no deadline. Neither is a wait a context in the CLI could shorten, so documenting them would not have kept them interruptible.

| Response | Commands |
| --- | --- |
| Stops the work in progress | the six `mimi services` subcommands |
| Shuts down through its own signal handler | `mimi start` |
| Runs on; the second Ctrl-C ends the process | `mimi action` and its four subcommands, the four `mimi config` subcommands, `mimi status`, `mimi stop` |

## Command and output changes

No flags, config keys, hook variables or command names change. Two things a script could notice:

- A command ended by the **second** Ctrl-C exits **130**, where before Ctrl-C killed the process by signal (which a shell also reports as 130, but a parent checking `WIFSIGNALED` will now see a normal exit instead).
- `SIGTERM` is untouched and keeps Go's default, so anything sending one is unaffected.

## Potentially breaking

Nothing in an existing config or hook script stops working. Two behaviours change for someone at a terminal:

- **A single Ctrl-C no longer ends a command that ignores its context.** `mimi action …`, `mimi config …`, `mimi status` and `mimi stop` now need two. Each of them is a local file read, a one-shot syscall, or a native call that was never interruptible in the middle anyway, so in practice the command has usually already finished — but a script or a person expecting one press to stop it will notice.
- **A second Ctrl-C during a stalled `mimi start` shutdown now ends the process**, where it used to be ignored. That skips the daemon's own cleanup and can leave a PID file behind; `mimi status` reports such a file as stale and the next `mimi start` overwrites it. The first Ctrl-C still shuts the daemon down gracefully, exactly as before.

Both are described in `docs/CLI.md` under a new "Interrupting a Command" section, alongside the cancellation exit from the unload wait that the docs previously omitted because no user could trigger it.

## Related Issues

Closes #173

Carries the second acceptance criterion of #166, which could not be met there. Builds on #172, which threaded the contexts, and #164, whose "launchctl ran, job absent" classification is now exercised against a real cancelled context rather than only a synthetic one.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

`just vet` was run too, and passes.

## Additional Context

**Why the root's watch does not disturb `mimi start`.** The daemon registers its own channel for `SIGINT`, and signal delivery goes to every registered channel, so the daemon still sees and handles it. The one gap is before the daemon reaches that watch — while the first-run config alert is up — where the second Ctrl-C is what ends it.

**Why only `SIGINT`.** `SIGTERM` keeps Go's default. Nothing in the CLI is written to be shut down politely by a supervisor, and taking a killing signal away from one would repeat the change made to Ctrl-C without the second stage that pays for it.

**#175's usage-suppression boundary is untouched.** `ExecuteContext` only records the context before handing over to the same `Execute` the tree ran under, so flag parsing and argument validation still happen before any persistent pre-run. Its tests pass unchanged.

**Tests drive the context, not the clock or the process.** Nothing here sends a real signal to the test process, sleeps, or waits on elapsed time; the signal channel and the force-exit function are both injected. `just test-all` (with the race detector) passes.

**Found and deliberately left alone:** `ipc.TryExecute` sets a 100 ms dial timeout but no read deadline, so an action sent to a daemon that accepts the connection and never replies waits forever. It is noted in the audit and covered by the second Ctrl-C, but the real fix is a read deadline in `internal/ipc`, which is a change of its own.
