### PR TITLE
feat(action,cli): move the frontmost window to another display with move_window_to_display

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,3 +80,9 @@ active space, the frontmost window. A query always runs on the direct path and
 never travels the socket.
 _Avoid_: action (an action changes the desktop), get, info, status (that is the
 daemon's health report)
+
+**Display**:
+One connected screen, identified by its 1-based index counting left to right
+and then top to bottom across every display. A display holds spaces; a space
+belongs to exactly one display.
+_Avoid_: monitor, screen (that is the geometry's word for a display's frames)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | Jump to next / previous space    | `mimi action space next` / `prev`                                         |
 | Move frontmost window to a space | `mimi action move_window_to_space <n\|next\|prev>`                        |
 | Move a window and go with it     | `mimi action move_window_to_space next --follow`                          |
+| Move a window to another display | `mimi action move_window_to_display <n\|next\|prev>`                      |
 | Cycle focus between windows      | `mimi action focus_window`                                                |
 | Cycle focus backward             | `mimi action focus_window --backward`                                     |
 | Focus window to the left         | `mimi action focus_window --left`                                         |

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -18,6 +18,7 @@ func newActionCmd(state *cliState) *cobra.Command {
 Available subcommands:
   Window control:   focus_window, resize_window
   Space control:    space, move_window_to_space
+  Display control:  move_window_to_display
 
 Examples:
   mimi action focus_window
@@ -29,6 +30,7 @@ Examples:
   mimi action move_window_to_space next
   mimi action move_window_to_space prev
   mimi action move_window_to_space next --follow
+  mimi action move_window_to_display next
   mimi action resize_window left-half
   mimi action resize_window --width 800 --height 600 --anchor cc
   mimi action resize_window --width-percent 50 --height-percent 100 --anchor tl`,
@@ -50,6 +52,7 @@ Examples:
 	cmd.AddCommand(buildFocusWindowCommand(state))
 	cmd.AddCommand(buildSpaceCommand(state))
 	cmd.AddCommand(buildMoveWindowToSpaceCommand(state))
+	cmd.AddCommand(buildMoveWindowToDisplayCommand(state))
 	cmd.AddCommand(buildResizeWindowCommand(state))
 
 	return cmd
@@ -186,6 +189,41 @@ Examples:
 		BoolVar(&follow, "follow", false, "Switch to the destination space after moving the window")
 
 	return cmd
+}
+
+func buildMoveWindowToDisplayCommand(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "move_window_to_display <number|next|prev>",
+		Short: "Move the frontmost window to another display by index or cycle next/prev",
+		Long: `Move the frontmost window to a display by its 1-based index, or cycle to the
+next or previous display.
+
+Displays are counted left to right, then top to bottom, across every
+connected display. Index 1 is the leftmost.
+
+The "next" and "prev" keywords cycle through displays with wrapping. A window
+already on the destination stays where it is, which is also what "next" does
+with a single display.
+
+The window keeps the share of the display it had: a window filling the left
+half of one display fills the left half of the other, whatever their sizes.
+The move goes through Accessibility, so it lands on the destination's active
+space with the same animation a drag would.
+
+Examples:
+  mimi action move_window_to_display 2        Move current window to the second display
+  mimi action move_window_to_display next     Move window to the next display (with wrap)
+  mimi action move_window_to_display prev     Move window to the previous display (with wrap)`,
+		Args: validateDisplayArg,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			moveCmd, err := action.NewMoveWindowToDisplayCommand(args)
+			if err != nil {
+				return err
+			}
+
+			return state.runAction(cobraCmd, moveCmd)
+		},
+	}
 }
 
 func buildResizeWindowCommand(state *cliState) *cobra.Command {
@@ -361,4 +399,13 @@ func validateSpaceArg(name action.Name) cobra.PositionalArgs {
 
 		return err
 	}
+}
+
+// validateDisplayArg is validateSpaceArg for move_window_to_display: cobra
+// rejects the argument before RunE runs, with action.ParseDisplayArg as the
+// rule, which is the rule the constructor in RunE calls.
+func validateDisplayArg(_ *cobra.Command, args []string) error {
+	_, err := action.ParseDisplayArg(args)
+
+	return err
 }

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -501,6 +501,7 @@ func malformedActionArgv() []malformedAction {
 			argv: []string{focusWindowCommandName, "--backward", "--up"},
 		},
 		{name: "space zero", argv: []string{string(action.NameSpace), "0"}},
+		{name: "display zero", argv: []string{string(action.NameMoveWindowToDisplay), "0"}},
 		{
 			name: "move_window_to_space nonsense",
 			argv: []string{string(action.NameMoveWindowToSpace), "nxt"},

--- a/cmd/mimi/cmd/interrupt_audit_test.go
+++ b/cmd/mimi/cmd/interrupt_audit_test.go
@@ -66,7 +66,7 @@ func audited(command string, response interruptResponse, why string) auditEntry 
 // no longer reaches the work, is invisible from the command's own code.
 //
 // What the audit found: six commands honor the context, one runs its own
-// signal handler, and fourteen ignore it. Twelve of those fourteen are local
+// signal handler, and fifteen ignore it. Thirteen of those fifteen are local
 // file work, one-shot syscalls or desktop reads, over before an interrupt could
 // be typed. The two that are not are in the action family — `action space` on the direct path
 // pumps the run loop for a stretch proportional to the spaces it crosses, and
@@ -94,6 +94,8 @@ var interruptAudit = []auditEntry{
 			"shorten even if runAction read one"),
 	audited("action move_window_to_space", interruptRunsOn,
 		"as space; the SkyLight move likewise runs to completion"),
+	audited("action move_window_to_display", interruptRunsOn,
+		"as resize_window; the Accessibility frame write runs to completion"),
 	audited("action resize_window", interruptRunsOn,
 		"as focus_window; the Accessibility resize runs to completion"),
 	audited("config dump", interruptRunsOn,

--- a/cmd/mimi/cmd/root_test.go
+++ b/cmd/mimi/cmd/root_test.go
@@ -291,6 +291,7 @@ func TestActionCommand_WithoutASubcommandStillListsItsSubcommands(t *testing.T) 
 		resizeWindowCommandName,
 		string(action.NameSpace),
 		string(action.NameMoveWindowToSpace),
+		string(action.NameMoveWindowToDisplay),
 	} {
 		if !strings.Contains(out, name) {
 			t.Errorf("mimi action never named the %q subcommand, got: %s", name, out)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,8 @@ it is what checks that the real desktop behaves the way the fake pretends to.
 | `focus_window` | Accessibility (`AXUIElement`) |
 | `space` | Synthetic dock-swipe gesture via `CGEvent` |
 | `move_window_to_space` | Private SkyLight (`SLSMoveWindowsToManagedSpace`) |
+| `move_window_to_display` | Accessibility (`AXUIElement`), `NSScreen` for the display list |
+| `resize_window` | Accessibility (`AXUIElement`), `NSScreen` for the visible frame |
 
 CLI actions pump the run loop briefly after posting events so gestures complete before the process exits.
 
@@ -102,8 +104,8 @@ Matches events against configured hooks, applies filters (`app`, `bundle_id`, `t
 cmd/mimi/           CLI entry point and commands
 internal/
   action/           Action dispatch (focus_window, space, move_window_to_space,
-                    resize_window), the queries, the Desktop seam and its
-                    native adapter
+                    move_window_to_display, resize_window), the queries, the
+                    Desktop seam and its native adapter
   native/           All Objective-C + CGO: AX window wrappers, Mission Control
                     space operations, screen queries, and the observer bridge
   observe/          Hook daemon event routing

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -83,6 +83,7 @@ mimi action move_window_to_space 2
 mimi action move_window_to_space next
 mimi action move_window_to_space prev
 mimi action move_window_to_space next --follow
+mimi action move_window_to_display next
 mimi action resize_window left-half
 mimi action resize_window center --width-percent 80 --height-percent 90
 mimi action resize_window --width 1024 --height 768 --anchor cc
@@ -104,6 +105,8 @@ Cycle keyboard focus through all focusable windows on the current space, or move
 
 Focus a Mission Control space by its 1-based index, or cycle to the next/previous space with wrapping. Uses a synthetic dock-swipe gesture (no public macOS API exists for direct space switching).
 
+When the destination space sits on another display, the mouse pointer is warped to the center of that display first so the gesture lands on the right screen, and it stays there afterwards. The same applies to `move_window_to_space --follow`.
+
 ### `mimi action move_window_to_space <number|next|prev>`
 
 Move the frontmost window to a space by its 1-based index, or cycle to the next/previous space with wrapping. Uses private SkyLight APIs; does not require disabling SIP.
@@ -113,6 +116,18 @@ Move the frontmost window to a space by its 1-based index, or cycle to the next/
 | `--follow` | Switch to the destination space once the window is there         |
 
 Without `--follow` the window leaves and the current space stays in front. With it, the switch is the same dock-swipe gesture `mimi action space` makes, so it is subject to the same timing. If the move lands but the switch fails, the error says the window moved and the window stays on its new space.
+
+### `mimi action move_window_to_display <number|next|prev>`
+
+Move the frontmost window to another display by its 1-based index, or cycle to the next/previous display with wrapping. Displays are counted left to right, then top to bottom, across every connected display. Goes through Accessibility, so the window lands on the destination's active space and the display becomes the active one. **Accessibility permission is required.**
+
+The window keeps the share of the display it had: a window filling the left half of one display fills the left half of the other, whatever their sizes or resolutions. A window already on the destination stays where it is, which is also what `next` does with a single display.
+
+```bash
+mimi action move_window_to_display 2
+mimi action move_window_to_display next
+mimi action move_window_to_display prev
+```
 
 ### `mimi action resize_window [preset] [flags]`
 

--- a/internal/action/accessibility_test.go
+++ b/internal/action/accessibility_test.go
@@ -53,6 +53,12 @@ func TestExecutor_DeniedAccessibilityLeavesTheDesktopAlone(t *testing.T) {
 			},
 		},
 		{
+			name: string(action.NameMoveWindowToDisplay),
+			run: func(e *action.Executor) error {
+				return e.ExecuteCommand(displayCommandFor(t, nextKeyword))
+			},
+		},
+		{
 			name: string(action.NameResizeWindow),
 			run: func(e *action.Executor) error {
 				return e.ExecuteCommand(resizeCommandFor(t, action.ResizeWindowArgs{
@@ -87,6 +93,7 @@ func TestExecutor_DeniedAccessibilityLeavesTheDesktopAlone(t *testing.T) {
 			desktop.screenErr = denied
 			desktop.focusSpaceErr = denied
 			desktop.moveErr = denied
+			desktop.displaysErr = denied
 
 			before := desktop.windows[0].frame
 

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -20,6 +20,15 @@ const (
 	NameSpace             Name = "space"
 	NameMoveWindowToSpace Name = "move_window_to_space"
 	NameResizeWindow      Name = "resize_window"
+
+	NameMoveWindowToDisplay Name = "move_window_to_display"
+)
+
+// Nouns the index-argument rule reports in: what a space argument and a
+// display argument each name.
+const (
+	spaceNoun   = "space"
+	displayNoun = "display"
 )
 
 // SpaceArg is the parsed form of the one argument space and
@@ -30,66 +39,107 @@ type SpaceArg struct {
 	Direction int `json:"direction"` // +1 for next, -1 for prev; 0 means absolute index
 }
 
+// DisplayArg is the parsed form of the one argument move_window_to_display
+// takes: either an absolute 1-based Index, counted left to right, or a
+// relative Direction (+1 for next, -1 for prev), never both. It is SpaceArg's
+// shape under another noun, and held to the same rule.
+type DisplayArg struct {
+	Index     int `json:"index"`
+	Direction int `json:"direction"` // +1 for next, -1 for prev; 0 means absolute index
+}
+
+// indexArg is the shape a space argument and a display argument share, which
+// is what lets one rule read and check both.
+type indexArg struct {
+	index     int
+	direction int
+}
+
 // ParseSpaceArg is the only place the written form of a space argument is
 // read — a 1-based number, "next", "prev", or "previous" — so every path that
 // takes one from a user rejects a malformed argument in the same words.
 //
 // It answers "what does this string mean"; validateSpaceArg answers "does this
 // value name a space", which is the question left once the string is gone and
-// a SpaceArg arrives off the socket instead. This runs that check on what it
-// parsed rather than restating it, so the two cannot come to disagree about
+// a SpaceArg arrives off the socket instead. The rule itself is parseIndexArg,
+// shared with the display argument, so the two cannot come to disagree about
 // which values are well-formed.
 //
 // name is the action the argument was given to, and appears in those words;
-// it is the only part of them that differs between the two actions.
+// it is the only part of them that differs between the two space actions.
 func ParseSpaceArg(name Name, args []string) (SpaceArg, error) {
+	arg, err := parseIndexArg(name, spaceNoun, args)
+	if err != nil {
+		return SpaceArg{}, err
+	}
+
+	return SpaceArg{Index: arg.index, Direction: arg.direction}, nil
+}
+
+// ParseDisplayArg is ParseSpaceArg for the display argument: the same
+// spellings, reported against move_window_to_display and the word "display".
+func ParseDisplayArg(args []string) (DisplayArg, error) {
+	arg, err := parseIndexArg(NameMoveWindowToDisplay, displayNoun, args)
+	if err != nil {
+		return DisplayArg{}, err
+	}
+
+	return DisplayArg{Index: arg.index, Direction: arg.direction}, nil
+}
+
+// parseIndexArg reads the one written form both index arguments take, and is
+// the only place that form is read. noun is what the argument names, "space"
+// or "display", and appears in the rejection alongside the action's name.
+func parseIndexArg(name Name, noun string, args []string) (indexArg, error) {
 	if len(args) != 1 {
-		return SpaceArg{}, derrors.Newf(
+		return indexArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
-			"%s requires exactly one argument: a 1-based space number, \"next\", or \"prev\"",
+			"%s requires exactly one argument: a 1-based %s number, \"next\", or \"prev\"",
 			name,
+			noun,
 		)
 	}
 
 	raw := strings.TrimSpace(args[0])
 	if raw == "" {
-		return SpaceArg{}, derrors.Newf(
+		return indexArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
-			"%s argument cannot be empty: give a 1-based space number, \"next\", or \"prev\"",
+			"%s argument cannot be empty: give a 1-based %s number, \"next\", or \"prev\"",
 			name,
+			noun,
 		)
 	}
 
-	arg, err := spaceArgOf(name, raw)
+	arg, err := indexArgOf(name, raw)
 	if err != nil {
-		return SpaceArg{}, err
+		return indexArg{}, err
 	}
 
-	// The value the spelling denotes still has to name a space. It always
+	// The value the spelling denotes still has to name something. It always
 	// does today, so this never fires — which is the point: it is what stops
 	// a new spelling from being added here that the daemon would then reject
 	// on a command the CLI happily built.
-	err = validateSpaceArg(name, arg)
+	err = validateIndexArg(name, noun, arg)
 	if err != nil {
-		return SpaceArg{}, err
+		return indexArg{}, err
 	}
 
 	return arg, nil
 }
 
-// spaceArgOf is the spelling half of ParseSpaceArg: which SpaceArg a written
-// space argument denotes, with raw already trimmed and known non-empty.
-func spaceArgOf(name Name, raw string) (SpaceArg, error) {
+// indexArgOf is the spelling half of parseIndexArg: which value a written
+// argument denotes, with raw already trimmed and known non-empty.
+func indexArgOf(name Name, raw string) (indexArg, error) {
 	switch raw {
 	case "next":
-		return SpaceArg{Direction: 1}, nil
+		return indexArg{direction: 1}, nil
 	case "prev", "previous":
-		return SpaceArg{Direction: -1}, nil
+		return indexArg{direction: -1}, nil
 	}
 
 	index, parseErr := strconv.Atoi(raw)
 	if parseErr != nil || index < 1 {
-		return SpaceArg{}, derrors.Newf(
+		return indexArg{}, derrors.Newf(
 			derrors.CodeInvalidInput,
 			"%s argument must be a positive integer, \"next\", or \"prev\", got %q",
 			name,
@@ -97,20 +147,35 @@ func spaceArgOf(name Name, raw string) (SpaceArg, error) {
 		)
 	}
 
-	return SpaceArg{Index: index}, nil
+	return indexArg{index: index}, nil
 }
 
 // validateSpaceArg rejects a SpaceArg that names no space.
 //
-// It is the typed half of the one space argument rule: ParseSpaceArg decides
+// It is the typed half of the one index argument rule: ParseSpaceArg decides
 // what a string means, and this decides whether the value is one the actions
 // can act on. Both the parser and every space action run it, so a SpaceArg the
 // CLI built and one the daemon decoded are held to the same rule.
 //
 // name is the action the argument was given to, and appears in the rejection.
 func validateSpaceArg(name Name, arg SpaceArg) error {
-	absolute := arg.Direction == 0 && arg.Index >= 1
-	relative := (arg.Direction == 1 || arg.Direction == -1) && arg.Index == 0
+	return validateIndexArg(name, spaceNoun, indexArg{index: arg.Index, direction: arg.Direction})
+}
+
+// validateDisplayArg is validateSpaceArg for the display argument.
+func validateDisplayArg(arg DisplayArg) error {
+	return validateIndexArg(
+		NameMoveWindowToDisplay,
+		displayNoun,
+		indexArg{index: arg.Index, direction: arg.Direction},
+	)
+}
+
+// validateIndexArg rejects a value that names nothing: neither an absolute
+// index nor a single step in one direction.
+func validateIndexArg(name Name, noun string, arg indexArg) error {
+	absolute := arg.direction == 0 && arg.index >= 1
+	relative := (arg.direction == 1 || arg.direction == -1) && arg.index == 0
 
 	if absolute || relative {
 		return nil
@@ -118,8 +183,10 @@ func validateSpaceArg(name Name, arg SpaceArg) error {
 
 	return derrors.Newf(
 		derrors.CodeInvalidInput,
-		"%s must name exactly one space: a 1-based space number, \"next\", or \"prev\"",
+		"%s must name exactly one %s: a 1-based %s number, \"next\", or \"prev\"",
 		name,
+		noun,
+		noun,
 	)
 }
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -9,8 +9,8 @@ import (
 // field matching Name is read; the others sit at their zero value.
 //
 // Build one through the constructor its action carries —
-// NewFocusWindowCommand, NewSpaceCommand, NewMoveWindowToSpaceCommand or
-// NewResizeWindowCommand. Each validates as it builds, so a command's
+// NewFocusWindowCommand, NewSpaceCommand, NewMoveWindowToSpaceCommand,
+// NewMoveWindowToDisplayCommand or NewResizeWindowCommand. Each validates as it builds, so a command's
 // arguments are checked once, in one implementation, at the moment the command
 // comes into existence: the direct path and the daemon path then reject the
 // same argument in the same words, and neither reaches a socket to do it.
@@ -31,10 +31,11 @@ import (
 type Command struct {
 	Name Name `json:"name"`
 
-	FocusWindow       FocusWindowArgs       `json:"focusWindow,omitzero"`
-	Space             SpaceArg              `json:"space,omitzero"`
-	MoveWindowToSpace MoveWindowToSpaceArgs `json:"moveWindowToSpace,omitzero"`
-	ResizeWindow      ResizeWindowArgs      `json:"resizeWindow,omitzero"`
+	FocusWindow         FocusWindowArgs       `json:"focusWindow,omitzero"`
+	Space               SpaceArg              `json:"space,omitzero"`
+	MoveWindowToSpace   MoveWindowToSpaceArgs `json:"moveWindowToSpace,omitzero"`
+	MoveWindowToDisplay DisplayArg            `json:"moveWindowToDisplay,omitzero"`
+	ResizeWindow        ResizeWindowArgs      `json:"resizeWindow,omitzero"`
 }
 
 // MoveWindowToSpaceArgs is move_window_to_space's typed payload: the space the
@@ -102,6 +103,18 @@ func NewMoveWindowToSpaceCommand(args []string, follow bool) (Command, error) {
 		Name:              NameMoveWindowToSpace,
 		MoveWindowToSpace: MoveWindowToSpaceArgs{Space: spaceArg, Follow: follow},
 	}, nil
+}
+
+// NewMoveWindowToDisplayCommand builds move_window_to_display's command from
+// the one positional argument the action takes. The rule is ParseDisplayArg's,
+// called rather than restated.
+func NewMoveWindowToDisplayCommand(args []string) (Command, error) {
+	displayArg, err := ParseDisplayArg(args)
+	if err != nil {
+		return Command{}, err
+	}
+
+	return Command{Name: NameMoveWindowToDisplay, MoveWindowToDisplay: displayArg}, nil
 }
 
 // NewResizeWindowCommand builds resize_window's command from the CLI's raw
@@ -418,6 +431,8 @@ func (e *Executor) ExecuteCommand(cmd Command) error {
 		}
 
 		return e.MoveWindowToSpace(index, cmd.MoveWindowToSpace.Follow)
+	case NameMoveWindowToDisplay:
+		return e.MoveWindowToDisplay(cmd.MoveWindowToDisplay)
 	case NameResizeWindow:
 		req, err := ResizeRequestFromArgs(cmd.ResizeWindow)
 		if err != nil {
@@ -428,7 +443,7 @@ func (e *Executor) ExecuteCommand(cmd Command) error {
 	default:
 		return derrors.Newf(
 			derrors.CodeInvalidInput,
-			"unknown action %q (supported: focus_window, space, move_window_to_space, resize_window)",
+			"unknown action %q (supported: focus_window, space, move_window_to_space, move_window_to_display, resize_window)",
 			cmd.Name,
 		)
 	}

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -37,7 +37,7 @@ func spaceCommandFor(t *testing.T, name action.Name, arg string) action.Command 
 		cmd, err = action.NewSpaceCommand([]string{arg})
 	case action.NameMoveWindowToSpace:
 		cmd, err = action.NewMoveWindowToSpaceCommand([]string{arg}, false)
-	case action.NameFocusWindow, action.NameResizeWindow:
+	case action.NameFocusWindow, action.NameResizeWindow, action.NameMoveWindowToDisplay:
 		t.Fatalf("%s takes no space argument", name)
 	default:
 		t.Fatalf("unknown action %q", name)
@@ -491,6 +491,26 @@ func TestExecuteCommand_ReachesEveryAction(t *testing.T) {
 		wantRefreshCalls(t, desktop, 1)
 	})
 
+	t.Run("move_window_to_display", func(t *testing.T) {
+		t.Parallel()
+
+		desktop := desktopWithDisplays()
+
+		err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
+			Name:                action.NameMoveWindowToDisplay,
+			MoveWindowToDisplay: action.DisplayArg{Direction: 1},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteCommand(move_window_to_display) error = %v, want nil", err)
+		}
+
+		if desktop.activatedDisplay != rightDisplayID {
+			t.Fatalf("activated display = %d, want %d", desktop.activatedDisplay, rightDisplayID)
+		}
+
+		wantRefreshCalls(t, desktop, 1)
+	})
+
 	t.Run("resize_window", func(t *testing.T) {
 		t.Parallel()
 
@@ -568,6 +588,17 @@ func TestExecuteCommand_RejectsAPayloadNoConstructorWouldBuild(t *testing.T) {
 				MoveWindowToSpace: action.MoveWindowToSpaceArgs{
 					Space: action.SpaceArg{Index: 2, Direction: -1},
 				},
+			},
+		},
+		{
+			name: "move_window_to_display naming no display at all",
+			cmd:  action.Command{Name: action.NameMoveWindowToDisplay},
+		},
+		{
+			name: "move_window_to_display naming an index and a direction at once",
+			cmd: action.Command{
+				Name:                action.NameMoveWindowToDisplay,
+				MoveWindowToDisplay: action.DisplayArg{Index: 1, Direction: 1},
 			},
 		},
 		{

--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -20,6 +20,18 @@ type Window struct {
 	PID int
 }
 
+// Display is one connected display as the actions see it: an identifier to
+// hand back to the desktop, and its frames in screen coordinates.
+type Display struct {
+	// ID names the display in later calls to the desktop it came from.
+	ID uint32
+	// Frame is the whole display, in screen (y-up) coordinates.
+	Frame geometry.Rect
+	// Visible is the frame less the menu bar and the Dock, in the same
+	// coordinates: the area a window is placed within.
+	Visible geometry.Rect
+}
+
 // Desktop is everything the actions need from macOS: the permission to drive
 // it, the windows on it, the screens under them, and the Mission Control
 // spaces beside it.
@@ -61,6 +73,14 @@ type Desktop interface {
 	// geometry resizes against. It stands on several reads, and names the one
 	// that failed in its error, so callers pass that error on unwrapped.
 	ScreenAt(window geometry.Rect) (geometry.Screen, error)
+
+	// Displays lists every connected display, in no particular order; the
+	// actions order them themselves.
+	Displays() ([]Display, error)
+
+	// ActivateDisplay makes a display the active one for the menu bar and
+	// event routing, which is what a window landing on it expects.
+	ActivateDisplay(id uint32)
 
 	// MissionControlActive reports whether Mission Control is open, which is
 	// the state the space actions refuse to run in.

--- a/internal/action/display.go
+++ b/internal/action/display.go
@@ -1,0 +1,142 @@
+package action
+
+import (
+	"slices"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// MoveWindowToDisplay moves the frontmost window to the display target names,
+// keeping the share of the visible frame it had, so a window tiled to the
+// left half of one display is tiled to the left half of the other.
+//
+// Displays are counted left to right, then top to bottom, across every
+// connected one. A window already on the destination stays where it is, which
+// is also what "next" does on a machine with one display.
+//
+// The payload is checked first, as every branch of ExecuteCommand checks its
+// own: on the direct path the constructor already did, on the daemon path
+// this is the first thing that has looked at it.
+func (e *Executor) MoveWindowToDisplay(target DisplayArg) error {
+	err := validateDisplayArg(target)
+	if err != nil {
+		return err
+	}
+
+	err = e.desktop.EnsureAccessible()
+	if err != nil {
+		return err
+	}
+
+	win, err := e.desktop.FrontmostWindow()
+	if err != nil {
+		return err
+	}
+
+	current, err := e.desktop.WindowFrame(win.ID)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get window frame")
+	}
+
+	// ScreenAt says which of the reads behind it failed, so this one passes
+	// the error along rather than wrapping that detail out of sight. Only the
+	// primary height is read from it here: the display list below is what
+	// says where the window is.
+	screen, err := e.desktop.ScreenAt(current)
+	if err != nil {
+		return err
+	}
+
+	displays, err := e.desktop.Displays()
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to enumerate displays")
+	}
+
+	if len(displays) == 0 {
+		return derrors.New(derrors.CodeActionFailed, "no displays found")
+	}
+
+	orderDisplays(displays)
+
+	frames := make([]geometry.Rect, len(displays))
+	for index, display := range displays {
+		frames[index] = display.Frame
+	}
+
+	fromIndex, found := geometry.ScreenContaining(current, screen.PrimaryHeight, frames)
+	if !found {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"could not tell which display the frontmost window is on",
+		)
+	}
+
+	toIndex, err := resolveDisplayArg(target, fromIndex, len(displays))
+	if err != nil {
+		return err
+	}
+
+	if toIndex == fromIndex {
+		return nil
+	}
+
+	frame := geometry.MoveToScreen(
+		current,
+		screen.PrimaryHeight,
+		displays[fromIndex].Visible,
+		displays[toIndex].Visible,
+	)
+
+	err = e.desktop.SetWindowFrame(win.ID, frame)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to move window")
+	}
+
+	e.desktop.ActivateDisplay(displays[toIndex].ID)
+	e.desktop.RefreshWorkspaceTitle()
+
+	return nil
+}
+
+// orderDisplays sorts displays the way the display argument counts them: left
+// to right by where each starts, and for two starting at the same x, top to
+// bottom. Screen coordinates are y-up, so the higher y comes first.
+func orderDisplays(displays []Display) {
+	slices.SortStableFunc(displays, func(first, second Display) int {
+		switch {
+		case first.Frame.X < second.Frame.X:
+			return -1
+		case first.Frame.X > second.Frame.X:
+			return 1
+		case first.Frame.Y > second.Frame.Y:
+			return -1
+		case first.Frame.Y < second.Frame.Y:
+			return 1
+		default:
+			return 0
+		}
+	})
+}
+
+// resolveDisplayArg turns a DisplayArg into the 0-based position, among count
+// ordered displays, of the display it names. from is the 0-based position of
+// the display the window is on, which "next" and "prev" step from, wrapping at
+// both ends. An absolute number outside the range is invalid input, as an
+// absolute space number is.
+func resolveDisplayArg(target DisplayArg, from, count int) (int, error) {
+	if target.Direction != 0 {
+		return (from + target.Direction + count) % count, nil
+	}
+
+	if target.Index < 1 || target.Index > count {
+		return 0, derrors.Newf(
+			derrors.CodeInvalidInput,
+			"display number %d is out of range; valid range is 1..%d",
+			target.Index,
+			count,
+		)
+	}
+
+	return target.Index - 1, nil
+}

--- a/internal/action/display_test.go
+++ b/internal/action/display_test.go
@@ -1,0 +1,324 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// Two displays side by side: the primary on the left with a 25-point menu
+// bar, and a larger one to its right whose bottom edge lines up with the
+// primary's. The window fills the left half of the primary's visible frame.
+const (
+	primaryHeight  = 1080
+	leftDisplayID  = 11
+	rightDisplayID = 22
+)
+
+var (
+	leftDisplay = action.Display{
+		ID:      leftDisplayID,
+		Frame:   geometry.Rect{X: 0, Y: 0, W: 1920, H: 1080},
+		Visible: geometry.Rect{X: 0, Y: 0, W: 1920, H: 1055},
+	}
+	rightDisplay = action.Display{
+		ID:      rightDisplayID,
+		Frame:   geometry.Rect{X: 1920, Y: 0, W: 2560, H: 1440},
+		Visible: geometry.Rect{X: 1920, Y: 0, W: 2560, H: 1415},
+	}
+	leftHalfOfLeft = geometry.Rect{X: 0, Y: 25, W: 960, H: 1055}
+	// leftHalfOfRight is where leftHalfOfLeft lands on the right display:
+	// the same share of a taller, wider visible frame, whose top in window
+	// coordinates sits above the primary's.
+	leftHalfOfRight = geometry.Rect{X: 1920, Y: -335, W: 1280, H: 1415}
+)
+
+// desktopWithDisplays builds a desktop of the two displays above, listed
+// right first so the ordering the action imposes is what a test sees, with
+// one window on the left display.
+func desktopWithDisplays() *fakeDesktop {
+	desktop := desktopWithWindows(1, 0)
+	desktop.windows[0].frame = leftHalfOfLeft
+	desktop.screen = geometry.Screen{Visible: leftDisplay.Visible, PrimaryHeight: primaryHeight}
+	desktop.displays = []action.Display{rightDisplay, leftDisplay}
+
+	return desktop
+}
+
+func displayCommandFor(t *testing.T, arg string) action.Command {
+	t.Helper()
+
+	cmd, err := action.NewMoveWindowToDisplayCommand([]string{arg})
+	if err != nil {
+		t.Fatalf("building move_window_to_display %q: %v", arg, err)
+	}
+
+	return cmd
+}
+
+func TestExecutor_MoveWindowToDisplay_KeepsTheWindowsShareOfTheDisplay(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		arg  string
+	}{
+		{name: "next", arg: nextKeyword},
+		{name: "prev wraps", arg: prevKeyword},
+		{name: "by number", arg: "2"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := desktopWithDisplays()
+
+			err := action.NewExecutor(desktop).ExecuteCommand(displayCommandFor(t, testCase.arg))
+			if err != nil {
+				t.Fatalf(
+					"ExecuteCommand(move_window_to_display %s) error = %v, want nil",
+					testCase.arg,
+					err,
+				)
+			}
+
+			if got := desktop.windows[0].frame; got != leftHalfOfRight {
+				t.Fatalf("window frame = %+v, want %+v", got, leftHalfOfRight)
+			}
+
+			if desktop.activatedDisplay != rightDisplayID {
+				t.Fatalf(
+					"activated display = %d, want %d",
+					desktop.activatedDisplay,
+					rightDisplayID,
+				)
+			}
+
+			wantRefreshCalls(t, desktop, 1)
+		})
+	}
+}
+
+// TestExecutor_MoveWindowToDisplay_StaysPutOnTheDestination covers a window
+// already where it was asked to go: by number, and by "next" on a machine
+// with one display. Nothing is written and nothing is activated.
+func TestExecutor_MoveWindowToDisplay_StaysPutOnTheDestination(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		arg     string
+		desktop func() *fakeDesktop
+	}{
+		{name: "by number", arg: "1", desktop: desktopWithDisplays},
+		{
+			name: "next with one display",
+			arg:  nextKeyword,
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithDisplays()
+				desktop.displays = []action.Display{leftDisplay}
+
+				return desktop
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := testCase.desktop()
+			desktop.windows[0].setFrameErr = derrors.New(
+				derrors.CodeActionFailed,
+				"nothing should be written",
+			)
+
+			err := action.NewExecutor(desktop).ExecuteCommand(displayCommandFor(t, testCase.arg))
+			if err != nil {
+				t.Fatalf(
+					"ExecuteCommand(move_window_to_display %s) error = %v, want nil",
+					testCase.arg,
+					err,
+				)
+			}
+
+			if desktop.activatedDisplay != 0 {
+				t.Fatalf("activated display = %d, want none", desktop.activatedDisplay)
+			}
+
+			wantRefreshCalls(t, desktop, 0)
+		})
+	}
+}
+
+func TestExecutor_MoveWindowToDisplay_OutOfRangeNumberIsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithDisplays()
+
+	err := action.NewExecutor(desktop).ExecuteCommand(displayCommandFor(t, "3"))
+	if err == nil {
+		t.Fatal("ExecuteCommand(move_window_to_display 3) error = nil, want an error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("error = %v, want invalid input", err)
+	}
+
+	if got := desktop.windows[0].frame; got != leftHalfOfLeft {
+		t.Fatalf("window frame = %+v, want it left at %+v", got, leftHalfOfLeft)
+	}
+}
+
+func TestExecutor_MoveWindowToDisplay_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		desktop  func() *fakeDesktop
+		wantCode derrors.Code
+	}{
+		{
+			name: "displays cannot be enumerated",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithDisplays()
+				desktop.displaysErr = derrors.New(derrors.CodeAccessibilityFailed, "no screens")
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+		{
+			name: "no displays at all",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithDisplays()
+				desktop.displays = nil
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+		{
+			name: "window on no display",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithDisplays()
+				desktop.windows[0].frame = geometry.Rect{X: -5000, Y: -5000, W: 100, H: 100}
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+		{
+			name: "frame cannot be written",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithDisplays()
+				desktop.windows[0].setFrameErr = derrors.New(
+					derrors.CodeAccessibilityFailed,
+					"refused",
+				)
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := testCase.desktop()
+
+			err := action.NewExecutor(desktop).ExecuteCommand(displayCommandFor(t, nextKeyword))
+			if err == nil {
+				t.Fatal("ExecuteCommand(move_window_to_display next) error = nil, want an error")
+			}
+
+			if !derrors.IsCode(err, testCase.wantCode) {
+				t.Fatalf("error code = %q, want %q", derrors.GetCode(err), testCase.wantCode)
+			}
+
+			if desktop.activatedDisplay != 0 {
+				t.Fatalf(
+					"activated display = %d, want none after a failure",
+					desktop.activatedDisplay,
+				)
+			}
+
+			wantRefreshCalls(t, desktop, 0)
+		})
+	}
+}
+
+// TestExecutor_MoveWindowToDisplay_CountsDisplaysLeftToRight pins the order
+// the display argument counts in, whatever order the desktop lists them:
+// leftmost first, and of two starting at the same x, the higher one first.
+func TestExecutor_MoveWindowToDisplay_CountsDisplaysLeftToRight(t *testing.T) {
+	t.Parallel()
+
+	above := action.Display{
+		ID:      33,
+		Frame:   geometry.Rect{X: 0, Y: 1080, W: 1920, H: 1080},
+		Visible: geometry.Rect{X: 0, Y: 1080, W: 1920, H: 1055},
+	}
+
+	desktop := desktopWithDisplays()
+	desktop.displays = []action.Display{rightDisplay, leftDisplay, above}
+
+	// The window is on the left display, which counts second: the one above
+	// it starts at the same x and sits higher. "3" is therefore the right one.
+	err := action.NewExecutor(desktop).ExecuteCommand(displayCommandFor(t, "3"))
+	if err != nil {
+		t.Fatalf("ExecuteCommand(move_window_to_display 3) error = %v, want nil", err)
+	}
+
+	if desktop.activatedDisplay != rightDisplayID {
+		t.Fatalf("activated display = %d, want %d", desktop.activatedDisplay, rightDisplayID)
+	}
+
+	desktop = desktopWithDisplays()
+	desktop.displays = []action.Display{rightDisplay, leftDisplay, above}
+
+	err = action.NewExecutor(desktop).ExecuteCommand(displayCommandFor(t, prevKeyword))
+	if err != nil {
+		t.Fatalf("ExecuteCommand(move_window_to_display prev) error = %v, want nil", err)
+	}
+
+	if desktop.activatedDisplay != above.ID {
+		t.Fatalf(
+			"activated display = %d, want %d (the one above)",
+			desktop.activatedDisplay,
+			above.ID,
+		)
+	}
+}
+
+func TestParseDisplayArg_ReportsTheDisplayNoun(t *testing.T) {
+	t.Parallel()
+
+	_, err := action.ParseDisplayArg([]string{"0"})
+	if err == nil {
+		t.Fatal("ParseDisplayArg(0) error = nil, want an error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("error = %v, want invalid input", err)
+	}
+
+	_, err = action.ParseDisplayArg(nil)
+	if err == nil || !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("ParseDisplayArg(nil) error = %v, want invalid input naming a display number", err)
+	}
+
+	got, err := action.ParseDisplayArg([]string{" next "})
+	if err != nil {
+		t.Fatalf("ParseDisplayArg(next) error = %v, want nil", err)
+	}
+
+	if got != (action.DisplayArg{Direction: 1}) {
+		t.Fatalf("ParseDisplayArg(next) = %+v, want a step forward", got)
+	}
+}

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -1,6 +1,7 @@
 package action_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/action"
@@ -36,6 +37,11 @@ type fakeDesktop struct {
 	screenErr error
 
 	missionControlActive bool
+
+	displays    []action.Display
+	displaysErr error
+	// activatedDisplay is the display last made active, or 0 for none.
+	activatedDisplay uint32
 
 	spaceCount     int
 	activeSpace    int // 1-based
@@ -131,6 +137,18 @@ func (d *fakeDesktop) ScreenAt(_ geometry.Rect) (geometry.Screen, error) {
 	}
 
 	return d.screen, nil
+}
+
+func (d *fakeDesktop) Displays() ([]action.Display, error) {
+	if d.displaysErr != nil {
+		return nil, d.displaysErr
+	}
+
+	return slices.Clone(d.displays), nil
+}
+
+func (d *fakeDesktop) ActivateDisplay(id uint32) {
+	d.activatedDisplay = id
 }
 
 func (d *fakeDesktop) MissionControlActive() bool {

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -153,6 +153,36 @@ func (d *nativeDesktop) ScreenAt(window geometry.Rect) (geometry.Screen, error) 
 	}, nil
 }
 
+// Displays lists the connected displays in the order macOS reports them.
+func (d *nativeDesktop) Displays() ([]Display, error) {
+	found, err := native.Displays()
+	if err != nil {
+		return nil, err
+	}
+
+	displays := make([]Display, len(found))
+	for index, display := range found {
+		displays[index] = Display{
+			ID:      display.ID,
+			Frame:   rectOf(display.Frame),
+			Visible: rectOf(display.Visible),
+		}
+	}
+
+	return displays, nil
+}
+
+// ActivateDisplay makes the display the active one for the menu bar and
+// event routing.
+func (d *nativeDesktop) ActivateDisplay(id uint32) {
+	native.ActivateDisplay(id)
+}
+
+// rectOf is a native frame as the geometry holds it.
+func rectOf(frame native.Frame) geometry.Rect {
+	return geometry.Rect{X: frame.X, Y: frame.Y, W: frame.W, H: frame.H}
+}
+
 // MissionControlActive reports whether Mission Control is open.
 func (d *nativeDesktop) MissionControlActive() bool {
 	return native.MissionControlActive()

--- a/internal/geometry/display.go
+++ b/internal/geometry/display.go
@@ -1,0 +1,51 @@
+package geometry
+
+// windowBounds is a visible frame in window coordinates. The top edge is the
+// one line that converts between the two systems:
+//
+//	y-down top = primaryHeight - visibleFrameY - visibleFrameHeight
+func windowBounds(visible Rect, primaryHeight float64) Rect {
+	return Rect{
+		X: visible.X,
+		Y: primaryHeight - visible.Y - visible.H,
+		W: visible.W,
+		H: visible.H,
+	}
+}
+
+// MoveToScreen returns the frame a window at cur takes when it moves from the
+// display whose visible frame is from to the one whose visible frame is to,
+// keeping the share of the visible frame it had: a window filling the left
+// half of one display fills the left half of the other, whatever their sizes.
+//
+// cur and the returned frame are in window coordinates; from and to are in
+// screen coordinates, as macOS reports them.
+func MoveToScreen(cur Rect, primaryHeight float64, from, to Rect) Rect {
+	src := windowBounds(from, primaryHeight)
+	dst := windowBounds(to, primaryHeight)
+
+	return Rect{
+		X: dst.X + (cur.X-src.X)/src.W*dst.W,
+		Y: dst.Y + (cur.Y-src.Y)/src.H*dst.H,
+		W: cur.W / src.W * dst.W,
+		H: cur.H / src.H * dst.H,
+	}
+}
+
+// ScreenContaining reports which of the given full frames holds the center of
+// cur, and false when none does. Frames are in screen coordinates and cur in
+// window coordinates; the center is what decides, so a window straddling two
+// displays belongs to the one showing more of it.
+func ScreenContaining(cur Rect, primaryHeight float64, frames []Rect) (int, bool) {
+	centerX, centerY := cur.CenterX(), cur.CenterY()
+
+	for index, frame := range frames {
+		bounds := windowBounds(frame, primaryHeight)
+		if centerX >= bounds.X && centerX < bounds.Right() &&
+			centerY >= bounds.Y && centerY < bounds.Bottom() {
+			return index, true
+		}
+	}
+
+	return 0, false
+}

--- a/internal/geometry/display_test.go
+++ b/internal/geometry/display_test.go
@@ -1,0 +1,118 @@
+package geometry_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+const displayPrimaryHeight = 1080.0
+
+var (
+	// leftVisible is a 1920x1080 primary display less a 25-point menu bar.
+	leftVisible = geometry.Rect{X: 0, Y: 0, W: 1920, H: 1055}
+	// rightVisible is a 2560x1440 display to its right, bottoms aligned, less
+	// the same menu bar.
+	rightVisible = geometry.Rect{X: 1920, Y: 0, W: 2560, H: 1415}
+)
+
+func TestMoveToScreen_KeepsTheShareOfTheVisibleFrame(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cur  geometry.Rect
+		want geometry.Rect
+	}{
+		{
+			name: "left half stays a left half",
+			cur:  geometry.Rect{X: 0, Y: 25, W: 960, H: 1055},
+			want: geometry.Rect{X: 1920, Y: -335, W: 1280, H: 1415},
+		},
+		{
+			name: "a centered quarter stays centered",
+			cur:  geometry.Rect{X: 480, Y: 25 + 1055/4.0, W: 960, H: 1055 / 2.0},
+			want: geometry.Rect{X: 1920 + 640, Y: -335 + 1415/4.0, W: 1280, H: 1415 / 2.0},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := geometry.MoveToScreen(
+				testCase.cur,
+				displayPrimaryHeight,
+				leftVisible,
+				rightVisible,
+			)
+			if got != testCase.want {
+				t.Fatalf("MoveToScreen() = %+v, want %+v", got, testCase.want)
+			}
+
+			// The trip back lands where it started.
+			back := geometry.MoveToScreen(got, displayPrimaryHeight, rightVisible, leftVisible)
+			if back != testCase.cur {
+				t.Fatalf("MoveToScreen() back = %+v, want %+v", back, testCase.cur)
+			}
+		})
+	}
+}
+
+func TestScreenContaining_DecidesByTheWindowsCenter(t *testing.T) {
+	t.Parallel()
+
+	frames := []geometry.Rect{
+		{X: 0, Y: 0, W: 1920, H: 1080},
+		{X: 1920, Y: 0, W: 2560, H: 1440},
+	}
+
+	cases := []struct {
+		name      string
+		cur       geometry.Rect
+		wantIndex int
+		wantFound bool
+	}{
+		{
+			name:      "on the first",
+			cur:       geometry.Rect{X: 100, Y: 100, W: 500, H: 500},
+			wantIndex: 0,
+			wantFound: true,
+		},
+		{
+			name:      "on the second",
+			cur:       geometry.Rect{X: 2000, Y: -300, W: 500, H: 500},
+			wantIndex: 1,
+			wantFound: true,
+		},
+		{
+			name:      "straddling, mostly on the second",
+			cur:       geometry.Rect{X: 1700, Y: 100, W: 600, H: 500},
+			wantIndex: 1,
+			wantFound: true,
+		},
+		{
+			name:      "off every display",
+			cur:       geometry.Rect{X: -900, Y: 100, W: 500, H: 500},
+			wantFound: false,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotIndex, gotFound := geometry.ScreenContaining(
+				testCase.cur,
+				displayPrimaryHeight,
+				frames,
+			)
+			if gotFound != testCase.wantFound || (gotFound && gotIndex != testCase.wantIndex) {
+				t.Fatalf(
+					"ScreenContaining() = %d, %v, want %d, %v",
+					gotIndex, gotFound, testCase.wantIndex, testCase.wantFound,
+				)
+			}
+		})
+	}
+}

--- a/internal/geometry/resize.go
+++ b/internal/geometry/resize.go
@@ -124,18 +124,9 @@ func Resize(cur Rect, scr Screen, req Request) Rect {
 	width := req.Width.resolve(cur.W, scr.Visible.W)
 	height := req.Height.resolve(cur.H, scr.Visible.H)
 
-	// The visible frame in window coordinates. Its top edge is the one line
-	// that converts between the two systems:
-	//
-	//	y-down top = primaryHeight - visibleFrameY - visibleFrameHeight
-	//
-	// Everything below this point is in window coordinates.
-	bounds := Rect{
-		X: scr.Visible.X,
-		Y: scr.PrimaryHeight - scr.Visible.Y - scr.Visible.H,
-		W: scr.Visible.W,
-		H: scr.Visible.H,
-	}
+	// The visible frame in window coordinates. Everything below this point is
+	// in window coordinates.
+	bounds := windowBounds(scr.Visible, scr.PrimaryHeight)
 
 	anchor := Center
 	if req.Anchor != nil {

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -16,7 +16,7 @@ import (
 // older daemon would read wrongly — a renamed or removed field, or a field
 // whose meaning changed. TestRequest_EncodesTheGoldenBytes is what makes such
 // a change visible.
-const ProtocolVersion = 2
+const ProtocolVersion = 3
 
 // Request is the envelope one command travels in over the daemon's Unix
 // socket.

--- a/internal/ipc/wire_test.go
+++ b/internal/ipc/wire_test.go
@@ -71,6 +71,17 @@ func everyPayloadSet() []payloadCase {
 			},
 		},
 		{
+			name: "move_window_to_display with nothing set",
+			cmd:  action.Command{Name: action.NameMoveWindowToDisplay},
+		},
+		{
+			name: "move_window_to_display with every field set",
+			cmd: action.Command{
+				Name:                action.NameMoveWindowToDisplay,
+				MoveWindowToDisplay: action.DisplayArg{Index: 2, Direction: -1},
+			},
+		},
+		{
 			name: "resize_window with nothing set",
 			cmd:  action.Command{Name: action.NameResizeWindow},
 		},
@@ -163,7 +174,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewFocusWindowCommand(true, false, false, false, false)
 			},
-			want: `{"version":2,"command":{"name":"focus_window",` +
+			want: `{"version":3,"command":{"name":"focus_window",` +
 				`"focusWindow":{"backward":true,"direction":""}}}`,
 		},
 		{
@@ -171,14 +182,14 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewFocusWindowCommand(false, false, false, false, false)
 			},
-			want: `{"version":2,"command":{"name":"focus_window"}}`,
+			want: `{"version":3,"command":{"name":"focus_window"}}`,
 		},
 		{
 			name: "mimi action space 3",
 			build: func() (action.Command, error) {
 				return action.NewSpaceCommand([]string{"3"})
 			},
-			want: `{"version":2,"command":{"name":"space",` +
+			want: `{"version":3,"command":{"name":"space",` +
 				`"space":{"index":3,"direction":0}}}`,
 		},
 		{
@@ -186,8 +197,16 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewMoveWindowToSpaceCommand([]string{"next"}, true)
 			},
-			want: `{"version":2,"command":{"name":"move_window_to_space",` +
+			want: `{"version":3,"command":{"name":"move_window_to_space",` +
 				`"moveWindowToSpace":{"space":{"index":0,"direction":1},"follow":true}}}`,
+		},
+		{
+			name: "mimi action move_window_to_display prev",
+			build: func() (action.Command, error) {
+				return action.NewMoveWindowToDisplayCommand([]string{"prev"})
+			},
+			want: `{"version":3,"command":{"name":"move_window_to_display",` +
+				`"moveWindowToDisplay":{"index":0,"direction":-1}}}`,
 		},
 		{
 			name: "mimi action resize_window left-half --width 800 --anchor cc --no-margin",
@@ -201,7 +220,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 					NoMargin:  true,
 				})
 			},
-			want: `{"version":2,"command":{"name":"resize_window",` +
+			want: `{"version":3,"command":{"name":"resize_window",` +
 				`"resizeWindow":{"preset":"left-half",` +
 				`"width":800,"widthSet":true,` +
 				`"height":0,"heightSet":false,` +

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -22,9 +22,16 @@ int MimiGetWindowPID(void *window);
 
 #pragma mark - Screen Functions
 
+/// Doubles per display in MimiCopyScreenFrames' result.
+#define MIMI_SCREEN_DOUBLES 9
+
 bool MimiIsMissionControlActive(void);
 double *MimiGetScreenFrameForPoint(double x, double y);
 double *MimiGetScreenVisibleFrameForPoint(double x, double y);
+/// Copy every connected display as nine doubles each: the CGDirectDisplayID,
+/// then the frame and the visible frame as x, y, w, h in NSScreen coordinates.
+/// Sets *count; the caller frees the result. NULL when there are none.
+double *MimiCopyScreenFrames(int *count);
 
 #pragma mark - Window Frame Functions
 

--- a/internal/native/screen.m
+++ b/internal/native/screen.m
@@ -136,6 +136,42 @@ double *MimiGetScreenVisibleFrameForPoint(double x, double y) {
 	}
 }
 
+double *MimiCopyScreenFrames(int *count) {
+	@autoreleasepool {
+		NSArray<NSScreen *> *screens = [NSScreen screens];
+		int screenCount = (int)screens.count;
+		*count = 0;
+		if (screenCount == 0) {
+			return NULL;
+		}
+
+		double *result = (double *)malloc((size_t)screenCount * MIMI_SCREEN_DOUBLES * sizeof(double));
+		if (!result) {
+			return NULL;
+		}
+
+		for (int i = 0; i < screenCount; i++) {
+			NSScreen *screen = screens[i];
+			NSRect frame = [screen frame];
+			NSRect visible = [screen visibleFrame];
+			double *row = result + i * MIMI_SCREEN_DOUBLES;
+
+			row[0] = (double)[screen.deviceDescription[@"NSScreenNumber"] unsignedIntValue];
+			row[1] = frame.origin.x;
+			row[2] = frame.origin.y;
+			row[3] = frame.size.width;
+			row[4] = frame.size.height;
+			row[5] = visible.origin.x;
+			row[6] = visible.origin.y;
+			row[7] = visible.size.width;
+			row[8] = visible.size.height;
+		}
+
+		*count = screenCount;
+		return result;
+	}
+}
+
 bool MimiTiledWindowMarginsEnabled(void) {
 	@autoreleasepool {
 		// CFPreferences is the most reliable way to read other app's preferences

--- a/internal/native/window.go
+++ b/internal/native/window.go
@@ -259,6 +259,67 @@ func ScreenVisibleFrame(xCoord, yCoord float64) (float64, float64, float64, floa
 		), nil
 }
 
+// Frame is a rectangle in NSScreen coordinates: y-up, origin at the primary
+// display's bottom-left.
+type Frame struct {
+	X, Y, W, H float64
+}
+
+// Display is one connected display: its identifier, its full frame and its
+// visible frame (the full frame less the menu bar and the Dock).
+type Display struct {
+	ID      uint32
+	Frame   Frame
+	Visible Frame
+}
+
+// Displays lists every connected display, in the order macOS reports them.
+func Displays() ([]Display, error) {
+	var count C.int
+
+	rows := C.MimiCopyScreenFrames(&count)
+	if rows == nil || count == 0 {
+		if rows != nil {
+			C.free(unsafe.Pointer(rows))
+		}
+
+		return nil, derrors.New(derrors.CodeAccessibilityFailed, "failed to enumerate displays")
+	}
+	defer C.free(unsafe.Pointer(rows)) //nolint:nlreturn
+
+	perDisplay := int(C.MIMI_SCREEN_DOUBLES)
+	total := int(count) * perDisplay
+	values := unsafe.Slice((*C.double)(unsafe.Pointer(rows)), total)
+	displays := make([]Display, int(count))
+
+	for index := range displays {
+		row := values[index*perDisplay : (index+1)*perDisplay]
+		displays[index] = Display{
+			ID: uint32(row[0]),
+			Frame: Frame{
+				X: float64(row[1]),
+				Y: float64(row[2]),
+				W: float64(row[3]),
+				H: float64(row[4]),
+			},
+			Visible: Frame{
+				X: float64(row[5]),
+				Y: float64(row[6]),
+				W: float64(row[7]),
+				H: float64(row[8]),
+			},
+		}
+	}
+
+	return displays, nil
+}
+
+// ActivateDisplay makes the given display the active one for the menu bar
+// and event routing, as a window move across displays leaves it.
+func ActivateDisplay(id uint32) {
+	C.MimiActivateDisplay(C.uint32_t(id))
+}
+
 // TiledWindowMarginsEnabled reports whether the system tiled window margins setting is enabled.
 func TiledWindowMarginsEnabled() bool {
 	return bool(C.MimiTiledWindowMarginsEnabled())


### PR DESCRIPTION
## Description

This PR adds `move_window_to_display`, which moves the frontmost window to another display by number or with `next`/`prev`. mimi could move a window between spaces but not between displays. The window keeps the share of the visible frame it had, so a window tiled to the left half of one display is tiled to the left half of the other whatever their sizes or resolutions. Displays are counted left to right, then top to bottom. A window already on the destination stays put, which is also what `next` does on a single display.

The move goes through Accessibility, so the window lands on the destination's active space with the same animation a drag would, and the destination becomes the active display, the same as a cross-display space move already leaves it. It also documents a side effect space switching always had: switching to a space on another display warps the mouse pointer to that display's center and leaves it there. That applies to `move_window_to_space --follow` too.

## Commands

| Surface | What it does |
| --- | --- |
| `mimi action move_window_to_display <n\|next\|prev>` | Moves the frontmost window to the display named, keeping its proportional position and size. Out-of-range numbers are rejected with the valid range, as for spaces. Accessibility required. |

```bash
# ~/.skhdrc
shift + alt - n : mimi action move_window_to_display next
```

The error wording for a malformed space argument is unchanged; the display argument reports the same sentences with "display" in place of "space".

## Potentially disruptive: the daemon wire version is bumped

The new action rides the daemon socket, so the request protocol version moved from 2 to 3. A daemon left running across the upgrade rejects this build's requests, the CLI prints a warning naming the mismatch, and runs the action on the direct path. The warning stops after `mimi stop && mimi start`, or `mimi services restart` for an installed service. If this ships in the same release as #193, users see one restart, not two.

Existing configs and hotkeys keep working unchanged.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Run on this machine, which has one display, after `just build`:

```
$ ./bin/mimi action move_window_to_display next      # no-op, exit 0
$ ./bin/mimi action move_window_to_display 1         # no-op, exit 0
$ ./bin/mimi action move_window_to_display 2
Error: [INVALID_INPUT] display number 2 is out of range; valid range is 1..1
$ ./bin/mimi action move_window_to_display 0
Error: [INVALID_INPUT] move_window_to_display argument must be a positive integer, "next", or "prev", got "0"
```

## Additional Context

Not tested on a real second display: this machine has one, so the cross-display frame write and the display activation ran only against the fake desktop in the unit tests. The mapping itself is pure geometry and is pinned by tests both ways (there and back), including a straddling window being assigned to the display holding its center. The display list comes from `NSScreen`, read fresh on every call, with the visible frame excluding the menu bar and Dock exactly as the resize geometry already reads it.

The proportional mapping is a deliberate choice over keeping the window's point size: it is what makes tiling presets survive the move on displays of different sizes. A window that fits comfortably on a small display therefore grows on a large one. Anyone who wants the old size back runs `resize_window` afterwards.

The space and display arguments now share one parsing rule under two nouns rather than two copies of it, in the spirit of the typed-wire ADR. The architecture doc's action table also gained the `resize_window` row it was missing.
