### PR TITLE
perf(native): enumerate the window list once per space change

### DIFF
--- a/internal/native/workspace.m
+++ b/internal/native/workspace.m
@@ -34,8 +34,7 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 	return CFBridgingRelease(windowList);
 }
 
-- (NSString *)windowInfoJSON {
-	NSArray *windows = [self currentWindowList];
+- (NSString *)windowInfoJSONFromWindows:(NSArray *)windows {
 	if (!windows)
 		return @"";
 
@@ -154,9 +153,13 @@ static _Atomic(CFRunLoopRef) gRunLoop = NULL;
 - (void)handleNotification:(NSNotification *)note {
 	int kind = [self kindForNotificationName:note.name];
 	if (kind == MIMI_KIND_WORKSPACE_CHANGED) {
+		// Enumerate the on-screen window list once and derive both the count
+		// and the JSON payload from it. CGWindowListCopyWindowInfo is a
+		// system call, and the previous code ran it twice per space change —
+		// once here for the count and again inside the JSON builder.
 		NSArray *windows = [self currentWindowList];
 		int windowCount = windows ? (int)[windows count] : 0;
-		NSString *infoJSON = [self windowInfoJSON];
+		NSString *infoJSON = [self windowInfoJSONFromWindows:windows];
 		goWorkspaceChangeEvent(kind, windowCount, (char *)[infoJSON UTF8String]);
 
 		return;


### PR DESCRIPTION
## Description

This PR removes a redundant window-list enumeration when the active space changes. Handling that notification queried the on-screen window list twice — once to compute the window count, then again inside the code that builds the JSON snapshot of open windows. Both now come from a single enumeration.

No behaviour change: the emitted event carries the same count and the same JSON payload. As a small bonus, the count can no longer disagree with the payload's own `total_count`, since both are derived from one list instead of two separate queries.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, pure refactor with no behaviour change; the window enumeration is a native system call with no test seam
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The saved call is `CGWindowListCopyWindowInfo`, a system call whose cost scales with the number of on-screen windows. It runs once per space switch, so the win is modest, but the duplication served no purpose. Verified via `just fmt-check`, `just vet`, `just test`, and `just build`; a live space-switch check was skipped as disruptive and the change is mechanically equivalent (same array, same count, same JSON builder).
