### PR TITLE
feat(action,cli): follow a window to its new space with move_window_to_space --follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | Jump to a specific space         | `mimi action space <n>`                                                   |
 | Jump to next / previous space    | `mimi action space next` / `prev`                                         |
 | Move frontmost window to a space | `mimi action move_window_to_space <n\|next\|prev>`                        |
+| Move a window and go with it     | `mimi action move_window_to_space next --follow`                          |
 | Cycle focus between windows      | `mimi action focus_window`                                                |
 | Cycle focus backward             | `mimi action focus_window --backward`                                     |
 | Focus window to the left         | `mimi action focus_window --left`                                         |

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -28,6 +28,7 @@ Examples:
   mimi action move_window_to_space 2
   mimi action move_window_to_space next
   mimi action move_window_to_space prev
+  mimi action move_window_to_space next --follow
   mimi action resize_window left-half
   mimi action resize_window --width 800 --height 600 --anchor cc
   mimi action resize_window --width-percent 50 --height-percent 100 --anchor tl`,
@@ -143,7 +144,9 @@ Examples:
 }
 
 func buildMoveWindowToSpaceCommand(state *cliState) *cobra.Command {
-	return &cobra.Command{
+	var follow bool
+
+	cmd := &cobra.Command{
 		Use:   "move_window_to_space <number|next|prev>",
 		Short: "Move current focused window to a Mission Control space by index or cycle next/prev",
 		Long: `Move the currently focused window to a Mission Control space by its 1-based
@@ -159,13 +162,18 @@ last space.
 This command uses private APIs (SkyLight) to move the window instantly
 without scripting additions or disabling SIP on macOS.
 
+With --follow, focus switches to the destination space once the window is
+there, the same way "mimi action space" switches. Without it the window
+leaves and the current space stays in front.
+
 Examples:
-  mimi action move_window_to_space 2        Move current window to space 2
-  mimi action move_window_to_space next     Move window to next space (with wrap)
-  mimi action move_window_to_space prev     Move window to previous space (with wrap)`,
+  mimi action move_window_to_space 2             Move current window to space 2
+  mimi action move_window_to_space next          Move window to next space (with wrap)
+  mimi action move_window_to_space prev          Move window to previous space (with wrap)
+  mimi action move_window_to_space next --follow Move window to next space and go with it`,
 		Args: validateSpaceArg(action.NameMoveWindowToSpace),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			moveCmd, err := action.NewMoveWindowToSpaceCommand(args)
+			moveCmd, err := action.NewMoveWindowToSpaceCommand(args, follow)
 			if err != nil {
 				return err
 			}
@@ -173,6 +181,11 @@ Examples:
 			return state.runAction(cobraCmd, moveCmd)
 		},
 	}
+
+	cmd.Flags().
+		BoolVar(&follow, "follow", false, "Switch to the destination space after moving the window")
+
+	return cmd
 }
 
 func buildResizeWindowCommand(state *cliState) *cobra.Command {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -82,6 +82,7 @@ mimi action space prev
 mimi action move_window_to_space 2
 mimi action move_window_to_space next
 mimi action move_window_to_space prev
+mimi action move_window_to_space next --follow
 mimi action resize_window left-half
 mimi action resize_window center --width-percent 80 --height-percent 90
 mimi action resize_window --width 1024 --height 768 --anchor cc
@@ -106,6 +107,12 @@ Focus a Mission Control space by its 1-based index, or cycle to the next/previou
 ### `mimi action move_window_to_space <number|next|prev>`
 
 Move the frontmost window to a space by its 1-based index, or cycle to the next/previous space with wrapping. Uses private SkyLight APIs; does not require disabling SIP.
+
+| Flag       | Description                                                      |
+| ---------- | ---------------------------------------------------------------- |
+| `--follow` | Switch to the destination space once the window is there         |
+
+Without `--follow` the window leaves and the current space stays in front. With it, the switch is the same dock-swipe gesture `mimi action space` makes, so it is subject to the same timing. If the move lands but the switch fails, the error says the window moved and the window stays on its new space.
 
 ### `mimi action resize_window [preset] [flags]`
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -31,10 +31,19 @@ import (
 type Command struct {
 	Name Name `json:"name"`
 
-	FocusWindow       FocusWindowArgs  `json:"focusWindow,omitzero"`
-	Space             SpaceArg         `json:"space,omitzero"`
-	MoveWindowToSpace SpaceArg         `json:"moveWindowToSpace,omitzero"`
-	ResizeWindow      ResizeWindowArgs `json:"resizeWindow,omitzero"`
+	FocusWindow       FocusWindowArgs       `json:"focusWindow,omitzero"`
+	Space             SpaceArg              `json:"space,omitzero"`
+	MoveWindowToSpace MoveWindowToSpaceArgs `json:"moveWindowToSpace,omitzero"`
+	ResizeWindow      ResizeWindowArgs      `json:"resizeWindow,omitzero"`
+}
+
+// MoveWindowToSpaceArgs is move_window_to_space's typed payload: the space the
+// window goes to, and whether focus goes with it.
+type MoveWindowToSpaceArgs struct {
+	Space SpaceArg `json:"space"`
+	// Follow switches to the destination space once the window is there, so
+	// one hotkey does what "move_window_to_space N" then "space N" would.
+	Follow bool `json:"follow"`
 }
 
 // FocusWindowArgs is focus_window's typed payload.
@@ -80,16 +89,19 @@ func NewSpaceCommand(args []string) (Command, error) {
 }
 
 // NewMoveWindowToSpaceCommand builds move_window_to_space's command from the
-// one positional argument the action takes. It is NewSpaceCommand's
-// counterpart: the same rule, reported against this action's name, landing on
-// the field this action reads.
-func NewMoveWindowToSpaceCommand(args []string) (Command, error) {
+// one positional argument the action takes and its --follow flag. It is
+// NewSpaceCommand's counterpart: the same rule, reported against this action's
+// name, landing on the field this action reads.
+func NewMoveWindowToSpaceCommand(args []string, follow bool) (Command, error) {
 	spaceArg, err := ParseSpaceArg(NameMoveWindowToSpace, args)
 	if err != nil {
 		return Command{}, err
 	}
 
-	return Command{Name: NameMoveWindowToSpace, MoveWindowToSpace: spaceArg}, nil
+	return Command{
+		Name:              NameMoveWindowToSpace,
+		MoveWindowToSpace: MoveWindowToSpaceArgs{Space: spaceArg, Follow: follow},
+	}, nil
 }
 
 // NewResizeWindowCommand builds resize_window's command from the CLI's raw
@@ -400,12 +412,12 @@ func (e *Executor) ExecuteCommand(cmd Command) error {
 
 		return e.FocusSpace(index)
 	case NameMoveWindowToSpace:
-		index, err := e.resolveSpaceArg(NameMoveWindowToSpace, cmd.MoveWindowToSpace)
+		index, err := e.resolveSpaceArg(NameMoveWindowToSpace, cmd.MoveWindowToSpace.Space)
 		if err != nil {
 			return err
 		}
 
-		return e.MoveWindowToSpace(index)
+		return e.MoveWindowToSpace(index, cmd.MoveWindowToSpace.Follow)
 	case NameResizeWindow:
 		req, err := ResizeRequestFromArgs(cmd.ResizeWindow)
 		if err != nil {

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -36,7 +36,7 @@ func spaceCommandFor(t *testing.T, name action.Name, arg string) action.Command 
 	case action.NameSpace:
 		cmd, err = action.NewSpaceCommand([]string{arg})
 	case action.NameMoveWindowToSpace:
-		cmd, err = action.NewMoveWindowToSpaceCommand([]string{arg})
+		cmd, err = action.NewMoveWindowToSpaceCommand([]string{arg}, false)
 	case action.NameFocusWindow, action.NameResizeWindow:
 		t.Fatalf("%s takes no space argument", name)
 	default:
@@ -251,13 +251,13 @@ func TestNewSpaceCommands_ParseTheArgumentIntoTheirOwnField(t *testing.T) {
 				)
 			}
 
-			moveCmd, err := action.NewMoveWindowToSpaceCommand([]string{testCase.arg})
+			moveCmd, err := action.NewMoveWindowToSpaceCommand([]string{testCase.arg}, false)
 			if err != nil {
 				t.Fatalf("NewMoveWindowToSpaceCommand(%q) error = %v, want nil", testCase.arg, err)
 			}
 
 			if moveCmd.Name != action.NameMoveWindowToSpace ||
-				moveCmd.MoveWindowToSpace != testCase.want {
+				moveCmd.MoveWindowToSpace.Space != testCase.want {
 				t.Fatalf(
 					"NewMoveWindowToSpaceCommand(%q) = %+v, want %s carrying %+v",
 					testCase.arg,
@@ -290,7 +290,12 @@ func TestNewSpaceCommands_RejectAMalformedArgument(t *testing.T) {
 		build      func([]string) (action.Command, error)
 	}{
 		{actionName: action.NameSpace, build: action.NewSpaceCommand},
-		{actionName: action.NameMoveWindowToSpace, build: action.NewMoveWindowToSpaceCommand},
+		{
+			actionName: action.NameMoveWindowToSpace,
+			build: func(args []string) (action.Command, error) {
+				return action.NewMoveWindowToSpaceCommand(args, false)
+			},
+		},
 	}
 
 	for _, builder := range builders {
@@ -473,7 +478,7 @@ func TestExecuteCommand_ReachesEveryAction(t *testing.T) {
 
 		err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
 			Name:              action.NameMoveWindowToSpace,
-			MoveWindowToSpace: action.SpaceArg{Direction: 1},
+			MoveWindowToSpace: action.MoveWindowToSpaceArgs{Space: action.SpaceArg{Direction: 1}},
 		})
 		if err != nil {
 			t.Fatalf("ExecuteCommand(move_window_to_space) error = %v, want nil", err)
@@ -559,8 +564,10 @@ func TestExecuteCommand_RejectsAPayloadNoConstructorWouldBuild(t *testing.T) {
 		{
 			name: "move_window_to_space naming an index and a direction at once",
 			cmd: action.Command{
-				Name:              action.NameMoveWindowToSpace,
-				MoveWindowToSpace: action.SpaceArg{Index: 2, Direction: -1},
+				Name: action.NameMoveWindowToSpace,
+				MoveWindowToSpace: action.MoveWindowToSpaceArgs{
+					Space: action.SpaceArg{Index: 2, Direction: -1},
+				},
 			},
 		},
 		{

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -95,8 +95,12 @@ func (e *Executor) FocusSpace(index int) error {
 }
 
 // MoveWindowToSpace moves the frontmost window to the space at the given
-// 1-based index.
-func (e *Executor) MoveWindowToSpace(index int) error {
+// 1-based index, and with follow set switches to that space afterwards.
+//
+// The switch is the same one the space action makes, so a window that was
+// moved but could not be followed is reported as such and stays where it was
+// moved to: the move landed, and undoing it would be a second surprise.
+func (e *Executor) MoveWindowToSpace(index int, follow bool) error {
 	err := e.desktop.EnsureAccessible()
 	if err != nil {
 		return err
@@ -117,6 +121,20 @@ func (e *Executor) MoveWindowToSpace(index int) error {
 	err = e.desktop.MoveWindowToSpace(index)
 	if err != nil {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to move window")
+	}
+
+	if follow {
+		err = e.desktop.FocusSpace(index)
+		if err != nil {
+			e.desktop.RefreshWorkspaceTitle()
+
+			return derrors.Wrapf(
+				err,
+				derrors.CodeActionFailed,
+				"window moved, but failed to follow it to space %d",
+				index,
+			)
+		}
 	}
 
 	e.desktop.RefreshWorkspaceTitle()

--- a/internal/action/space_test.go
+++ b/internal/action/space_test.go
@@ -1,6 +1,7 @@
 package action_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/action"
@@ -125,7 +126,7 @@ func TestExecutor_Space_MissionControlRefusesBothActions(t *testing.T) {
 		desktop := desktopWithSpaces(2)
 		desktop.missionControlActive = true
 
-		err := action.NewExecutor(desktop).MoveWindowToSpace(3)
+		err := action.NewExecutor(desktop).MoveWindowToSpace(3, false)
 		if err == nil {
 			t.Fatal("MoveWindowToSpace() error = nil, want an error")
 		}
@@ -145,7 +146,7 @@ func TestExecutor_MoveWindowToSpace_MovesTheWindow(t *testing.T) {
 
 	desktop := desktopWithSpaces(1)
 
-	err := action.NewExecutor(desktop).MoveWindowToSpace(3)
+	err := action.NewExecutor(desktop).MoveWindowToSpace(3, false)
 	if err != nil {
 		t.Fatalf("MoveWindowToSpace() error = %v, want nil", err)
 	}
@@ -220,7 +221,7 @@ func TestExecutor_Space_DoesNotRefreshWorkspaceTitleOnFailure(t *testing.T) {
 			t.Fatal("FocusSpace() error = nil, want an error")
 		}
 
-		err = action.NewExecutor(desktop).MoveWindowToSpace(3)
+		err = action.NewExecutor(desktop).MoveWindowToSpace(3, false)
 		if err == nil {
 			t.Fatal("MoveWindowToSpace() error = nil, want an error")
 		}
@@ -240,11 +241,117 @@ func TestExecutor_Space_DoesNotRefreshWorkspaceTitleOnFailure(t *testing.T) {
 			t.Fatal("FocusSpace() error = nil, want an error")
 		}
 
-		err = action.NewExecutor(desktop).MoveWindowToSpace(3)
+		err = action.NewExecutor(desktop).MoveWindowToSpace(3, false)
 		if err == nil {
 			t.Fatal("MoveWindowToSpace() error = nil, want an error")
 		}
 
 		wantRefreshCalls(t, desktop, 0)
 	})
+}
+
+// TestExecutor_MoveWindowToSpace_FollowSwitchesToTheDestination pins what
+// --follow adds: the window lands on the destination and so does focus,
+// through the same switch the space action makes.
+func TestExecutor_MoveWindowToSpace_FollowSwitchesToTheDestination(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(1)
+
+	err := action.NewExecutor(desktop).MoveWindowToSpace(3, true)
+	if err != nil {
+		t.Fatalf("MoveWindowToSpace(3, follow) error = %v, want nil", err)
+	}
+
+	if desktop.windowSpace != 3 {
+		t.Fatalf("window space = %d, want 3", desktop.windowSpace)
+	}
+
+	if desktop.activeSpace != 3 {
+		t.Fatalf("active space = %d, want 3", desktop.activeSpace)
+	}
+
+	wantRefreshCalls(t, desktop, 1)
+}
+
+// TestExecutor_MoveWindowToSpace_WithoutFollowStaysPut is the behavior every
+// existing hotkey relies on: the window leaves, the current space stays in
+// front.
+func TestExecutor_MoveWindowToSpace_WithoutFollowStaysPut(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(1)
+
+	err := action.NewExecutor(desktop).MoveWindowToSpace(3, false)
+	if err != nil {
+		t.Fatalf("MoveWindowToSpace(3) error = %v, want nil", err)
+	}
+
+	if desktop.activeSpace != 1 {
+		t.Fatalf("active space = %d, want it left on 1", desktop.activeSpace)
+	}
+}
+
+// TestExecutor_MoveWindowToSpace_AFailedFollowReportsTheWindowAsMoved: the
+// move landed before the switch failed, so the error says so and the window
+// is not pulled back, and the systray still learns the window's new space.
+func TestExecutor_MoveWindowToSpace_AFailedFollowReportsTheWindowAsMoved(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(1)
+	desktop.focusSpaceErr = derrors.New(derrors.CodeActionFailed, "swipe failed")
+
+	err := action.NewExecutor(desktop).MoveWindowToSpace(3, true)
+	if err == nil {
+		t.Fatal("MoveWindowToSpace(3, follow) error = nil, want the follow failure")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeActionFailed) {
+		t.Fatalf("error = %v, want an action failure", err)
+	}
+
+	if !strings.Contains(err.Error(), "window moved") {
+		t.Fatalf("error = %q, want it to say the window moved", err.Error())
+	}
+
+	if desktop.windowSpace != 3 {
+		t.Fatalf("window space = %d, want it left on 3", desktop.windowSpace)
+	}
+
+	if desktop.activeSpace != 1 {
+		t.Fatalf("active space = %d, want it left on 1", desktop.activeSpace)
+	}
+
+	wantRefreshCalls(t, desktop, 1)
+}
+
+// TestExecuteCommand_MoveWindowToSpace_CarriesFollowOverTheWire checks the
+// flag survives the trip a decoded payload makes: a command built with follow
+// and run through ExecuteCommand, as the daemon runs it, follows.
+func TestExecuteCommand_MoveWindowToSpace_CarriesFollowOverTheWire(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(1)
+
+	cmd, err := action.NewMoveWindowToSpaceCommand([]string{nextKeyword}, true)
+	if err != nil {
+		t.Fatalf("NewMoveWindowToSpaceCommand(next, follow) error = %v, want nil", err)
+	}
+
+	if !cmd.MoveWindowToSpace.Follow {
+		t.Fatal("the command does not carry follow")
+	}
+
+	err = action.NewExecutor(desktop).ExecuteCommand(cmd)
+	if err != nil {
+		t.Fatalf("ExecuteCommand(move_window_to_space next --follow) error = %v, want nil", err)
+	}
+
+	if desktop.windowSpace != 2 || desktop.activeSpace != 2 {
+		t.Fatalf(
+			"window space = %d, active space = %d, want both 2",
+			desktop.windowSpace,
+			desktop.activeSpace,
+		)
+	}
 }

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -16,7 +16,7 @@ import (
 // older daemon would read wrongly — a renamed or removed field, or a field
 // whose meaning changed. TestRequest_EncodesTheGoldenBytes is what makes such
 // a change visible.
-const ProtocolVersion = 1
+const ProtocolVersion = 2
 
 // Request is the envelope one command travels in over the daemon's Unix
 // socket.

--- a/internal/ipc/wire_test.go
+++ b/internal/ipc/wire_test.go
@@ -63,8 +63,11 @@ func everyPayloadSet() []payloadCase {
 		{
 			name: "move_window_to_space with every field set",
 			cmd: action.Command{
-				Name:              action.NameMoveWindowToSpace,
-				MoveWindowToSpace: action.SpaceArg{Index: 7, Direction: 1},
+				Name: action.NameMoveWindowToSpace,
+				MoveWindowToSpace: action.MoveWindowToSpaceArgs{
+					Space:  action.SpaceArg{Index: 7, Direction: 1},
+					Follow: true,
+				},
 			},
 		},
 		{
@@ -160,7 +163,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewFocusWindowCommand(true, false, false, false, false)
 			},
-			want: `{"version":1,"command":{"name":"focus_window",` +
+			want: `{"version":2,"command":{"name":"focus_window",` +
 				`"focusWindow":{"backward":true,"direction":""}}}`,
 		},
 		{
@@ -168,23 +171,23 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewFocusWindowCommand(false, false, false, false, false)
 			},
-			want: `{"version":1,"command":{"name":"focus_window"}}`,
+			want: `{"version":2,"command":{"name":"focus_window"}}`,
 		},
 		{
 			name: "mimi action space 3",
 			build: func() (action.Command, error) {
 				return action.NewSpaceCommand([]string{"3"})
 			},
-			want: `{"version":1,"command":{"name":"space",` +
+			want: `{"version":2,"command":{"name":"space",` +
 				`"space":{"index":3,"direction":0}}}`,
 		},
 		{
-			name: "mimi action move_window_to_space next",
+			name: "mimi action move_window_to_space next --follow",
 			build: func() (action.Command, error) {
-				return action.NewMoveWindowToSpaceCommand([]string{"next"})
+				return action.NewMoveWindowToSpaceCommand([]string{"next"}, true)
 			},
-			want: `{"version":1,"command":{"name":"move_window_to_space",` +
-				`"moveWindowToSpace":{"index":0,"direction":1}}}`,
+			want: `{"version":2,"command":{"name":"move_window_to_space",` +
+				`"moveWindowToSpace":{"space":{"index":0,"direction":1},"follow":true}}}`,
 		},
 		{
 			name: "mimi action resize_window left-half --width 800 --anchor cc --no-margin",
@@ -198,7 +201,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 					NoMargin:  true,
 				})
 			},
-			want: `{"version":1,"command":{"name":"resize_window",` +
+			want: `{"version":2,"command":{"name":"resize_window",` +
 				`"resizeWindow":{"preset":"left-half",` +
 				`"width":800,"widthSet":true,` +
 				`"height":0,"heightSet":false,` +


### PR DESCRIPTION
## Description

This PR adds a `--follow` flag to `move_window_to_space`, so one hotkey moves the frontmost window to a space and switches to it. Moving and then following is the commonest pairing in a hotkey config, and until now it took two hotkeys and two round trips to the desktop. The switch is the same dock-swipe gesture `mimi action space` makes, so it carries the same timing and the same cross-display cursor warp.

If the move lands but the switch fails, the error says the window moved and the window stays on its new space; pulling it back would be a second surprise. Without the flag, nothing changes: the window leaves and the current space stays in front.

## Commands

| Surface | What it does |
| --- | --- |
| `mimi action move_window_to_space <n\|next\|prev> --follow` | Moves the frontmost window, then switches to the destination space. Default off. |

```bash
# ~/.skhdrc
shift + alt - m : mimi action move_window_to_space next --follow
```

## Potentially disruptive: the daemon wire version is bumped

The flag rides the command over the daemon socket, so the request payload gained a field and the protocol version moved from 1 to 2. That is the mechanism the typed wire was built for, but it has a visible consequence once: a daemon left running across the upgrade rejects this build's requests, the CLI prints a warning naming the mismatch, and runs the action on the direct path. Every action still does what it was asked. The warning stops after `mimi stop && mimi start`, or `mimi services restart` for an installed service.

Existing configs and hotkeys keep working unchanged.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Run on this machine after `just build`, with the terminal window frontmost and no daemon running:

```
$ ./bin/mimi query space
{"index":1,"count":9}
$ ./bin/mimi action move_window_to_space next --follow
$ ./bin/mimi query space
{"index":2,"count":9}
$ ./bin/mimi action move_window_to_space prev --follow
$ ./bin/mimi query space
{"index":1,"count":9}
```

The moved window was still the frontmost window after each follow, so focus stayed on it across the switch without any extra activation.

## Additional Context

The move payload changed from the bare space argument to a struct holding the space argument and the flag, which is what the version bump is for: an older daemon would have decoded the space and silently dropped the follow, doing half of what was asked with no warning. Strict version equality turns that into the documented warn-and-fall-back instead.

Not tested: a follow across displays. This machine has one display, so the cross-display path in the switch (cursor warp, menu bar display) ran only in the form `mimi action space` already exercises.
