### PR TITLE
fix(action): land a window moved across displays at the size it was asked for

### DIFF
--- a/internal/action/display.go
+++ b/internal/action/display.go
@@ -93,6 +93,22 @@ func (e *Executor) MoveWindowToDisplay(target DisplayArg) error {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to move window")
 	}
 
+	// A frame written across displays can land short. The application
+	// applies the new size while it still counts the window as being on the
+	// display it just left, and clamps the size to that display's edge, so a
+	// window moving from a small display to a large one comes up narrow.
+	// Writing the same frame once more, now that the window is where the
+	// size was measured for, lands it. A frame that cannot be read back is
+	// left as the first write put it: that write succeeded, and this is a
+	// correction, not the move.
+	landed, err := e.desktop.WindowFrame(win.ID)
+	if err == nil && !geometry.SameFrame(landed, frame) {
+		err = e.desktop.SetWindowFrame(win.ID, frame)
+		if err != nil {
+			return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to move window")
+		}
+	}
+
 	e.desktop.ActivateDisplay(displays[toIndex].ID)
 	e.desktop.RefreshWorkspaceTitle()
 

--- a/internal/action/display_test.go
+++ b/internal/action/display_test.go
@@ -102,6 +102,45 @@ func TestExecutor_MoveWindowToDisplay_KeepsTheWindowsShareOfTheDisplay(t *testin
 	}
 }
 
+// TestExecutor_MoveWindowToDisplay_WritesAgainWhenTheFrameLandsShort pins the
+// correction for a frame written across displays: the application clamps the
+// first size to the display the window is leaving, so the frame is read back
+// and written once more, and only when it landed somewhere else.
+func TestExecutor_MoveWindowToDisplay_WritesAgainWhenTheFrameLandsShort(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		clamps     bool
+		wantWrites int
+	}{
+		{name: "lands short and is written again", clamps: true, wantWrites: 2},
+		{name: "lands as asked and is left alone", clamps: false, wantWrites: 1},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := desktopWithDisplays()
+			desktop.windows[0].clampsFirstWrite = testCase.clamps
+
+			err := action.NewExecutor(desktop).ExecuteCommand(displayCommandFor(t, nextKeyword))
+			if err != nil {
+				t.Fatalf("ExecuteCommand(move_window_to_display next) error = %v, want nil", err)
+			}
+
+			if got := desktop.windows[0].frame; got != leftHalfOfRight {
+				t.Fatalf("window frame = %+v, want %+v", got, leftHalfOfRight)
+			}
+
+			if got := desktop.windows[0].setFrameWrites; got != testCase.wantWrites {
+				t.Fatalf("frame writes = %d, want %d", got, testCase.wantWrites)
+			}
+		})
+	}
+}
+
 // TestExecutor_MoveWindowToDisplay_StaysPutOnTheDestination covers a window
 // already where it was asked to go: by number, and by "next" on a machine
 // with one display. Nothing is written and nothing is activated.

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -18,6 +18,13 @@ type fakeWindow struct {
 	frameErr    error
 	activateErr error
 	setFrameErr error
+	// setFrameWrites counts how many frames were written to the window.
+	setFrameWrites int
+	// clampsFirstWrite makes the first frame written land one point
+	// narrower than asked, the way an application does when it applies a
+	// size while it still counts the window as being on the display it just
+	// left. Later writes land as asked.
+	clampsFirstWrite bool
 }
 
 // fakeDesktop is a desktop made of plain values. Every action's effect lands
@@ -124,6 +131,11 @@ func (d *fakeDesktop) SetWindowFrame(windowID action.WindowID, frame geometry.Re
 
 	if d.windows[index].setFrameErr != nil {
 		return d.windows[index].setFrameErr
+	}
+
+	d.windows[index].setFrameWrites++
+	if d.windows[index].clampsFirstWrite && d.windows[index].setFrameWrites == 1 {
+		frame.W--
 	}
 
 	d.windows[index].frame = frame

--- a/internal/geometry/display.go
+++ b/internal/geometry/display.go
@@ -1,5 +1,7 @@
 package geometry
 
+import "math"
+
 // windowBounds is a visible frame in window coordinates. The top edge is the
 // one line that converts between the two systems:
 //
@@ -19,16 +21,19 @@ func windowBounds(visible Rect, primaryHeight float64) Rect {
 // half of one display fills the left half of the other, whatever their sizes.
 //
 // cur and the returned frame are in window coordinates; from and to are in
-// screen coordinates, as macOS reports them.
+// screen coordinates, as macOS reports them. The frame comes back in whole
+// points, which is how macOS stores it: rounding here rather than leaving it
+// to the application keeps a window that goes there and back from drifting a
+// point each way.
 func MoveToScreen(cur Rect, primaryHeight float64, from, to Rect) Rect {
 	src := windowBounds(from, primaryHeight)
 	dst := windowBounds(to, primaryHeight)
 
 	return Rect{
-		X: dst.X + (cur.X-src.X)/src.W*dst.W,
-		Y: dst.Y + (cur.Y-src.Y)/src.H*dst.H,
-		W: cur.W / src.W * dst.W,
-		H: cur.H / src.H * dst.H,
+		X: math.Round(dst.X + (cur.X-src.X)/src.W*dst.W),
+		Y: math.Round(dst.Y + (cur.Y-src.Y)/src.H*dst.H),
+		W: math.Round(cur.W / src.W * dst.W),
+		H: math.Round(cur.H / src.H * dst.H),
 	}
 }
 

--- a/internal/geometry/display_test.go
+++ b/internal/geometry/display_test.go
@@ -30,9 +30,11 @@ func TestMoveToScreen_KeepsTheShareOfTheVisibleFrame(t *testing.T) {
 			want: geometry.Rect{X: 1920, Y: -335, W: 1280, H: 1415},
 		},
 		{
-			name: "a centered quarter stays centered",
-			cur:  geometry.Rect{X: 480, Y: 25 + 1055/4.0, W: 960, H: 1055 / 2.0},
-			want: geometry.Rect{X: 1920 + 640, Y: -335 + 1415/4.0, W: 1280, H: 1415 / 2.0},
+			// The shares here do not divide evenly, so this is also the case
+			// that pins the frame coming back in whole points.
+			name: "a centered window stays centered, in whole points",
+			cur:  geometry.Rect{X: 480, Y: 289, W: 960, H: 527},
+			want: geometry.Rect{X: 2560, Y: 19, W: 1280, H: 707},
 		},
 	}
 
@@ -114,5 +116,19 @@ func TestScreenContaining_DecidesByTheWindowsCenter(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestSameFrame_ToleratesHalfAPoint(t *testing.T) {
+	t.Parallel()
+
+	base := geometry.Rect{X: 10, Y: 20, W: 300, H: 400}
+
+	if !geometry.SameFrame(base, geometry.Rect{X: 10.4, Y: 19.6, W: 300.4, H: 400}) {
+		t.Fatal("SameFrame() = false for frames under half a point apart, want true")
+	}
+
+	if geometry.SameFrame(base, geometry.Rect{X: 10, Y: 20, W: 299, H: 400}) {
+		t.Fatal("SameFrame() = true for frames a point apart, want false")
 	}
 }

--- a/internal/geometry/rect.go
+++ b/internal/geometry/rect.go
@@ -12,6 +12,14 @@ type Rect struct {
 	H float64
 }
 
+// SameFrame reports whether two frames are the same to within the slack a
+// display can show: macOS stores window frames in whole points, so two frames
+// half a point apart are one frame.
+func SameFrame(first, second Rect) bool {
+	return adjacent(first.X, second.X) && adjacent(first.Y, second.Y) &&
+		adjacent(first.W, second.W) && adjacent(first.H, second.H)
+}
+
 // Right returns the x coordinate of the rectangle's right edge.
 func (r Rect) Right() float64 {
 	return r.X + r.W


### PR DESCRIPTION
## Description

This PR fixes `move_window_to_display` landing a window narrower than asked when it moves to a larger display. Trying #194 on a two-display machine, a window returning from a 1470-point display to a 1920-point one came back 1675 points wide, with its right edge sitting exactly where the smaller display ends. The application applies the new size while it still counts the window as being on the display it just left, and clamps the size to that display's edge.

The frame is now read back after the write and written once more when it landed somewhere else, by which time the window is where the size was measured for. A frame that matches is left alone, so the common case still writes once. The mapped frame is also rounded to whole points, as macOS stores it, so a window that goes there and back no longer drifts a point each way.

No command, flag, or config surface changes.

## Related Issues

Follow-up to #194.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Two displays: a 1920x1080 primary and a 1470x956 display below it. The terminal window, filling the primary, moved there and back twice with the fix:

```
before: {"pid":90234,"frame":{"x":6,"y":38,"width":1906,"height":1034}}
on 2:   {"pid":90234,"frame":{"x":217,"y":1119,"width":1459,"height":910}}
back:   {"pid":90234,"frame":{"x":7,"y":38,"width":1906,"height":1034}}
twice:  {"pid":90234,"frame":{"x":7,"y":38,"width":1906,"height":1034}}
```

Before the fix the same round trip came back as `{"x":7,"y":38,"width":1675,"height":1034}`.

## Additional Context

The second write is a correction, not a retry loop: it happens at most once, and only when the read-back frame differs by more than half a point, the same slack the resize geometry already uses for edges. A frame that cannot be read back is left as the first write put it, since that write succeeded.
