### PR TITLE
feat(cli,hooks): add mimi query and pass the active space to workspace hooks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,3 +73,10 @@ The category of desktop change a hook subscribes to — window focused, space
 changed, app launched, and so on. One table defines the set; every other list
 of kinds is derived from that table rather than restated alongside it.
 _Avoid_: event type, event name
+
+**Query**:
+A read of desktop state that mimi reports without changing anything: the
+active space, the frontmost window. A query always runs on the direct path and
+never travels the socket.
+_Avoid_: action (an action changes the desktop), get, info, status (that is the
+daemon's health report)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | Center at specific size          | `mimi action resize_window center --width-percent 80 --height-percent 90` |
 | Resize to exact pixels           | `mimi action resize_window --width 1024 --height 768`                     |
 | Resize anchored to a corner      | `mimi action resize_window --width 1024 --height 768 --anchor br`         |
+| Read the active space as JSON    | `mimi query space`                                                        |
+| Read the frontmost window's frame| `mimi query window`                                                       |
 
 Full reference → [CLI Guide](docs/CLI.md)
 
@@ -118,7 +120,7 @@ show_workspace_number = true   # current space number in your menu bar
 
 [hooks]
 on_window_focus      = ['echo "$mimi_APP_NAME — $mimi_WINDOW_TITLE"']
-on_workspace_changed = ['~/.config/sketchybar/plugins/space.sh']
+on_workspace_changed = ['sketchybar --trigger space_change INDEX=$mimi_SPACE_INDEX']
 on_app_launch        = ['osascript -e "display notification \"$mimi_APP_NAME launched\""']
 ```
 

--- a/cmd/mimi/cmd/interrupt_audit_test.go
+++ b/cmd/mimi/cmd/interrupt_audit_test.go
@@ -66,9 +66,9 @@ func audited(command string, response interruptResponse, why string) auditEntry 
 // no longer reaches the work, is invisible from the command's own code.
 //
 // What the audit found: six commands honor the context, one runs its own
-// signal handler, and eleven ignore it. Nine of those eleven are local file
-// work or one-shot syscalls, over before an interrupt could be typed. The two
-// that are not are in the action family — `action space` on the direct path
+// signal handler, and fourteen ignore it. Twelve of those fourteen are local
+// file work, one-shot syscalls or desktop reads, over before an interrupt could
+// be typed. The two that are not are in the action family — `action space` on the direct path
 // pumps the run loop for a stretch proportional to the spaces it crosses, and
 // any action on the daemon path waits for a reply that ipc.TryExecute reads
 // with no deadline, so a daemon that accepts the connection and then goes quiet
@@ -105,6 +105,13 @@ var interruptAudit = []auditEntry{
 			"nothing here waits for the daemon to finish reloading"),
 	audited("config validate", interruptRunsOn,
 		"reads and parses one local file and reports on it"),
+	audited("query", interruptRunsOn,
+		"as action: the body only reports the missing subcommand and returns"),
+	audited("query space", interruptRunsOn,
+		"two SkyLight reads and one line of output; nothing blocks"),
+	audited("query window", interruptRunsOn,
+		"one Accessibility round trip to the frontmost application for its "+
+			"window and frame, which runs to completion, then one line of output"),
 	audited("services install", interruptStopsTheWork,
 		"Service.Install threads the context through every launchctl call "+
 			"and checks it again before the plist is written, so a canceled "+

--- a/cmd/mimi/cmd/query.go
+++ b/cmd/mimi/cmd/query.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// newQueryCmd builds the command tree that reports desktop state.
+//
+// Queries take no cliState: they never route through the daemon, so the
+// socket path is nothing they need. A running daemon serializes the actions
+// it performs; a read has nothing to serialize with, and routing it over the
+// socket would buy a wire change and nothing else.
+func newQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "query",
+		Short: "Report desktop state as JSON",
+		Long: `Report what the desktop looks like right now, as one line of JSON on stdout.
+
+Queries only read. They never move focus, a window, or a space, and they run
+in this process whether or not the daemon is running.
+
+Available subcommands:
+  space     the active Mission Control space and how many there are
+  window    the frontmost window's owner and frame
+
+Examples:
+  mimi query space
+  mimi query window
+  mimi query space | jq .index`,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			// As for "mimi action": nothing ran, the user is missing a
+			// subcommand, and usage is the only place the subcommands are
+			// named.
+			cobraCmd.SilenceUsage = false
+
+			return derrors.New(
+				derrors.CodeInvalidInput,
+				"query subcommand required (e.g., mimi query space, mimi query window)",
+			)
+		},
+	}
+
+	cmd.AddCommand(buildQuerySpaceCommand())
+	cmd.AddCommand(buildQueryWindowCommand())
+
+	return cmd
+}
+
+func buildQuerySpaceCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "space",
+		Short: "Report the active Mission Control space and the space count",
+		Long: `Report the active Mission Control space as JSON:
+
+  {"index":2,"count":5}
+
+"index" is the 1-based index of the space in front, in the same ordering
+"mimi action space" takes, and "count" is how many spaces there are across
+every connected display. Accessibility permission is not needed.`,
+		Args: cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return answerQuery(cobraCmd, action.QuerySpace)
+		},
+	}
+}
+
+func buildQueryWindowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "window",
+		Short: "Report the frontmost window's owner and frame",
+		Long: `Report the frontmost window as JSON:
+
+  {"pid":4242,"frame":{"x":100,"y":50,"width":1024,"height":768}}
+
+"pid" is the process ID of the application that owns the window. The frame
+is in window coordinates: the origin is the top-left corner of the primary
+display and y grows downward, which is what "mimi action resize_window"
+takes for --x and --y. Accessibility permission is required.`,
+		Args: cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return answerQuery(cobraCmd, action.QueryWindow)
+		},
+	}
+}
+
+// answerQuery runs one query and prints its answer as a single line of JSON
+// on the command's stdout. A query that fails prints nothing there: the error
+// goes out the way every other command's does, so a script reading stdout
+// never has to tell an answer from a complaint.
+func answerQuery[T any](cobraCmd *cobra.Command, query func() (T, error)) error {
+	answer, err := query()
+	if err != nil {
+		return err
+	}
+
+	err = json.NewEncoder(cobraCmd.OutOrStdout()).Encode(answer)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeSerializationFailed, "encoding query result")
+	}
+
+	return nil
+}

--- a/cmd/mimi/cmd/query_test.go
+++ b/cmd/mimi/cmd/query_test.go
@@ -1,0 +1,139 @@
+//nolint:testpackage
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+const (
+	queryCommandName       = "query"
+	querySpaceCommandName  = "space"
+	queryWindowCommandName = "window"
+)
+
+// answerOn runs answerQuery against a command whose streams are captured, and
+// returns what reached stdout and stderr.
+func answerOn[T any](t *testing.T, query func() (T, error)) (string, string, error) {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+
+	cobraCmd := &cobra.Command{}
+	cobraCmd.SetOut(&stdout)
+	cobraCmd.SetErr(&stderr)
+
+	err := answerQuery(cobraCmd, query)
+
+	return stdout.String(), stderr.String(), err
+}
+
+// TestAnswerQuery_PrintsOneLineOfJSON pins the output format a script reads:
+// the answer, as compact JSON, on one line, followed by a newline and nothing
+// else.
+func TestAnswerQuery_PrintsOneLineOfJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		answer any
+		want   string
+	}{
+		{
+			name:   querySpaceCommandName,
+			answer: action.SpaceInfo{Index: 2, Count: 5},
+			want:   `{"index":2,"count":5}` + "\n",
+		},
+		{
+			name: queryWindowCommandName,
+			answer: action.WindowInfo{
+				PID:   4242,
+				Frame: action.Frame{X: 100, Y: 50, Width: 1024, Height: 768},
+			},
+			want: `{"pid":4242,"frame":{"x":100,"y":50,"width":1024,"height":768}}` + "\n",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr, err := answerOn(t, func() (any, error) { return testCase.answer, nil })
+			if err != nil {
+				t.Fatalf("answerQuery() error = %v, want nil", err)
+			}
+
+			if stdout != testCase.want {
+				t.Errorf("stdout = %q, want %q", stdout, testCase.want)
+			}
+
+			if stderr != "" {
+				t.Errorf("stderr = %q, want nothing", stderr)
+			}
+		})
+	}
+}
+
+// TestAnswerQuery_AFailurePrintsNothingOnStdout is the contract a script
+// depends on: stdout carries an answer or nothing, never an error dressed as
+// one.
+func TestAnswerQuery_AFailurePrintsNothingOnStdout(t *testing.T) {
+	t.Parallel()
+
+	failure := derrors.New(derrors.CodeActionFailed, "no active window found")
+
+	stdout, _, err := answerOn(t, func() (action.WindowInfo, error) {
+		return action.WindowInfo{}, failure
+	})
+	if err == nil {
+		t.Fatal("answerQuery() error = nil, want the query's failure")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeActionFailed) {
+		t.Errorf("error code = %q, want %q", derrors.GetCode(err), derrors.CodeActionFailed)
+	}
+
+	if stdout != "" {
+		t.Errorf("stdout = %q, want nothing", stdout)
+	}
+}
+
+func TestQueryCommand_WithoutASubcommandStillListsItsSubcommands(t *testing.T) {
+	isolateConfigHome(t)
+
+	out, err := runCommand(t, queryCommandName)
+	if err == nil {
+		t.Fatal("expected mimi query to fail without a subcommand")
+	}
+
+	if !strings.Contains(out, "Usage:") {
+		t.Errorf("mimi query printed no usage, got: %s", out)
+	}
+
+	for _, name := range []string{querySpaceCommandName, queryWindowCommandName} {
+		if !strings.Contains(out, name) {
+			t.Errorf("mimi query never named the %q subcommand, got: %s", name, out)
+		}
+	}
+}
+
+// TestQueryCommands_TakeNoArguments: a query has nothing to be told, so a
+// stray argument is a mistake worth rejecting before any desktop read runs.
+func TestQueryCommands_TakeNoArguments(t *testing.T) {
+	isolateConfigHome(t)
+
+	for _, name := range []string{querySpaceCommandName, queryWindowCommandName} {
+		t.Run(name, func(t *testing.T) {
+			_, err := runCommand(t, queryCommandName, name, "extra")
+			if err == nil {
+				t.Fatalf("mimi query %s extra reported success, want an argument error", name)
+			}
+		})
+	}
+}

--- a/cmd/mimi/cmd/root.go
+++ b/cmd/mimi/cmd/root.go
@@ -33,6 +33,7 @@ func newRootCmd() *cobra.Command {
 		Long: `mimi provides macOS-native window and space management without disabling SIP.
 
 Use "mimi action" for immediate commands (focus window, switch space, move window).
+Use "mimi query" to read the active space or the frontmost window as JSON.
 Use "mimi start" to run the background daemon and react to window/space events via hooks.`,
 		Version: Version,
 		// Cobra runs the nearest persistent pre-run it finds walking up from the
@@ -72,6 +73,7 @@ Use "mimi start" to run the background daemon and react to window/space events v
 	root.AddCommand(newConfigCmd(state))
 	root.AddCommand(newServicesCmd(state))
 	root.AddCommand(newActionCmd(state))
+	root.AddCommand(newQueryCmd())
 
 	return root
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,6 +60,13 @@ When the daemon is running, `mimi action` first tries the Unix socket at `settin
 
 Each action builds its command through the constructor `internal/action` gives it (`NewFocusWindowCommand`, `NewSpaceCommand`, `NewMoveWindowToSpaceCommand`, `NewResizeWindowCommand`), and those constructors validate as they build. A malformed argument is therefore rejected before either path is chosen — no socket is opened, and the message reads the same whether or not a daemon is listening.
 
+### Queries
+
+`mimi query` reads the desktop through the same seam and prints one line of
+JSON. A query runs on the direct path only: it has no side effect to serialize
+with the daemon's actions, so routing it over the socket would cost a wire
+change and buy nothing.
+
 ---
 
 ## Hook Daemon
@@ -95,7 +102,8 @@ Matches events against configured hooks, applies filters (`app`, `bundle_id`, `t
 cmd/mimi/           CLI entry point and commands
 internal/
   action/           Action dispatch (focus_window, space, move_window_to_space,
-                    resize_window), the Desktop seam and its native adapter
+                    resize_window), the queries, the Desktop seam and its
+                    native adapter
   native/           All Objective-C + CGO: AX window wrappers, Mission Control
                     space operations, screen queries, and the observer bridge
   observe/          Hook daemon event routing
@@ -113,9 +121,10 @@ internal/
 **Accessibility** is required for:
 
 - All `mimi action` commands
+- `mimi query window`
 - Window hooks (`on_window_*`)
 
-App lifecycle hooks (`on_app_*`) and workspace hooks (`on_workspace_changed`) do not require Accessibility.
+App lifecycle hooks (`on_app_*`), workspace hooks (`on_workspace_changed`) and `mimi query space` do not require Accessibility.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,6 +9,7 @@ mimi is a macOS window and space utility. Use `mimi action` for immediate comman
 - [Global Flags](#global-flags)
 - [Interrupting a Command](#interrupting-a-command)
 - [Window & Space Actions](#window--space-actions)
+- [Queries](#queries)
 - [Hook Daemon](#hook-daemon)
 - [Service Management](#service-management)
 - [Configuration Management](#configuration-management)
@@ -41,8 +42,9 @@ command; the **second** always ends the process immediately, with exit status
 | `mimi action *`              | Does not reach the action; it finishes. Press Ctrl-C again to end the process.   |
 | `mimi config *`              | Does not reach the command; it finishes. Each is one local file read or write.   |
 | `mimi status`, `mimi stop`   | Does not reach the command; it finishes. Each is a file read and one syscall.    |
+| `mimi query *`               | Does not reach the command; it finishes. Each is a few desktop reads and one line of output. |
 
-A command in the bottom three rows that the first Ctrl-C did not reach still
+A command in the bottom four rows that the first Ctrl-C did not reach still
 succeeds and exits 0, because it did in fact finish — `mimi config init`
 interrupted once has still written the file. Press Ctrl-C twice to be sure a
 command did not run.
@@ -181,6 +183,53 @@ mimi action resize_window left-half --no-margin
 
 # Mix preset with custom size
 mimi action resize_window center --width-percent 80 --height-percent 90
+```
+
+---
+
+## Queries
+
+Queries read the desktop and print what they find as one line of JSON on
+stdout. They never move focus, a window, or a space, and they always run in the
+CLI's own process. A running daemon is neither consulted nor required.
+
+```bash
+mimi query space
+mimi query window
+```
+
+A query that fails prints nothing on stdout and reports the error the way every
+other command does, so a script can read stdout as the answer or nothing.
+
+### `mimi query space`
+
+Report the active Mission Control space and how many there are, in the same
+1-based ordering `mimi action space` takes. Needs no Accessibility permission.
+
+```
+$ mimi query space
+{"index":2,"count":5}
+```
+
+`index` is the space in front on the display holding the cursor, which is the
+one `space next` and `space prev` step from.
+
+### `mimi query window`
+
+Report the frontmost window, the one `resize_window` would act on, with the
+process ID of its owner and its frame. The frame is in window coordinates: the
+origin is the top-left corner of the primary display and y grows downward,
+which is what `--x` and `--y` take. **Accessibility permission is required.**
+
+```
+$ mimi query window
+{"pid":4242,"frame":{"x":100,"y":50,"width":1024,"height":768}}
+```
+
+Pipe through `jq` to pick one field:
+
+```bash
+mimi query space | jq .index
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -275,6 +275,8 @@ Every hook receives:
 | `mimi_TIMESTAMP` | RFC3339 timestamp |
 | `mimi_WINDOWS_COUNT` | Window count (workspace events only) |
 | `mimi_INFO` | JSON workspace info (workspace events only) |
+| `mimi_SPACE_INDEX` | 1-based index of the space now in front (workspace events only) |
+| `mimi_SPACE_COUNT` | How many Mission Control spaces there are (workspace events only) |
 
 Use `$mimi_APP_NAME` or `${mimi_WINDOW_TITLE}` in hook commands. Each value is
 substituted as a single, self-quoted shell token, so write the reference
@@ -307,6 +309,6 @@ on_window_focus = [
 ]
 
 on_workspace_changed = [
-  "echo 'switched space' >> ~/space.log"
+  "echo switched to space $mimi_SPACE_INDEX >> ~/space.log"
 ]
 ```

--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -51,7 +51,7 @@ type Desktop interface {
 	// FrontmostWindow is the window in front, which is the one the window
 	// actions that take no window act on. It reports an error when there is
 	// none.
-	FrontmostWindow() (WindowID, error)
+	FrontmostWindow() (Window, error)
 
 	// SetWindowFrame moves and resizes one window.
 	SetWindowFrame(id WindowID, frame geometry.Rect) error

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -139,7 +139,7 @@ func (e *Executor) ResizeWindow(req geometry.Request) error {
 		return err
 	}
 
-	current, err := e.desktop.WindowFrame(win)
+	current, err := e.desktop.WindowFrame(win.ID)
 	if err != nil {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get window frame")
 	}
@@ -151,7 +151,7 @@ func (e *Executor) ResizeWindow(req geometry.Request) error {
 		return err
 	}
 
-	return e.desktop.SetWindowFrame(win, geometry.Resize(current, screen, req))
+	return e.desktop.SetWindowFrame(win.ID, geometry.Resize(current, screen, req))
 }
 
 // ensureSpaceExists is the one range check both space actions share. A space

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -97,12 +97,17 @@ func (d *fakeDesktop) ActivateWindow(windowID action.WindowID) error {
 	return nil
 }
 
-func (d *fakeDesktop) FrontmostWindow() (action.WindowID, error) {
+func (d *fakeDesktop) FrontmostWindow() (action.Window, error) {
 	if d.frontmostErr != nil {
-		return 0, d.frontmostErr
+		return action.Window{}, d.frontmostErr
 	}
 
-	return d.frontmost, nil
+	index, err := d.indexOf(d.frontmost)
+	if err != nil {
+		return action.Window{}, err
+	}
+
+	return action.Window{ID: d.frontmost, PID: d.windows[index].pid}, nil
 }
 
 func (d *fakeDesktop) SetWindowFrame(windowID action.WindowID, frame geometry.Rect) error {

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -66,10 +66,18 @@ func (d *nativeDesktop) FocusableWindows() ([]Window, int, error) {
 }
 
 // FrontmostWindow returns the window currently in front.
-func (d *nativeDesktop) FrontmostWindow() (WindowID, error) {
+func (d *nativeDesktop) FrontmostWindow() (Window, error) {
 	element := native.FrontmostWindow()
 	if element == nil {
-		return 0, derrors.New(derrors.CodeActionFailed, "no active window found")
+		return Window{}, derrors.New(derrors.CodeActionFailed, "no active window found")
+	}
+
+	// As in FocusableWindows, a window whose owning process cannot be read is
+	// still the window in front; the pid is reported as 0 rather than the
+	// window refused.
+	pid, pidErr := element.PID()
+	if pidErr != nil {
+		pid = 0
 	}
 
 	d.mu.Lock()
@@ -77,7 +85,7 @@ func (d *nativeDesktop) FrontmostWindow() (WindowID, error) {
 
 	d.releaseLocked()
 
-	return d.registerLocked(element), nil
+	return Window{ID: d.registerLocked(element), PID: pid}, nil
 }
 
 // WindowFrame reads one window's frame.

--- a/internal/action/query.go
+++ b/internal/action/query.go
@@ -1,0 +1,103 @@
+package action
+
+import (
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// SpaceInfo is what a space query reports: the space in front and how many
+// there are, both counted in Mission Control ordering across every display.
+type SpaceInfo struct {
+	Index int `json:"index"`
+	Count int `json:"count"`
+}
+
+// Frame is a window frame as a query prints it, in window coordinates: the
+// origin is the top-left corner of the primary display and y grows downward,
+// which is the frame resize_window's --x and --y take.
+type Frame struct {
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
+}
+
+// WindowInfo is what a window query reports about the frontmost window.
+type WindowInfo struct {
+	PID   int   `json:"pid"`
+	Frame Frame `json:"frame"`
+}
+
+// QuerySpace reports the active Mission Control space on the desktop mimi is
+// running on.
+func QuerySpace() (SpaceInfo, error) {
+	return defaultExecutor.QuerySpace()
+}
+
+// QueryWindow reports the frontmost window on the desktop mimi is running on.
+func QueryWindow() (WindowInfo, error) {
+	return defaultExecutor.QueryWindow()
+}
+
+// QuerySpace reports which space is in front and how many there are.
+//
+// It reads Mission Control the way the space actions do, through SkyLight
+// rather than Accessibility, so unlike every action it does not check the
+// permission first: the daemon's workspace hooks answer the same question
+// without it, and a query that refused would be refusing what the daemon
+// already does.
+func (e *Executor) QuerySpace() (SpaceInfo, error) {
+	count := e.desktop.SpaceCount()
+	if count == 0 {
+		return SpaceInfo{}, derrors.New(
+			derrors.CodeActionFailed,
+			"failed to enumerate Mission Control spaces",
+		)
+	}
+
+	index, err := e.desktop.ActiveSpaceIndex()
+	if err != nil {
+		return SpaceInfo{}, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to resolve the active space",
+		)
+	}
+
+	return SpaceInfo{Index: index, Count: count}, nil
+}
+
+// QueryWindow reports the frontmost window and its frame.
+//
+// The frame is read through Accessibility, so this checks the permission the
+// way resize_window does, and reports the same window resize_window would act
+// on.
+func (e *Executor) QueryWindow() (WindowInfo, error) {
+	err := e.desktop.EnsureAccessible()
+	if err != nil {
+		return WindowInfo{}, err
+	}
+
+	win, err := e.desktop.FrontmostWindow()
+	if err != nil {
+		return WindowInfo{}, err
+	}
+
+	frame, err := e.desktop.WindowFrame(win.ID)
+	if err != nil {
+		return WindowInfo{}, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to get window frame",
+		)
+	}
+
+	return WindowInfo{
+		PID: win.PID,
+		Frame: Frame{
+			X:      frame.X,
+			Y:      frame.Y,
+			Width:  frame.W,
+			Height: frame.H,
+		},
+	}, nil
+}

--- a/internal/action/query_test.go
+++ b/internal/action/query_test.go
@@ -1,0 +1,192 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+func TestExecutor_QuerySpace_ReportsTheActiveSpaceAndTheCount(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(2)
+
+	got, err := action.NewExecutor(desktop).QuerySpace()
+	if err != nil {
+		t.Fatalf("QuerySpace() error = %v, want nil", err)
+	}
+
+	want := action.SpaceInfo{Index: 2, Count: spaceCount}
+	if got != want {
+		t.Fatalf("QuerySpace() = %+v, want %+v", got, want)
+	}
+}
+
+// TestExecutor_QuerySpace_NeedsNoAccessibility pins the one way a query
+// differs from an action: the workspace hooks report the space without the
+// permission, so the query that answers the same question does too.
+func TestExecutor_QuerySpace_NeedsNoAccessibility(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(1)
+	desktop.accessibilityErr = derrors.New(derrors.CodeAccessibilityDenied, "denied")
+
+	_, err := action.NewExecutor(desktop).QuerySpace()
+	if err != nil {
+		t.Fatalf("QuerySpace() without Accessibility error = %v, want nil", err)
+	}
+}
+
+func TestExecutor_QuerySpace_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		desktop func() *fakeDesktop
+	}{
+		{
+			name: "no spaces enumerated",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithSpaces(1)
+				desktop.spaceCount = 0
+
+				return desktop
+			},
+		},
+		{
+			name: "active space unresolved",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithSpaces(1)
+				desktop.activeSpaceErr = derrors.New(derrors.CodeActionFailed, "no active space")
+
+				return desktop
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := action.NewExecutor(testCase.desktop()).QuerySpace()
+			if err == nil {
+				t.Fatal("QuerySpace() error = nil, want an error")
+			}
+
+			if !derrors.IsCode(err, derrors.CodeActionFailed) {
+				t.Fatalf(
+					"QuerySpace() error code = %q, want %q",
+					derrors.GetCode(err),
+					derrors.CodeActionFailed,
+				)
+			}
+		})
+	}
+}
+
+func TestExecutor_QueryWindow_ReportsTheFrontmostWindowAndItsFrame(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithOneWindow()
+
+	got, err := action.NewExecutor(desktop).QueryWindow()
+	if err != nil {
+		t.Fatalf("QueryWindow() error = %v, want nil", err)
+	}
+
+	want := action.WindowInfo{
+		PID:   100,
+		Frame: action.Frame{X: 10, Y: 10, Width: 200, Height: 200},
+	}
+	if got != want {
+		t.Fatalf("QueryWindow() = %+v, want %+v", got, want)
+	}
+}
+
+func TestExecutor_QueryWindow_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		desktop  func() *fakeDesktop
+		wantCode derrors.Code
+	}{
+		{
+			name: "accessibility denied",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithOneWindow()
+				desktop.accessibilityErr = derrors.New(derrors.CodeAccessibilityDenied, "denied")
+
+				return desktop
+			},
+			wantCode: derrors.CodeAccessibilityDenied,
+		},
+		{
+			name: "no frontmost window",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithOneWindow()
+				desktop.frontmostErr = derrors.New(
+					derrors.CodeActionFailed,
+					"no active window found",
+				)
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+		{
+			name: "frame unreadable",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithOneWindow()
+				desktop.windows[0].frameErr = derrors.New(
+					derrors.CodeAccessibilityFailed,
+					"no frame",
+				)
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := action.NewExecutor(testCase.desktop()).QueryWindow()
+			if err == nil {
+				t.Fatal("QueryWindow() error = nil, want an error")
+			}
+
+			if !derrors.IsCode(err, testCase.wantCode) {
+				t.Fatalf(
+					"QueryWindow() error code = %q, want %q",
+					derrors.GetCode(err),
+					testCase.wantCode,
+				)
+			}
+		})
+	}
+}
+
+// TestExecutor_QueryWindow_ReadsButNeverWrites is what makes a query a query:
+// the window it reports is left exactly where it was.
+func TestExecutor_QueryWindow_ReadsButNeverWrites(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithOneWindow()
+	before := desktop.windows[0].frame
+
+	_, err := action.NewExecutor(desktop).QueryWindow()
+	if err != nil {
+		t.Fatalf("QueryWindow() error = %v, want nil", err)
+	}
+
+	if got := desktop.windows[0].frame; got != before {
+		t.Fatalf("window frame after query = %+v, want %+v unchanged", got, before)
+	}
+
+	wantRefreshCalls(t, desktop, 0)
+	wantFocused(t, desktop, desktop.windows[0].id)
+}

--- a/internal/native/bridge.go
+++ b/internal/native/bridge.go
@@ -127,21 +127,55 @@ func goWorkspaceEvent(kind C.int, appName, bundleID *C.char, pid C.int,
 
 //export goWorkspaceChangeEvent
 func goWorkspaceChangeEvent(kind C.int, windowCount C.int, infoJSON *C.char) {
+	info := ""
+	if infoJSON != nil {
+		info = C.GoString(infoJSON)
+	}
+
+	trySend(workspaceChangeEvent(kindFromInt(int(kind)), int(windowCount), info, activeSpace))
+}
+
+// activeSpace is the read a workspace change carries to its hooks: the 1-based
+// index of the space now in front and how many spaces there are. ok is false
+// when Mission Control could not be enumerated, in which case the event says
+// nothing about the space rather than naming a wrong one.
+func activeSpace() (int, int, bool) {
+	index, err := ActiveSpaceIndex()
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return index, SpaceCount(), true
+}
+
+// workspaceChangeEvent builds the event one space change publishes. space is
+// the read behind mimi_SPACE_INDEX and mimi_SPACE_COUNT, passed in so the
+// shape of the event can be pinned without a desktop under it.
+func workspaceChangeEvent(
+	kind events.EventKind,
+	windowCount int,
+	infoJSON string,
+	space func() (int, int, bool),
+) events.Event {
 	evt := events.Event{
 		ID:   uuid.NewString(),
-		Kind: kindFromInt(int(kind)),
+		Kind: kind,
 		At:   time.Now(),
 		Extra: map[string]string{
-			"windows_count": strconv.Itoa(int(windowCount)),
+			"windows_count": strconv.Itoa(windowCount),
 		},
 	}
-	if infoJSON != nil {
-		jsonStr := C.GoString(infoJSON)
-		if jsonStr != "" {
-			evt.Extra["info"] = jsonStr
-		}
+
+	if infoJSON != "" {
+		evt.Extra["info"] = infoJSON
 	}
-	trySend(evt)
+
+	if index, count, ok := space(); ok {
+		evt.Extra["space_index"] = strconv.Itoa(index)
+		evt.Extra["space_count"] = strconv.Itoa(count)
+	}
+
+	return evt
 }
 
 //export goAXEvent

--- a/internal/native/workspace_event_test.go
+++ b/internal/native/workspace_event_test.go
@@ -1,0 +1,72 @@
+package native //nolint:testpackage // tests unexported workspaceChangeEvent
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+const (
+	testWindowCount = 3
+	testInfoJSON    = `{"windows":[]}`
+)
+
+// TestWorkspaceChangeEvent_CarriesTheActiveSpace pins what reaches a
+// workspace hook: the window count and JSON it always carried, and now the
+// space in front and the count, which is what lets a hook show a space number
+// without asking anything else.
+func TestWorkspaceChangeEvent_CarriesTheActiveSpace(t *testing.T) {
+	t.Parallel()
+
+	evt := workspaceChangeEvent(
+		events.WorkspaceChanged,
+		testWindowCount,
+		testInfoJSON,
+		func() (int, int, bool) { return 2, 5, true },
+	)
+
+	if evt.Kind != events.WorkspaceChanged {
+		t.Fatalf("Kind = %q, want %q", evt.Kind, events.WorkspaceChanged)
+	}
+
+	want := map[string]string{
+		"windows_count": "3",
+		"info":          testInfoJSON,
+		"space_index":   "2",
+		"space_count":   "5",
+	}
+
+	for key, wantValue := range want {
+		if got := evt.Extra[key]; got != wantValue {
+			t.Errorf("Extra[%q] = %q, want %q", key, got, wantValue)
+		}
+	}
+
+	if len(evt.Extra) != len(want) {
+		t.Errorf("Extra = %v, want exactly %d keys", evt.Extra, len(want))
+	}
+}
+
+// TestWorkspaceChangeEvent_OmitsTheSpaceItCannotResolve: a hook reads an
+// unset mimi_SPACE_INDEX as "unknown", which is the truth; a zero would read
+// as a space number.
+func TestWorkspaceChangeEvent_OmitsTheSpaceItCannotResolve(t *testing.T) {
+	t.Parallel()
+
+	evt := workspaceChangeEvent(
+		events.WorkspaceChanged,
+		testWindowCount,
+		"",
+		func() (int, int, bool) { return 0, 0, false },
+	)
+
+	for _, key := range []string{"space_index", "space_count", "info"} {
+		if got, ok := evt.Extra[key]; ok {
+			t.Errorf("Extra[%q] = %q, want it absent", key, got)
+		}
+	}
+
+	if got := evt.Extra["windows_count"]; got != "3" {
+		t.Errorf("Extra[windows_count] = %q, want %q", got, "3")
+	}
+}


### PR DESCRIPTION
## Description

This PR adds a read-only `mimi query` command and passes the active space to workspace hooks. mimi could change the desktop but never report it: nothing printed the active space or the frontmost window, and a workspace hook received the window list but not the space it had just landed on, so a menu bar indicator (sketchybar, say) had no way to show a space number without another tool.

Queries print one line of JSON on stdout and nothing there on failure, so a script reads stdout as the answer or nothing. They run in the CLI's own process whether or not the daemon is running; a read has nothing to serialize with the daemon's actions, so the socket protocol is unchanged. Reading the space needs no Accessibility permission, the same as the workspace hooks. Reading the window does.

## Commands and hook variables

| Surface | What it does |
| --- | --- |
| `mimi query space` | Prints `{"index":2,"count":9}`: the 1-based active space in Mission Control ordering, and how many spaces exist across every display. No Accessibility needed. |
| `mimi query window` | Prints `{"pid":4242,"frame":{"x":8,"y":38,"width":1904,"height":1034}}`: the frontmost window's owner and its frame in window coordinates (origin top-left of the primary display, y down, the same frame `resize_window --x/--y` takes). Accessibility required. |
| `mimi_SPACE_INDEX` | New on every `on_workspace_changed` hook: the 1-based index of the space now in front. |
| `mimi_SPACE_COUNT` | New on every `on_workspace_changed` hook: how many spaces there are. |

Both variables are left unset when Mission Control cannot be enumerated, rather than set to 0. Existing configs and hook scripts keep working unchanged; the only difference a hook sees is two extra variables.

```toml
[hooks]
on_workspace_changed = ['sketchybar --trigger space_change INDEX=$mimi_SPACE_INDEX']
```

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Run on this machine after `just build`:

```
$ ./bin/mimi query space
{"index":2,"count":9}
$ ./bin/mimi query window
{"pid":90234,"frame":{"x":8,"y":38,"width":1904,"height":1034}}
```

A throwaway daemon with `on_workspace_changed = ["echo idx=$mimi_SPACE_INDEX count=$mimi_SPACE_COUNT >> space.log"]`, driven by `action space next` then `action space prev`, logged:

```
idx=3 count=9
idx=2 count=9
```

## Additional Context

The space index is read when the space-change notification arrives, on the observer thread, with the same SkyLight calls `action space next` uses to find where it is. The live check above matched the systray's number on both switches. The systray reads the number again 30ms after the notification as a precaution; nothing in this PR does, so if a machine ever reports a stale index the retry is the first thing to try.

The window query widens the internal frontmost-window read to carry the owning process ID alongside the window, which is what `resize_window` already had available through the window list; there is no behaviour change for `resize_window`.

Not verified by revoking the grant: that `mimi query space` works without Accessibility. It calls only the SkyLight space reads, which the docs already state the workspace hooks use without the permission.
