### PR TITLE
feat(action,cli): add thirds presets and a --cycle flag that steps a half through them

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | Focus window above               | `mimi action focus_window --up`                                           |
 | Focus window below               | `mimi action focus_window --down`                                         |
 | Tile window to a preset          | `mimi action resize_window <left-half\|right-half\|center\|fill>`         |
+| Tile to a third                  | `mimi action resize_window <left-third\|center-third\|right-third>`      |
+| Cycle a half through its thirds  | `mimi action resize_window left-half --cycle`                             |
 | Center at specific size          | `mimi action resize_window center --width-percent 80 --height-percent 90` |
 | Resize to exact pixels           | `mimi action resize_window --width 1024 --height 768`                     |
 | Resize anchored to a corner      | `mimi action resize_window --width 1024 --height 768 --anchor br`         |

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -32,6 +32,7 @@ Examples:
   mimi action move_window_to_space next --follow
   mimi action move_window_to_display next
   mimi action resize_window left-half
+  mimi action resize_window left-half --cycle
   mimi action resize_window --width 800 --height 600 --anchor cc
   mimi action resize_window --width-percent 50 --height-percent 100 --anchor tl`,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
@@ -241,8 +242,18 @@ Presets provide quick tiling:
   top-right      Fill the top-right quadrant
   bottom-left    Fill the bottom-left quadrant
   bottom-right   Fill the bottom-right quadrant
+  left-third     Fill the left third of the screen
+  center-third   Fill the middle third of the screen
+  right-third    Fill the right third of the screen
+  left-two-thirds   Fill the left two thirds of the screen
+  right-two-thirds  Fill the right two thirds of the screen
   center         Center the window at 60% x 80% of screen
   fill           Fill the entire screen (respecting margins)
+
+With --cycle, left-half and right-half step through their sizes on
+repeated presses: half, then two thirds, then a third, then back to
+half. A window at none of those sizes starts at the half. --cycle takes
+no size, position or anchor flag; margins still apply.
 
 Custom flags allow precise control using an anchor system:
   Anchors: tl (top-left), tc (top-center), tr (top-right),
@@ -296,6 +307,8 @@ Examples:
 		StringP("anchor", "a", "", "Anchor point for positioning (tl, tc, tr, cl, cc, cr, bl, bc, br)")
 	cmd.Flags().Bool("margin", false, "Enable tiled window margins (overrides system setting)")
 	cmd.Flags().Bool("no-margin", false, "Disable tiled window margins (overrides system setting)")
+	cmd.Flags().
+		Bool("cycle", false, "Step left-half or right-half through half, two thirds and a third")
 
 	return cmd
 }
@@ -318,6 +331,7 @@ func resizeWindowArgsFromFlags(cobraCmd *cobra.Command, preset string) action.Re
 	anchor, _ := flags.GetString("anchor")
 	useMargin, _ := flags.GetBool("margin")
 	noMargin, _ := flags.GetBool("no-margin")
+	cycle, _ := flags.GetBool("cycle")
 
 	return action.ResizeWindowArgs{
 		Preset:           preset,
@@ -337,6 +351,7 @@ func resizeWindowArgsFromFlags(cobraCmd *cobra.Command, preset string) action.Re
 		AnchorSet:        flags.Changed("anchor"),
 		UseMargin:        useMargin,
 		NoMargin:         noMargin,
+		Cycle:            cycle,
 	}
 }
 

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -25,13 +25,19 @@ const (
 	focusWindowCommandName  = string(action.NameFocusWindow)
 	resizeWindowCommandName = string(action.NameResizeWindow)
 
-	// unknownPreset is a name that is not one of the ten presets, and never
+	// unknownPreset is a name that is not one of the fifteen presets, and never
 	// becomes one.
-	unknownPreset = "left-third"
+	unknownPreset = "left-quarter"
 
 	// whitespaceOnlyArg is a positional argument made of nothing but
 	// whitespace, which names neither a preset nor a space.
 	whitespaceOnlyArg = "   "
+
+	// leftHalfPreset is the preset the cycle tests bind, spelled once.
+	leftHalfPreset = "left-half"
+
+	// widthFlag is the size flag the malformed-argument cases reach for.
+	widthFlag = "--width"
 )
 
 // resizeFlags parses args against a fresh resize_window flag set and returns
@@ -61,7 +67,7 @@ func TestResizeWindowArgsFromFlags_UsesChangedForEveryDimensionFlag(t *testing.T
 	t.Run("width 0 is forwarded when given", func(t *testing.T) {
 		t.Parallel()
 
-		got := resizeFlags(t, "", "--width", "0")
+		got := resizeFlags(t, "", widthFlag, "0")
 
 		if !got.WidthSet {
 			t.Fatal("WidthSet = false, want true for an explicit --width 0")
@@ -112,10 +118,20 @@ func TestResizeWindowArgsFromFlags_UsesChangedForEveryDimensionFlag(t *testing.T
 		}
 	})
 
+	t.Run("cycle is forwarded when given", func(t *testing.T) {
+		t.Parallel()
+
+		got := resizeFlags(t, leftHalfPreset, "--cycle")
+
+		if !got.Cycle || got.Preset != leftHalfPreset {
+			t.Fatalf("got %+v, want Cycle=true Preset=left-half", got)
+		}
+	})
+
 	t.Run("a positive width is still forwarded, as before", func(t *testing.T) {
 		t.Parallel()
 
-		got := resizeFlags(t, "", "--width", "800")
+		got := resizeFlags(t, "", widthFlag, "800")
 
 		if !got.WidthSet || got.Width != 800 {
 			t.Fatalf("got %+v, want WidthSet=true Width=800", got)
@@ -126,10 +142,10 @@ func TestResizeWindowArgsFromFlags_UsesChangedForEveryDimensionFlag(t *testing.T
 func TestResizeWindowArgsFromFlags_CarriesThePresetAndTheOtherFlags(t *testing.T) {
 	t.Parallel()
 
-	got := resizeFlags(t, "left-half", "--x", "10", "--y", "20", "--anchor", "cc", "--margin")
+	got := resizeFlags(t, leftHalfPreset, "--x", "10", "--y", "20", "--anchor", "cc", "--margin")
 
 	want := action.ResizeWindowArgs{
-		Preset:    "left-half",
+		Preset:    leftHalfPreset,
 		X:         10,
 		XSet:      true,
 		Y:         20,
@@ -392,7 +408,7 @@ func TestResizeWindowArgValidation_AcceptsWhatItAlwaysAccepted(t *testing.T) {
 	}{
 		{name: "no argument", args: nil},
 		{name: "the empty argument", args: []string{""}},
-		{name: "a preset", args: []string{"left-half"}},
+		{name: "a preset", args: []string{leftHalfPreset}},
 		{name: "a padded preset", args: []string{" left-half "}},
 		{name: "a preset beside its flags", args: []string{"center", "--x", "10"}},
 		{name: "flags with no preset", args: []string{"--margin"}},
@@ -465,7 +481,7 @@ type malformedAction struct {
 // constructor calls. None of them can reach the desktop.
 func malformedActionArgv() []malformedAction {
 	return []malformedAction{
-		{name: "negative width", argv: []string{resizeWindowCommandName, "--width", "-5"}},
+		{name: "negative width", argv: []string{resizeWindowCommandName, widthFlag, "-5"}},
 		{name: "negative height", argv: []string{resizeWindowCommandName, "--height", "-5"}},
 		{
 			name: "width-percent above 100",
@@ -495,6 +511,14 @@ func malformedActionArgv() []malformedAction {
 			// constructor runs rather than by anything in this layer.
 			name: "both margin flags at once",
 			argv: []string{resizeWindowCommandName, "--margin", "--no-margin"},
+		},
+		{
+			name: "cycle on a preset that does not cycle",
+			argv: []string{resizeWindowCommandName, "fill", "--cycle"},
+		},
+		{
+			name: "cycle combined with a size flag",
+			argv: []string{resizeWindowCommandName, leftHalfPreset, "--cycle", widthFlag, "800"},
 		},
 		{
 			name: "a direction combined with --backward",

--- a/cmd/mimi/cmd/root_test.go
+++ b/cmd/mimi/cmd/root_test.go
@@ -243,7 +243,7 @@ func TestNewRootCmd_AnArgumentFailureStillPrintsUsage(t *testing.T) {
 			actionCommandName, focusWindowCommandName, "--not-a-flag",
 		}},
 		{name: "an unparsable flag value", argv: []string{
-			actionCommandName, resizeWindowCommandName, "--width", "abc",
+			actionCommandName, resizeWindowCommandName, widthFlag, "abc",
 		}},
 		{name: "a missing argument", argv: []string{
 			actionCommandName, string(action.NameSpace),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -145,8 +145,15 @@ Resize and reposition the frontmost window using presets or custom flags. Respec
 | `top-right`    | Fill the top-right quadrant          |
 | `bottom-left`  | Fill the bottom-left quadrant        |
 | `bottom-right` | Fill the bottom-right quadrant       |
+| `left-third`   | Fill the left third of the screen    |
+| `center-third` | Fill the middle third of the screen  |
+| `right-third`  | Fill the right third of the screen   |
+| `left-two-thirds`  | Fill the left two thirds of the screen  |
+| `right-two-thirds` | Fill the right two thirds of the screen |
 | `center`       | Center window at 60% × 80% of screen |
 | `fill`         | Fill entire screen                   |
+
+**Cycling:** with `--cycle`, `left-half` and `right-half` step through their sizes on repeated presses: half, then two thirds, then a third, then back to half. A window at none of those sizes starts at the half, so one hotkey bound to `resize_window left-half --cycle` covers all three. The step is decided from where the window is now, so it works the same with or without the daemon. `--cycle` takes no size, position or anchor flag, and only those two presets accept it; margins still apply to every step.
 
 **Custom sizing flags:**
 
@@ -202,6 +209,9 @@ mimi action resize_window --width 1024 --height 768 --x 100 --y 50 --anchor tl
 
 # Override margins for a preset
 mimi action resize_window left-half --no-margin
+
+# One hotkey: half, then two thirds, then a third, then half again
+mimi action resize_window left-half --cycle
 
 # Mix preset with custom size
 mimi action resize_window center --width-percent 80 --height-percent 90

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -241,7 +241,7 @@ func (e *Executor) resolveSpaceArg(name Name, parsed SpaceArg) (int, error) {
 // be rejected on every other one (mimi#132); this is now the only place it
 // happens.
 //
-// The rejection lists the ten valid names, read from the geometry's own table
+// The rejection lists the fifteen valid names, read from the geometry's own table
 // rather than restated here, since mistyping one is the likely way to get
 // here, and quotes the name as it was given rather than as it was trimmed, so
 // padding the user did type is visible in it. A name that is empty, or is

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -28,7 +28,7 @@ const (
 
 	// unknownPreset is a name that is not one of the ten, and never becomes
 	// one: the input every rejection case below is written against.
-	unknownPreset = "left-third"
+	unknownPreset = "left-quarter"
 
 	// nonNumericArg names no space and no preset — the argument every
 	// "that is not a number or a keyword" case is written against.
@@ -144,6 +144,7 @@ func everyPreset() []string {
 	return []string{
 		presetLeftHalf, presetRightHalf, presetTopHalf, presetBottomHalf,
 		presetTopLeft, presetTopRight, presetBottomLeft, presetBottomRight,
+		"left-third", "center-third", "right-third", "left-two-thirds", "right-two-thirds",
 		presetCenter, presetFill,
 	}
 }
@@ -161,7 +162,7 @@ func presetFor(t *testing.T, name string) geometry.Preset {
 	return preset
 }
 
-// assertListsEveryPreset checks a rejection names all ten presets, which is
+// assertListsEveryPreset checks a rejection names every preset, which is
 // what makes it useful to whoever mistyped one.
 func assertListsEveryPreset(t *testing.T, err error) {
 	t.Helper()

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"strings"
+
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/geometry"
 )
@@ -246,6 +248,10 @@ type ResizeWindowArgs struct {
 
 	UseMargin bool `json:"useMargin"`
 	NoMargin  bool `json:"noMargin"`
+
+	// Cycle steps the preset through its cycle: left-half to left-two-thirds
+	// to left-third and back, and the same on the right.
+	Cycle bool `json:"cycle"`
 }
 
 // ResizeRequestFromArgs turns resize_window's arguments into the geometry
@@ -310,7 +316,14 @@ func ResizeRequestFromArgs(args ResizeWindowArgs) (geometry.Request, error) {
 		)
 	}
 
-	req := geometry.Request{Preset: preset}
+	if args.Cycle {
+		err = validateCycle(args, preset)
+		if err != nil {
+			return geometry.Request{}, err
+		}
+	}
+
+	req := geometry.Request{Preset: preset, Cycle: args.Cycle}
 
 	width, widthPercent := 0.0, 0.0
 	if args.WidthSet {
@@ -365,6 +378,29 @@ func ResizeRequestFromArgs(args ResizeWindowArgs) (geometry.Request, error) {
 	req.UseMargins = useMargins
 
 	return req, nil
+}
+
+// validateCycle holds --cycle's two rules: it needs a preset that has a cycle,
+// and the cycle decides the size and the place, so no flag may set either.
+// Margins are the one thing left to ask for, since every step honors them.
+func validateCycle(args ResizeWindowArgs, preset geometry.Preset) error {
+	if !preset.Cycles() {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"--cycle needs a preset that cycles (%s)",
+			strings.Join(geometry.CyclingPresetNames(), ", "),
+		)
+	}
+
+	if args.WidthSet || args.HeightSet || args.WidthPercentSet || args.HeightPercentSet ||
+		args.XSet || args.YSet || args.AnchorSet {
+		return derrors.New(
+			derrors.CodeInvalidInput,
+			"--cycle cannot be combined with a size, position or anchor flag",
+		)
+	}
+
+	return nil
 }
 
 // marginPreferenceOf turns resize_window's two margin flags into the margin

--- a/internal/action/cycle_test.go
+++ b/internal/action/cycle_test.go
@@ -1,0 +1,84 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+func TestResizeRequestFromArgs_CycleNeedsACyclingPresetAndNoSizeFlags(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		args    action.ResizeWindowArgs
+		wantErr bool
+	}{
+		{
+			name: "left-half cycles",
+			args: action.ResizeWindowArgs{Preset: presetLeftHalf, Cycle: true},
+		},
+		{
+			name: "right-half cycles",
+			args: action.ResizeWindowArgs{Preset: presetRightHalf, Cycle: true},
+		},
+		{
+			name: "margins may still be asked for",
+			args: action.ResizeWindowArgs{Preset: presetLeftHalf, Cycle: true, NoMargin: true},
+		},
+		{name: "no preset", args: action.ResizeWindowArgs{Cycle: true}, wantErr: true},
+		{
+			name:    "fill does not cycle",
+			args:    action.ResizeWindowArgs{Preset: presetFill, Cycle: true},
+			wantErr: true,
+		},
+		{
+			name: "a width flag",
+			args: action.ResizeWindowArgs{
+				Preset:   "left-half",
+				Cycle:    true,
+				Width:    800,
+				WidthSet: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "an anchor flag",
+			args: action.ResizeWindowArgs{
+				Preset:    "left-half",
+				Cycle:     true,
+				Anchor:    "tl",
+				AnchorSet: true,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := action.ResizeRequestFromArgs(testCase.args)
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("ResizeRequestFromArgs() error = nil, want invalid input")
+				}
+
+				if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+					t.Fatalf("error = %v, want invalid input", err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ResizeRequestFromArgs() error = %v, want nil", err)
+			}
+
+			if !req.Cycle {
+				t.Fatal("Cycle = false on the request, want it carried")
+			}
+		})
+	}
+}

--- a/internal/action/display.go
+++ b/internal/action/display.go
@@ -93,6 +93,22 @@ func (e *Executor) MoveWindowToDisplay(target DisplayArg) error {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to move window")
 	}
 
+	// A frame written across displays can land short. The application
+	// applies the new size while it still counts the window as being on the
+	// display it just left, and clamps the size to that display's edge, so a
+	// window moving from a small display to a large one comes up narrow.
+	// Writing the same frame once more, now that the window is where the
+	// size was measured for, lands it. A frame that cannot be read back is
+	// left as the first write put it: that write succeeded, and this is a
+	// correction, not the move.
+	landed, err := e.desktop.WindowFrame(win.ID)
+	if err == nil && !geometry.SameFrame(landed, frame) {
+		err = e.desktop.SetWindowFrame(win.ID, frame)
+		if err != nil {
+			return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to move window")
+		}
+	}
+
 	e.desktop.ActivateDisplay(displays[toIndex].ID)
 	e.desktop.RefreshWorkspaceTitle()
 

--- a/internal/action/display_test.go
+++ b/internal/action/display_test.go
@@ -102,6 +102,45 @@ func TestExecutor_MoveWindowToDisplay_KeepsTheWindowsShareOfTheDisplay(t *testin
 	}
 }
 
+// TestExecutor_MoveWindowToDisplay_WritesAgainWhenTheFrameLandsShort pins the
+// correction for a frame written across displays: the application clamps the
+// first size to the display the window is leaving, so the frame is read back
+// and written once more, and only when it landed somewhere else.
+func TestExecutor_MoveWindowToDisplay_WritesAgainWhenTheFrameLandsShort(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		clamps     bool
+		wantWrites int
+	}{
+		{name: "lands short and is written again", clamps: true, wantWrites: 2},
+		{name: "lands as asked and is left alone", clamps: false, wantWrites: 1},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := desktopWithDisplays()
+			desktop.windows[0].clampsFirstWrite = testCase.clamps
+
+			err := action.NewExecutor(desktop).ExecuteCommand(displayCommandFor(t, nextKeyword))
+			if err != nil {
+				t.Fatalf("ExecuteCommand(move_window_to_display next) error = %v, want nil", err)
+			}
+
+			if got := desktop.windows[0].frame; got != leftHalfOfRight {
+				t.Fatalf("window frame = %+v, want %+v", got, leftHalfOfRight)
+			}
+
+			if got := desktop.windows[0].setFrameWrites; got != testCase.wantWrites {
+				t.Fatalf("frame writes = %d, want %d", got, testCase.wantWrites)
+			}
+		})
+	}
+}
+
 // TestExecutor_MoveWindowToDisplay_StaysPutOnTheDestination covers a window
 // already where it was asked to go: by number, and by "next" on a machine
 // with one display. Nothing is written and nothing is activated.

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -18,6 +18,13 @@ type fakeWindow struct {
 	frameErr    error
 	activateErr error
 	setFrameErr error
+	// setFrameWrites counts how many frames were written to the window.
+	setFrameWrites int
+	// clampsFirstWrite makes the first frame written land one point
+	// narrower than asked, the way an application does when it applies a
+	// size while it still counts the window as being on the display it just
+	// left. Later writes land as asked.
+	clampsFirstWrite bool
 }
 
 // fakeDesktop is a desktop made of plain values. Every action's effect lands
@@ -124,6 +131,11 @@ func (d *fakeDesktop) SetWindowFrame(windowID action.WindowID, frame geometry.Re
 
 	if d.windows[index].setFrameErr != nil {
 		return d.windows[index].setFrameErr
+	}
+
+	d.windows[index].setFrameWrites++
+	if d.windows[index].clampsFirstWrite && d.windows[index].setFrameWrites == 1 {
+		frame.W--
 	}
 
 	d.windows[index].frame = frame

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -110,6 +110,8 @@ type ResizeArgs struct {
 
 	UseMargin bool `json:"useMargin,omitempty"`
 	NoMargin  bool `json:"noMargin,omitempty"`
+
+	Cycle bool `json:"cycle,omitempty"`
 }
 
 // ResizeCase is one recorded resize_window invocation: the arguments, the frame

--- a/internal/geometry/cycle.go
+++ b/internal/geometry/cycle.go
@@ -1,0 +1,57 @@
+package geometry
+
+// cycles are the presets that step through a sequence when asked to, keyed by
+// the preset the sequence starts from, which is the name the user binds. The
+// halves step to their two-thirds and then their third, the order Rectangle
+// made familiar, and wrap back to the half.
+var cycles = map[string][]string{
+	leftHalfName:  {leftHalfName, leftTwoThirdsName, leftThirdName},
+	rightHalfName: {rightHalfName, rightTwoThirdsName, rightThirdName},
+}
+
+// Cycles reports whether the preset has a cycle for Request.Cycle to step
+// through.
+func (p Preset) Cycles() bool {
+	_, ok := cycles[p.name]
+
+	return ok
+}
+
+// CyclingPresetNames returns the names of the presets that cycle, in the
+// order PresetNames lists them. It is what a caller rejecting --cycle on any
+// other preset tells the user about.
+func CyclingPresetNames() []string {
+	var names []string
+
+	for _, named := range presets {
+		if _, ok := cycles[named.name]; ok {
+			names = append(names, named.name)
+		}
+	}
+
+	return names
+}
+
+// nextInCycle picks the preset a cycling request applies. It places the
+// window at each frame of the cycle in turn, on the same terms as the request
+// (margins included), and steps to the one after the first frame the window
+// is already at; a window at none of them starts the cycle over. A preset
+// with no cycle comes back unchanged.
+func nextInCycle(cur Rect, scr Screen, req Request) Preset {
+	names, ok := cycles[req.Preset.name]
+	if !ok {
+		return req.Preset
+	}
+
+	step := req
+	step.Cycle = false
+
+	for index, name := range names {
+		step.Preset = Preset{name: name}
+		if SameFrame(cur, Resize(cur, scr, step)) {
+			return Preset{name: names[(index+1)%len(names)]}
+		}
+	}
+
+	return Preset{name: names[0]}
+}

--- a/internal/geometry/cycle_test.go
+++ b/internal/geometry/cycle_test.go
@@ -1,0 +1,139 @@
+package geometry_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+func cycling(name string) geometry.Request {
+	return geometry.Request{Preset: presetFor(name), Cycle: true}
+}
+
+// TestResize_CycleStepsAHalfThroughItsThirds pins the sequence a repeated
+// press walks: half, two thirds, a third, and back to the half, on either
+// side. A window at none of those frames starts the sequence at the half.
+func TestResize_CycleStepsAHalfThroughItsThirds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		half  string
+		steps []geometry.Rect
+	}{
+		{
+			name: presetLeftHalf,
+			half: presetLeftHalf,
+			steps: []geometry.Rect{
+				{X: 0, Y: 30, W: 960, H: 1050},
+				{X: 0, Y: 30, W: 1280, H: 1050},
+				{X: 0, Y: 30, W: 640, H: 1050},
+				{X: 0, Y: 30, W: 960, H: 1050},
+			},
+		},
+		{
+			name: presetRightHalf,
+			half: presetRightHalf,
+			steps: []geometry.Rect{
+				{X: 960, Y: 30, W: 960, H: 1050},
+				{X: 640, Y: 30, W: 1280, H: 1050},
+				{X: 1280, Y: 30, W: 640, H: 1050},
+				{X: 960, Y: 30, W: 960, H: 1050},
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			frame := startFrame
+			for index, want := range testCase.steps {
+				frame = geometry.Resize(frame, singleDisplay, cycling(testCase.half))
+				if frame != want {
+					t.Fatalf(
+						"press %d: Resize(%s --cycle) = %v, want %v",
+						index+1,
+						testCase.half,
+						frame,
+						want,
+					)
+				}
+			}
+		})
+	}
+}
+
+// TestResize_CycleRecognisesAFrameMacOSRounded: the frame macOS stores is in
+// whole points, so a third of 1470 (490) matches exactly while a third of
+// 2560 (853.33) comes back as 853. Either has to read as "already at the
+// third" for the cycle to step on rather than start over.
+func TestResize_CycleRecognisesAFrameMacOSRounded(t *testing.T) {
+	t.Parallel()
+
+	wide := geometry.Screen{
+		Visible:       geometry.Rect{X: 0, Y: 0, W: 2560, H: 1415},
+		PrimaryHeight: 1440,
+	}
+	atTheThirdAsStored := geometry.Rect{X: 0, Y: 25, W: 853, H: 1415}
+
+	got := geometry.Resize(atTheThirdAsStored, wide, cycling(presetLeftHalf))
+
+	want := geometry.Rect{X: 0, Y: 25, W: 1280, H: 1415}
+	if got != want {
+		t.Fatalf(
+			"Resize(left-half --cycle) from the stored third = %v, want the half %v",
+			got,
+			want,
+		)
+	}
+}
+
+// TestResize_CycleHonorsMargins: each step is measured with the same margins
+// it is placed with, so a cycle with margins on still steps rather than
+// restarting because the inset frame never matched an uninset one.
+func TestResize_CycleHonorsMargins(t *testing.T) {
+	t.Parallel()
+
+	withMargins := singleDisplay
+	withMargins.MarginsEnabled = true
+
+	first := geometry.Resize(startFrame, withMargins, cycling(presetLeftHalf))
+	second := geometry.Resize(first, withMargins, cycling(presetLeftHalf))
+
+	// The half is flush left and top and bottom: full margins there, half a
+	// margin on the shared right edge.
+	wantFirst := geometry.Rect{X: 8, Y: 38, W: 948, H: 1034}
+	if first != wantFirst {
+		t.Fatalf("first press = %v, want %v", first, wantFirst)
+	}
+
+	if second.W <= first.W {
+		t.Fatalf("second press = %v, want wider than the half %v", second, first)
+	}
+}
+
+func TestResize_CycleIsIgnoredByAPresetThatDoesNotCycle(t *testing.T) {
+	t.Parallel()
+
+	got := geometry.Resize(startFrame, singleDisplay, cycling(presetFill))
+	want := geometry.Resize(startFrame, singleDisplay, geometry.Request{Preset: fill})
+
+	if got != want {
+		t.Fatalf("Resize(fill --cycle) = %v, want fill's own frame %v", got, want)
+	}
+}
+
+func TestCyclingPresetNames_AreTheTwoHalves(t *testing.T) {
+	t.Parallel()
+
+	want := []string{presetLeftHalf, presetRightHalf}
+	if got := geometry.CyclingPresetNames(); !slices.Equal(got, want) {
+		t.Fatalf("CyclingPresetNames() = %v, want %v", got, want)
+	}
+
+	if !presetFor(presetLeftHalf).Cycles() || presetFor(presetFill).Cycles() {
+		t.Fatal("Cycles() disagrees with CyclingPresetNames()")
+	}
+}

--- a/internal/geometry/display.go
+++ b/internal/geometry/display.go
@@ -1,5 +1,7 @@
 package geometry
 
+import "math"
+
 // windowBounds is a visible frame in window coordinates. The top edge is the
 // one line that converts between the two systems:
 //
@@ -19,16 +21,19 @@ func windowBounds(visible Rect, primaryHeight float64) Rect {
 // half of one display fills the left half of the other, whatever their sizes.
 //
 // cur and the returned frame are in window coordinates; from and to are in
-// screen coordinates, as macOS reports them.
+// screen coordinates, as macOS reports them. The frame comes back in whole
+// points, which is how macOS stores it: rounding here rather than leaving it
+// to the application keeps a window that goes there and back from drifting a
+// point each way.
 func MoveToScreen(cur Rect, primaryHeight float64, from, to Rect) Rect {
 	src := windowBounds(from, primaryHeight)
 	dst := windowBounds(to, primaryHeight)
 
 	return Rect{
-		X: dst.X + (cur.X-src.X)/src.W*dst.W,
-		Y: dst.Y + (cur.Y-src.Y)/src.H*dst.H,
-		W: cur.W / src.W * dst.W,
-		H: cur.H / src.H * dst.H,
+		X: math.Round(dst.X + (cur.X-src.X)/src.W*dst.W),
+		Y: math.Round(dst.Y + (cur.Y-src.Y)/src.H*dst.H),
+		W: math.Round(cur.W / src.W * dst.W),
+		H: math.Round(cur.H / src.H * dst.H),
 	}
 }
 

--- a/internal/geometry/display_test.go
+++ b/internal/geometry/display_test.go
@@ -30,9 +30,11 @@ func TestMoveToScreen_KeepsTheShareOfTheVisibleFrame(t *testing.T) {
 			want: geometry.Rect{X: 1920, Y: -335, W: 1280, H: 1415},
 		},
 		{
-			name: "a centered quarter stays centered",
-			cur:  geometry.Rect{X: 480, Y: 25 + 1055/4.0, W: 960, H: 1055 / 2.0},
-			want: geometry.Rect{X: 1920 + 640, Y: -335 + 1415/4.0, W: 1280, H: 1415 / 2.0},
+			// The shares here do not divide evenly, so this is also the case
+			// that pins the frame coming back in whole points.
+			name: "a centered window stays centered, in whole points",
+			cur:  geometry.Rect{X: 480, Y: 289, W: 960, H: 527},
+			want: geometry.Rect{X: 2560, Y: 19, W: 1280, H: 707},
 		},
 	}
 
@@ -114,5 +116,19 @@ func TestScreenContaining_DecidesByTheWindowsCenter(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestSameFrame_ToleratesHalfAPoint(t *testing.T) {
+	t.Parallel()
+
+	base := geometry.Rect{X: 10, Y: 20, W: 300, H: 400}
+
+	if !geometry.SameFrame(base, geometry.Rect{X: 10.4, Y: 19.6, W: 300.4, H: 400}) {
+		t.Fatal("SameFrame() = false for frames under half a point apart, want true")
+	}
+
+	if geometry.SameFrame(base, geometry.Rect{X: 10, Y: 20, W: 299, H: 400}) {
+		t.Fatal("SameFrame() = true for frames a point apart, want false")
 	}
 }

--- a/internal/geometry/rect.go
+++ b/internal/geometry/rect.go
@@ -12,6 +12,14 @@ type Rect struct {
 	H float64
 }
 
+// SameFrame reports whether two frames are the same to within the slack a
+// display can show: macOS stores window frames in whole points, so two frames
+// half a point apart are one frame.
+func SameFrame(first, second Rect) bool {
+	return adjacent(first.X, second.X) && adjacent(first.Y, second.Y) &&
+		adjacent(first.W, second.W) && adjacent(first.H, second.H)
+}
+
 // Right returns the x coordinate of the rectangle's right edge.
 func (r Rect) Right() float64 {
 	return r.X + r.W

--- a/internal/geometry/resize.go
+++ b/internal/geometry/resize.go
@@ -49,6 +49,11 @@ type Request struct {
 	// UseMargins overrides the system tiled-window-margins setting. A nil
 	// preference follows the system.
 	UseMargins *bool
+	// Cycle steps the preset through its cycle instead of applying it as it
+	// is: a window already at one of the cycle's frames moves to the next,
+	// and any other window starts at the first. Only a preset that Cycles
+	// has one; for any other it is ignored.
+	Cycle bool
 }
 
 // dimensionKind is how a requested dimension is expressed.
@@ -100,12 +105,29 @@ func (d Dimension) resolve(current, available float64) float64 {
 	case absoluteKind:
 		return d.value
 	case percentKind:
-		return available * d.value / percentageWhole
+		return snapToPoint(available * d.value / percentageWhole)
 	case keepKind:
 		return current
 	default:
 		return current
 	}
+}
+
+// pointNoise is how far a length may sit from a whole point and still be
+// that point: a third of 1920 is 640, and the floating-point product that
+// says 640.0000000000001 is not asking for anything else.
+const pointNoise = 1e-6
+
+// snapToPoint removes floating-point noise from a length that is a whole
+// number of points. A genuinely fractional length is left as it is; what
+// macOS makes of that is its own business, as it always was.
+func snapToPoint(length float64) float64 {
+	whole := math.Round(length)
+	if math.Abs(length-whole) < pointNoise {
+		return whole
+	}
+
+	return length
 }
 
 // Resize returns the frame a window at cur should be moved to on scr to
@@ -119,6 +141,11 @@ func (d Dimension) resolve(current, available float64) float64 {
 // primary display's top-left — while scr.Visible is in screen coordinates.
 // Resize converts between the two.
 func Resize(cur Rect, scr Screen, req Request) Rect {
+	if req.Cycle {
+		req.Preset = nextInCycle(cur, scr, req)
+		req.Cycle = false
+	}
+
 	req = expandPreset(req)
 
 	width := req.Width.resolve(cur.W, scr.Visible.W)
@@ -431,10 +458,23 @@ type preset struct {
 
 // The shares of the visible frame the presets are defined in.
 const (
-	wholeScreen  = percentageWhole
-	halfScreen   = 50.0
-	centerWidth  = 60.0
-	centerHeight = 80.0
+	wholeScreen     = percentageWhole
+	halfScreen      = 50.0
+	thirdScreen     = percentageWhole / 3
+	twoThirdsScreen = 2 * percentageWhole / 3
+	centerWidth     = 60.0
+	centerHeight    = 80.0
+)
+
+// The preset names that appear in more than one table: the halves and the
+// thirds they cycle through.
+const (
+	leftHalfName       = "left-half"
+	rightHalfName      = "right-half"
+	leftThirdName      = "left-third"
+	rightThirdName     = "right-third"
+	leftTwoThirdsName  = "left-two-thirds"
+	rightTwoThirdsName = "right-two-thirds"
 )
 
 // namedPreset pairs a preset with the name resize_window takes it by.
@@ -445,12 +485,12 @@ type namedPreset struct {
 
 // presets are the named tiling shortcuts resize_window accepts as its
 // positional argument, in the order the CLI's help and docs/CLI.md list them:
-// the halves, then the quadrants, then the two that need neither word. The
-// order is user-visible through PresetNames, which is what an unknown name is
-// rejected with, so this is the one place it is decided.
+// the halves, the quadrants, the thirds, then the two that need none of those
+// words. The order is user-visible through PresetNames, which is what an
+// unknown name is rejected with, so this is the one place it is decided.
 var presets = []namedPreset{
-	{"left-half", preset{widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopLeft}},
-	{"right-half", preset{widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopRight}},
+	{leftHalfName, preset{widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopLeft}},
+	{rightHalfName, preset{widthPercent: halfScreen, heightPercent: wholeScreen, anchor: TopRight}},
 	{"top-half", preset{widthPercent: wholeScreen, heightPercent: halfScreen, anchor: TopLeft}},
 	{
 		"bottom-half",
@@ -465,6 +505,23 @@ var presets = []namedPreset{
 	{
 		"bottom-right",
 		preset{widthPercent: halfScreen, heightPercent: halfScreen, anchor: BottomRight},
+	},
+	{leftThirdName, preset{widthPercent: thirdScreen, heightPercent: wholeScreen, anchor: TopLeft}},
+	{
+		"center-third",
+		preset{widthPercent: thirdScreen, heightPercent: wholeScreen, anchor: TopCenter},
+	},
+	{
+		rightThirdName,
+		preset{widthPercent: thirdScreen, heightPercent: wholeScreen, anchor: TopRight},
+	},
+	{
+		leftTwoThirdsName,
+		preset{widthPercent: twoThirdsScreen, heightPercent: wholeScreen, anchor: TopLeft},
+	},
+	{
+		rightTwoThirdsName,
+		preset{widthPercent: twoThirdsScreen, heightPercent: wholeScreen, anchor: TopRight},
 	},
 	{"center", preset{widthPercent: centerWidth, heightPercent: centerHeight, anchor: Center}},
 	{"fill", preset{widthPercent: wholeScreen, heightPercent: wholeScreen, anchor: TopLeft}},
@@ -519,7 +576,7 @@ func PresetNames() []string {
 }
 
 // presetNamed returns the preset the given name asks for, and reports whether
-// there is one. The table is ten entries long and its order is what
+// there is one. The table is fifteen entries long and its order is what
 // PresetNames reports, so it is scanned by name the way ParseAnchor scans
 // anchorNames.
 func presetNamed(name string) (preset, bool) {

--- a/internal/geometry/resize_test.go
+++ b/internal/geometry/resize_test.go
@@ -22,16 +22,21 @@ var singleDisplay = geometry.Screen{
 
 // The preset names the tests below reach for by name.
 const (
-	presetLeftHalf    = "left-half"
-	presetRightHalf   = "right-half"
-	presetTopHalf     = "top-half"
-	presetBottomHalf  = "bottom-half"
-	presetTopLeft     = "top-left"
-	presetTopRight    = "top-right"
-	presetBottomLeft  = "bottom-left"
-	presetBottomRight = "bottom-right"
-	presetCenter      = "center"
-	presetFill        = "fill"
+	presetLeftHalf       = "left-half"
+	presetRightHalf      = "right-half"
+	presetTopHalf        = "top-half"
+	presetBottomHalf     = "bottom-half"
+	presetTopLeft        = "top-left"
+	presetTopRight       = "top-right"
+	presetBottomLeft     = "bottom-left"
+	presetBottomRight    = "bottom-right"
+	presetLeftThird      = "left-third"
+	presetCenterThird    = "center-third"
+	presetRightThird     = "right-third"
+	presetLeftTwoThirds  = "left-two-thirds"
+	presetRightTwoThirds = "right-two-thirds"
+	presetCenter         = "center"
+	presetFill           = "fill"
 )
 
 // The presets the cases below place windows with, in the form a request holds
@@ -45,7 +50,7 @@ var (
 )
 
 // presetFor is ParsePreset for the names this file spells out as constants,
-// which TestParsePreset pins as ten of the ten. A name that somehow stopped
+// which TestParsePreset pins as fifteen of the fifteen. A name that somehow stopped
 // being one yields the zero preset, and the frame the case expects then fails
 // to match.
 func presetFor(name string) geometry.Preset {
@@ -217,6 +222,11 @@ func TestResize_ExpandsEveryPreset(t *testing.T) {
 		{preset: presetTopRight, want: geometry.Rect{X: 960, Y: 30, W: 960, H: 525}},
 		{preset: presetBottomLeft, want: geometry.Rect{X: 0, Y: 555, W: 960, H: 525}},
 		{preset: presetBottomRight, want: geometry.Rect{X: 960, Y: 555, W: 960, H: 525}},
+		{preset: presetLeftThird, want: geometry.Rect{X: 0, Y: 30, W: 640, H: 1050}},
+		{preset: presetCenterThird, want: geometry.Rect{X: 640, Y: 30, W: 640, H: 1050}},
+		{preset: presetRightThird, want: geometry.Rect{X: 1280, Y: 30, W: 640, H: 1050}},
+		{preset: presetLeftTwoThirds, want: geometry.Rect{X: 0, Y: 30, W: 1280, H: 1050}},
+		{preset: presetRightTwoThirds, want: geometry.Rect{X: 640, Y: 30, W: 1280, H: 1050}},
 		{preset: presetCenter, want: geometry.Rect{X: 384, Y: 135, W: 1152, H: 840}},
 		{preset: presetFill, want: geometry.Rect{X: 0, Y: 30, W: 1920, H: 1050}},
 	}
@@ -890,9 +900,14 @@ func TestParsePreset(t *testing.T) {
 		{name: presetTopRight, want: true},
 		{name: presetBottomLeft, want: true},
 		{name: presetBottomRight, want: true},
+		{name: presetLeftThird, want: true},
+		{name: presetCenterThird, want: true},
+		{name: presetRightThird, want: true},
+		{name: presetLeftTwoThirds, want: true},
+		{name: presetRightTwoThirds, want: true},
 		{name: presetCenter, want: true},
 		{name: presetFill, want: true},
-		{name: "left-third", want: false},
+		{name: "left-quarter", want: false},
 		{name: "", want: false},
 	}
 
@@ -931,6 +946,8 @@ func TestPresetNames_ListsEveryPresetInTheDocumentedOrder(t *testing.T) {
 	want := []string{
 		presetLeftHalf, presetRightHalf, presetTopHalf, presetBottomHalf,
 		presetTopLeft, presetTopRight, presetBottomLeft, presetBottomRight,
+		presetLeftThird, presetCenterThird, presetRightThird,
+		presetLeftTwoThirds, presetRightTwoThirds,
 		presetCenter, presetFill,
 	}
 

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -16,7 +16,7 @@ import (
 // older daemon would read wrongly — a renamed or removed field, or a field
 // whose meaning changed. TestRequest_EncodesTheGoldenBytes is what makes such
 // a change visible.
-const ProtocolVersion = 3
+const ProtocolVersion = 4
 
 // Request is the envelope one command travels in over the daemon's Unix
 // socket.

--- a/internal/ipc/wire_test.go
+++ b/internal/ipc/wire_test.go
@@ -107,6 +107,7 @@ func everyPayloadSet() []payloadCase {
 					AnchorSet:        true,
 					UseMargin:        true,
 					NoMargin:         true,
+					Cycle:            true,
 				},
 			},
 		},
@@ -174,7 +175,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewFocusWindowCommand(true, false, false, false, false)
 			},
-			want: `{"version":3,"command":{"name":"focus_window",` +
+			want: `{"version":4,"command":{"name":"focus_window",` +
 				`"focusWindow":{"backward":true,"direction":""}}}`,
 		},
 		{
@@ -182,14 +183,14 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewFocusWindowCommand(false, false, false, false, false)
 			},
-			want: `{"version":3,"command":{"name":"focus_window"}}`,
+			want: `{"version":4,"command":{"name":"focus_window"}}`,
 		},
 		{
 			name: "mimi action space 3",
 			build: func() (action.Command, error) {
 				return action.NewSpaceCommand([]string{"3"})
 			},
-			want: `{"version":3,"command":{"name":"space",` +
+			want: `{"version":4,"command":{"name":"space",` +
 				`"space":{"index":3,"direction":0}}}`,
 		},
 		{
@@ -197,7 +198,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewMoveWindowToSpaceCommand([]string{"next"}, true)
 			},
-			want: `{"version":3,"command":{"name":"move_window_to_space",` +
+			want: `{"version":4,"command":{"name":"move_window_to_space",` +
 				`"moveWindowToSpace":{"space":{"index":0,"direction":1},"follow":true}}}`,
 		},
 		{
@@ -205,7 +206,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewMoveWindowToDisplayCommand([]string{"prev"})
 			},
-			want: `{"version":3,"command":{"name":"move_window_to_display",` +
+			want: `{"version":4,"command":{"name":"move_window_to_display",` +
 				`"moveWindowToDisplay":{"index":0,"direction":-1}}}`,
 		},
 		{
@@ -220,7 +221,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 					NoMargin:  true,
 				})
 			},
-			want: `{"version":3,"command":{"name":"resize_window",` +
+			want: `{"version":4,"command":{"name":"resize_window",` +
 				`"resizeWindow":{"preset":"left-half",` +
 				`"width":800,"widthSet":true,` +
 				`"height":0,"heightSet":false,` +
@@ -229,7 +230,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 				`"x":0,"xSet":false,` +
 				`"y":0,"ySet":false,` +
 				`"anchor":"cc","anchorSet":true,` +
-				`"useMargin":false,"noMargin":true}}}`,
+				`"useMargin":false,"noMargin":true,"cycle":false}}}`,
 		},
 	}
 


### PR DESCRIPTION
## Description

This PR adds five thirds presets to `resize_window` and a `--cycle` flag that lets one hotkey step a half through its thirds. The preset set had halves, quadrants, center and fill, which leaves a wide display with nothing between half and full, and every hotkey doing exactly one size.

With `--cycle`, `left-half` and `right-half` step through half, two thirds and a third on repeated presses, then back to the half. The step is decided from where the window is now, measured with the same margins it is placed with, so it behaves the same on the daemon path and the direct path and keeps no state anywhere. A window at none of the cycle's frames starts at the half.

`restore` (return to the frame a window had before its last resize) was on the original list and is deliberately left out: it needs a frame remembered across one-shot invocations, and the direct path and the daemon path would need one shared store for it to behave the same on both. That is a design of its own and would not fit honestly in this PR.

## Commands and flags

| Surface | What it does |
| --- | --- |
| `resize_window left-third` / `center-third` / `right-third` | Fill a third of the screen, full height. |
| `resize_window left-two-thirds` / `right-two-thirds` | Fill two thirds of the screen, full height. |
| `resize_window left-half --cycle` / `right-half --cycle` | Step through half, two thirds, a third, and back. Default off. |

`--cycle` is rejected with any other preset, with no preset, and alongside a size, position or anchor flag. `--margin` and `--no-margin` still apply to every step. The rejection for an unknown preset now lists fifteen names instead of ten.

```bash
# ~/.skhdrc
shift + alt - h : mimi action resize_window left-half --cycle
shift + alt - l : mimi action resize_window right-half --cycle
```

## Potentially disruptive: the daemon wire version is bumped

The flag rides the command over the daemon socket, so the request protocol version moved from 3 to 4. A daemon left running across the upgrade rejects this build's requests, the CLI prints a warning naming the mismatch, and runs the action on the direct path. The warning stops after `mimi stop && mimi start`, or `mimi services restart` for an installed service. Shipped in the same release as #193 and #194, this is one restart for users, not three.

Existing configs and hotkeys keep working unchanged. Anyone who had bound a hotkey to a hypothetical `left-third` expecting a rejection would now get a resize, which is the point.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

On a 1920x1080 display with tiled margins on, the terminal window pressed four times, then two thirds presets:

```
press 1: {"frame":{"x":8,"y":38,"width":948,"height":1034}}
press 2: {"frame":{"x":8,"y":38,"width":1268,"height":1034}}
press 3: {"frame":{"x":8,"y":38,"width":628,"height":1034}}
press 4: {"frame":{"x":8,"y":38,"width":948,"height":1034}}
center-third:     {"frame":{"x":644,"y":38,"width":632,"height":1034}}
right-two-thirds: {"frame":{"x":644,"y":38,"width":1268,"height":1034}}
$ mimi action resize_window fill --cycle
Error: [INVALID_INPUT] --cycle needs a preset that cycles (left-half, right-half)
```

## Additional Context

A third of 1920 comes out of floating point as 640.0000000000001, which an exact comparison and the cycle's "already there" check both dislike. Percent-derived lengths that sit within a millionth of a point of a whole number are now snapped to it; a genuinely fractional length (75% of 1050, say) is left exactly as before, so the recorded baseline still replays unchanged.

The cycle's "already at this frame" test tolerates half a point, the same slack the resize geometry uses for edges, so a third of 2560 stored by macOS as 853 still reads as the third. An application that refuses the exact size it is handed (some terminals snap to character cells) will never match and restarts the cycle at the half on every press; that is the honest outcome, and the docs say the step is decided from where the window is.

Not extended: the recorded window baseline still covers the original ten presets. Recording the thirds needs the recorder run on a display, and is a follow-up if wanted.

Branched from #195, which it builds on for the frame comparison; the diff will shrink to this PR's own changes once that lands.
