### PR TITLE
fix(hooks): quote event values substituted into hook commands

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -242,7 +242,7 @@ while running the hooks it did understand.
 
 ```toml
 [hooks]
-on_window_focus = ["echo 'focus: $mimi_APP_NAME'"]
+on_window_focus = ["echo focus: $mimi_APP_NAME"]
 
 on_window_focus = [
   { run = "notify-send focus", app = "Slack", async = true }
@@ -276,7 +276,21 @@ Every hook receives:
 | `mimi_WINDOWS_COUNT` | Window count (workspace events only) |
 | `mimi_INFO` | JSON workspace info (workspace events only) |
 
-Use `$mimi_APP_NAME` or `${mimi_WINDOW_TITLE}` in hook commands.
+Use `$mimi_APP_NAME` or `${mimi_WINDOW_TITLE}` in hook commands. Each value is
+substituted as a single, self-quoted shell token, so write the reference
+**without** wrapping it in your own quotes:
+
+```toml
+# Correct — the value quotes itself:
+on_window_title_change = [{ run = "notify-send $mimi_WINDOW_TITLE" }]
+```
+
+This matters because a value can contain anything — a window title is chosen by
+whatever web page or document is open — and mimi runs the command through a
+shell. Self-quoting stops a crafted title from breaking out and running as its
+own command. One consequence: a reference placed inside your own double quotes
+(`"... $mimi_WINDOW_TITLE ..."`) will show the wrapping quotes literally; leave
+it unquoted instead.
 
 ---
 
@@ -285,7 +299,7 @@ Use `$mimi_APP_NAME` or `${mimi_WINDOW_TITLE}` in hook commands.
 ```toml
 [hooks]
 on_app_activate = [
-  { run = "echo 'active: $mimi_APP_NAME'", async = true }
+  { run = "echo active: $mimi_APP_NAME", async = true }
 ]
 
 on_window_focus = [

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -243,6 +243,13 @@ var mimiVarRegex = regexp.MustCompile(`\${mimi_[A-Za-z0-9_]+}|\$mimi_[A-Za-z0-9_
 // with the values from evt. Uses a per-event lookup closure (no map allocation
 // in the common case) and only falls back to a per-event scan for keys not
 // produced by eventEnv (i.e. user-provided Extra keys).
+//
+// Each substituted value is wrapped by shellQuote so it lands as a single,
+// inert shell token. The values carry untrusted, attacker-influenced text —
+// a window title is whatever a web page or document chose to call itself —
+// and this string is handed straight to `sh -c`. Without quoting, a title
+// like `'; rm -rf ~; '` would break out of the command and run as its own
+// statement.
 func replaceEventVars(runCmd string, evt events.Event) string {
 	return mimiVarRegex.ReplaceAllStringFunc(runCmd, func(match string) string {
 		var varName string
@@ -253,11 +260,21 @@ func replaceEventVars(runCmd string, evt events.Event) string {
 		}
 
 		if val, ok := lookupEventVar(varName, evt); ok {
-			return val
+			return shellQuote(val)
 		}
 
 		return match
 	})
+}
+
+// shellQuote wraps s in single quotes so `sh -c` treats it as one literal
+// token, escaping any embedded single quote with the standard POSIX
+// '\” idiom (close the quote, emit an escaped quote, reopen). The result is
+// safe in every unquoted or single-quoted context; a value substituted inside
+// the user's own double quotes will show its wrapping quotes literally, which
+// is the documented trade-off for closing the injection hole.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // lookupEventVar resolves a mimi_* environment variable name (including the

--- a/internal/hooks/executor_test.go
+++ b/internal/hooks/executor_test.go
@@ -614,3 +614,119 @@ func TestRun_HookOkLogsIndexNotCommandAndKeepsOutput(t *testing.T) {
 
 	assertNoLeak(t, logs, secretCmd)
 }
+
+// TestReplaceEventVars_QuotesValues pins that substituted values are wrapped
+// as a single inert shell token, including the escaping of an embedded single
+// quote, and that legitimate values still round-trip through the shell.
+func TestReplaceEventVars_QuotesValues(t *testing.T) {
+	t.Parallel()
+
+	const notifyTitle = "notify-send $mimi_WINDOW_TITLE"
+
+	cases := []struct {
+		name  string
+		run   string
+		title string
+		want  string
+	}{
+		{
+			name:  "plain value is single-quoted",
+			run:   notifyTitle,
+			title: "Inbox",
+			want:  "notify-send 'Inbox'",
+		},
+		{
+			name:  "embedded single quote is escaped",
+			run:   notifyTitle,
+			title: "it's here",
+			want:  `notify-send 'it'\''s here'`,
+		},
+		{
+			name:  "injection payload is neutralized",
+			run:   notifyTitle,
+			title: "'; rm -rf ~; '",
+			want:  `notify-send ''\''; rm -rf ~; '\'''`,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := replaceEventVars(testCase.run, events.Event{
+				Kind:        events.WindowTitleChange,
+				WindowTitle: testCase.title,
+			})
+			if got != testCase.want {
+				t.Errorf("replaceEventVars = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestHandle_TitleInjectionDoesNotExecute is the end-to-end guard: a window
+// title crafted to break out of the hook command must not run as its own
+// shell statement. The hook writes the title to a legit file; the payload
+// tries to create a sentinel file. After the hook runs, the legit file must
+// hold the raw title verbatim and the sentinel must not exist.
+func TestHandle_TitleInjectionDoesNotExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	legit := filepath.Join(dir, "legit.txt")
+	sentinel := filepath.Join(dir, "pwned.txt")
+
+	// The payload closes the printf's quoting and appends a command that
+	// would create the sentinel file if substitution were not quoted.
+	payload := fmt.Sprintf(`'; touch %s; '`, sentinel)
+
+	reg := NewRegistry()
+
+	loadErr := reg.Reload(&config.Config{
+		Hooks: config.HooksConfig{
+			WindowTitleChange: []config.HookEntry{{
+				Run: "printf '%s' $mimi_WINDOW_TITLE > " + legit,
+			}},
+		},
+	})
+	if loadErr != nil {
+		t.Fatalf("registry reload: %v", loadErr)
+	}
+
+	cfg := &config.SettingsConfig{
+		HookShell:       defaultShell,
+		HookTimeoutSecs: 5,
+		MaxHookWorkers:  1,
+	}
+	exec := NewExecutor(reg, cfg, zap.NewNop().Sugar())
+
+	exec.Handle(events.Event{
+		Kind:        events.WindowTitleChange,
+		ID:          "inject-test",
+		WindowTitle: payload,
+		At:          time.Now(),
+	})
+
+	var content []byte
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var readErr error
+
+		content, readErr = os.ReadFile(legit) //nolint:gosec // test-controlled path
+		if readErr == nil {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := string(content); got != payload {
+		t.Errorf("legit file = %q, want the raw title %q", got, payload)
+	}
+
+	_, statErr := os.Stat(sentinel)
+	if statErr == nil {
+		t.Fatalf("injection executed: sentinel file %s was created", sentinel)
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a command-injection hole in hook execution. Hook commands run through a shell, and `$mimi_*` references in them were substituted with raw event values before the command reached the shell. Those values carry untrusted text — a window title is whatever a web page or document decides to call itself — so a title such as `'; rm -rf ~; '` broke out of the command and ran as its own shell statement, for any config that interpolated the value. Merely focusing a browser tab with a crafted title was enough to trigger it.

Every substituted value is now wrapped as a single, self-quoting shell token, so hostile text can no longer escape into command position. Unquoted and single-quoted references keep working unchanged; the one behaviour change is that a reference placed inside the user's own double quotes now shows those quotes literally.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Hook variable substitution — updated guidance

`$mimi_APP_NAME` / `${mimi_WINDOW_TITLE}` and the other `mimi_*` references are still available in hook commands, but each value is now substituted as a single self-quoted token. Write the reference **without** wrapping it in your own quotes:

```toml
# Correct — the value quotes itself:
on_window_title_change = [{ run = "notify-send $mimi_WINDOW_TITLE" }]
```

## Potentially breaking for double-quoted references

If an existing config wraps a reference in its own double quotes — `run = "echo \"title: $mimi_WINDOW_TITLE\""` — the substituted value now carries its own single quotes, so the output shows them literally (`title: 'My Window'`). Drop the surrounding quotes to fix it: `run = "echo title: $mimi_WINDOW_TITLE"`. Unquoted and single-quoted references (including every example in the docs) are unaffected.

## Additional Context

Considered dropping textual substitution entirely and relying only on the exported `mimi_*` environment variables, which is the fully standard approach — but that breaks the single-quoted references the docs teach (a shell won't expand a variable inside single quotes), a wider compatibility break than the quoting approach. Single-quote wrapping keeps the documented ergonomics while closing the hole.

Covered by two new tests: a table test pinning the quoting/escaping of substituted values, and an end-to-end test that fires a hook with a breakout payload as the window title and asserts the injected command did not run.
