### PR TITLE
fix(observe): key the resize debounce on window id, not title

### DIFF
--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -55,12 +55,19 @@ var AllKinds = []EventKind{
 
 // Event carries information about a system event through the bus.
 type Event struct {
-	ID          string            `json:"id"`
-	Kind        EventKind         `json:"kind"`
-	AppName     string            `json:"appName,omitempty"`
-	BundleID    string            `json:"bundleId,omitempty"`
-	PID         int               `json:"pid,omitempty"`
-	WindowTitle string            `json:"windowTitle,omitempty"`
-	At          time.Time         `json:"at"`
-	Extra       map[string]string `json:"extra,omitempty"`
+	ID          string    `json:"id"`
+	Kind        EventKind `json:"kind"`
+	AppName     string    `json:"appName,omitempty"`
+	BundleID    string    `json:"bundleId,omitempty"`
+	PID         int       `json:"pid,omitempty"`
+	WindowTitle string    `json:"windowTitle,omitempty"`
+	// WindowID identifies the window an AX event came from, stable across
+	// that window's lifetime. It is the accessibility element's pointer
+	// identity — meaningful only within this process run, so it is not
+	// serialized — and is used to key the resize debounce per window rather
+	// than per title. Zero for events that do not originate from a specific
+	// window (app lifecycle, workspace).
+	WindowID uint64            `json:"-"`
+	At       time.Time         `json:"at"`
+	Extra    map[string]string `json:"extra,omitempty"`
 }

--- a/internal/native/axobserver.m
+++ b/internal/native/axobserver.m
@@ -125,7 +125,13 @@ static void dispatchAXEvent(int kind, pid_t pid, AXUIElementRef element) {
 	const char *appName = app ? [app.localizedName UTF8String] : "";
 	const char *bundleID = app ? [app.bundleIdentifier UTF8String] : "";
 
-	goAXEvent(kind, (char *)appName, (char *)bundleID, (int)pid, (char *)title);
+	// The element's pointer identity is stable across a window's lifetime
+	// (the same reason knownRealWindows can key on it), so it serves as a
+	// per-window id. The Go side keys the resize debounce on it, so two
+	// windows of one app that happen to share a title no longer collide.
+	unsigned long long windowID = (unsigned long long)(uintptr_t)element;
+
+	goAXEvent(kind, (char *)appName, (char *)bundleID, (int)pid, (char *)title, windowID);
 }
 
 static void axCallback(AXObserverRef observer, AXUIElementRef element, CFStringRef notification, void *refcon) {

--- a/internal/native/bridge.go
+++ b/internal/native/bridge.go
@@ -145,7 +145,13 @@ func goWorkspaceChangeEvent(kind C.int, windowCount C.int, infoJSON *C.char) {
 }
 
 //export goAXEvent
-func goAXEvent(kind C.int, appName, bundleID *C.char, pid C.int, windowTitle *C.char) {
+func goAXEvent(
+	kind C.int,
+	appName, bundleID *C.char,
+	pid C.int,
+	windowTitle *C.char,
+	windowID C.ulonglong,
+) {
 	trySend(events.Event{
 		ID:          uuid.NewString(),
 		Kind:        kindFromInt(int(kind)),
@@ -153,6 +159,7 @@ func goAXEvent(kind C.int, appName, bundleID *C.char, pid C.int, windowTitle *C.
 		BundleID:    C.GoString(bundleID),
 		PID:         int(pid),
 		WindowTitle: C.GoString(windowTitle),
+		WindowID:    uint64(windowID),
 		At:          time.Now(),
 	})
 }

--- a/internal/observe/router.go
+++ b/internal/observe/router.go
@@ -129,12 +129,20 @@ func (r *Router) handle(evt events.Event) {
 	r.bus.Publish(evt)
 }
 
-func resizeKey(pid int, title string) string {
-	return fmt.Sprintf("%d:%s", pid, title)
+// resizeKey identifies the debounce bucket a resize event coalesces into.
+// It keys on the window id when the native layer supplied one, so two
+// windows of the same app with identical titles debounce independently;
+// it falls back to the title only when no id is available.
+func resizeKey(evt events.Event) string {
+	if evt.WindowID != 0 {
+		return fmt.Sprintf("%d:%d", evt.PID, evt.WindowID)
+	}
+
+	return fmt.Sprintf("%d:%s", evt.PID, evt.WindowTitle)
 }
 
 func (r *Router) debounceResize(evt events.Event) {
-	key := resizeKey(evt.PID, evt.WindowTitle)
+	key := resizeKey(evt)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -184,6 +192,7 @@ func (r *Router) newDebounceEntry(key string, evt events.Event) *resizeState {
 			BundleID:    snapshot.BundleID,
 			PID:         snapshot.PID,
 			WindowTitle: snapshot.WindowTitle,
+			WindowID:    snapshot.WindowID,
 			At:          time.Now(),
 		}
 		r.logger.Debugw("event",

--- a/internal/observe/router_test.go
+++ b/internal/observe/router_test.go
@@ -262,6 +262,44 @@ func TestDebounceResize_DifferentWindows(t *testing.T) {
 	}
 }
 
+// TestDebounceResize_SameTitleDistinctWindows guards the collision fix: two
+// windows of one app that share a title but carry different window ids must
+// debounce into separate buckets and both fire, rather than one coalescing
+// into the other and being lost.
+func TestDebounceResize_SameTitleDistinctWindows(t *testing.T) {
+	router, sub := newTestRouter(t)
+
+	router.debounceResize(events.Event{
+		Kind:        events.WindowResizing,
+		PID:         7,
+		WindowTitle: "Untitled",
+		AppName:     "App",
+		WindowID:    1001,
+	})
+	router.debounceResize(events.Event{
+		Kind:        events.WindowResizing,
+		PID:         7,
+		WindowTitle: "Untitled",
+		AppName:     "App",
+		WindowID:    2002,
+	})
+
+	received := make(map[uint64]bool)
+
+	for range 2 {
+		select {
+		case e := <-sub:
+			received[e.WindowID] = true
+		case <-time.After(testFireTimeout):
+			t.Fatalf("timed out; got events for windows: %v", received)
+		}
+	}
+
+	if !received[1001] || !received[2002] {
+		t.Errorf("expected a debounced resize for each window id, got: %v", received)
+	}
+}
+
 func TestDebounceResize_CancelTimersForPID(t *testing.T) {
 	router, sub := newTestRouter(t)
 


### PR DESCRIPTION
## Description

This PR fixes window resize events being lost when two windows of the same app share a title. The `on_window_resize` debounce grouped pending resizes by app process plus window title, so two windows with the same title — two empty-title windows being the common case — fell into one bucket. Resizing one then reset the other's pending timer, and only one of the two `window_resize` events ever fired.

Each window now carries a stable per-window identifier derived from its accessibility element, and the debounce groups on that instead of the title. Two windows with identical titles now debounce and fire independently. Behaviour is unchanged for the ordinary single-window and distinct-title cases.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no config, CLI, or hook surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The identifier is the accessibility element's pointer identity, which is stable across a window's lifetime — the same property the existing close-tracking already relies on to match a created window to its later destroy. It is meaningful only within a single daemon run, so it is not exported to hooks and not serialized into the event log; it exists purely to key the debounce. Events that do not come from a specific window (app lifecycle, workspace) carry a zero id and fall back to the previous title-based key.

Plumbing it through touched the native → Go event bridge (the accessibility callback now passes the id alongside the existing fields). Verified with a new router test that fires two same-title resizes with distinct ids and asserts both are delivered — it fails on the old title-only key and passes now — plus a live check that a real window resize still fires `window_resize` after the bridge change.
