### PR TITLE
feat(action,cli): keep focus_window within the frontmost application with --same-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | Move a window to another display | `mimi action move_window_to_display <n\|next\|prev>`                      |
 | Cycle focus between windows      | `mimi action focus_window`                                                |
 | Cycle focus backward             | `mimi action focus_window --backward`                                     |
+| Cycle within the frontmost app   | `mimi action focus_window --same-app`                                     |
 | Focus window to the left         | `mimi action focus_window --left`                                         |
 | Focus window to the right        | `mimi action focus_window --right`                                        |
 | Focus window above               | `mimi action focus_window --up`                                           |

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -23,6 +23,7 @@ Available subcommands:
 Examples:
   mimi action focus_window
   mimi action focus_window --backward
+  mimi action focus_window --same-app
   mimi action space 1
   mimi action space next
   mimi action space prev
@@ -66,6 +67,7 @@ func buildFocusWindowCommand(state *cliState) *cobra.Command {
 		focusDown  bool
 		focusLeft  bool
 		focusRight bool
+		sameApp    bool
 	)
 
 	cmd := &cobra.Command{
@@ -79,7 +81,9 @@ Cycles forward (or backward with --backward), wrapping at the end. Use
 in that direction based on screen position.
 
 Only windows that are focusable (not minimized, not hidden) and on the
-current space are included.`,
+current space are included. With --same-app, only the windows of the
+application that owns the focused window take part, whether cycling or
+moving in a direction.`,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			focusCmd, err := action.NewFocusWindowCommand(
 				backward,
@@ -87,6 +91,7 @@ current space are included.`,
 				focusDown,
 				focusLeft,
 				focusRight,
+				sameApp,
 			)
 			if err != nil {
 				return err
@@ -106,6 +111,8 @@ current space are included.`,
 		BoolVar(&focusLeft, "left", false, "Move focus to the nearest window on the left")
 	cmd.Flags().
 		BoolVar(&focusRight, "right", false, "Move focus to the nearest window on the right")
+	cmd.Flags().
+		BoolVar(&sameApp, "same-app", false, "Stay within the focused window's application")
 
 	return cmd
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -76,6 +76,7 @@ mimi action focus_window --left
 mimi action focus_window --right
 mimi action focus_window --up
 mimi action focus_window --down
+mimi action focus_window --same-app
 mimi action space 1
 mimi action space next
 mimi action space prev
@@ -100,6 +101,9 @@ Cycle keyboard focus through all focusable windows on the current space, or move
 | `--down`     | Move focus to the nearest window below the current one           |
 | `--left`     | Move focus to the nearest window to the left of the current one  |
 | `--right`    | Move focus to the nearest window to the right of the current one |
+| `--same-app` | Stay within the focused window's application, cycling or directional |
+
+`--same-app` is the keyboard's Cmd-backtick: it cycles through the windows of the frontmost application only, and combines with `--backward` or a direction flag. It needs a focused window to take the application from, and reports so when there is none.
 
 ### `mimi action space <number|next|prev>`
 

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -30,6 +30,10 @@ const (
 	// one: the input every rejection case below is written against.
 	unknownPreset = "left-quarter"
 
+	// The two directions the focus tests reach for by name.
+	directionLeft  = "left"
+	directionRight = "right"
+
 	// nonNumericArg names no space and no preset — the argument every
 	// "that is not a number or a keyword" case is written against.
 	nonNumericArg = "foo"

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -54,6 +54,9 @@ type FocusWindowArgs struct {
 	Backward bool `json:"backward"`
 	// Direction is "", "up", "down", "left", or "right".
 	Direction string `json:"direction"`
+	// SameApp confines the cycle, or the directional move, to the windows of
+	// the application that owns the focused window.
+	SameApp bool `json:"sameApp"`
 }
 
 // NewFocusWindowCommand builds focus_window's command directly from the CLI's
@@ -62,14 +65,14 @@ type FocusWindowArgs struct {
 // validateFocusWindowArgs, the same check ExecuteCommand applies to a payload
 // that arrived off the socket.
 func NewFocusWindowCommand(
-	backward, focusUp, focusDown, focusLeft, focusRight bool,
+	backward, focusUp, focusDown, focusLeft, focusRight, sameApp bool,
 ) (Command, error) {
 	direction, err := focusDirectionOf(focusUp, focusDown, focusLeft, focusRight)
 	if err != nil {
 		return Command{}, err
 	}
 
-	args := FocusWindowArgs{Backward: backward, Direction: direction}
+	args := FocusWindowArgs{Backward: backward, Direction: direction, SameApp: sameApp}
 
 	err = validateFocusWindowArgs(args)
 	if err != nil {
@@ -452,7 +455,7 @@ func (e *Executor) ExecuteCommand(cmd Command) error {
 			return err
 		}
 
-		return e.FocusWindow(cmd.FocusWindow.Backward, cmd.FocusWindow.Direction)
+		return e.FocusWindow(cmd.FocusWindow)
 	case NameSpace:
 		index, err := e.resolveSpaceArg(NameSpace, cmd.Space)
 		if err != nil {

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -16,7 +16,7 @@ import (
 func focusCommandFor(t *testing.T, backward, up, down, left, right bool) action.Command {
 	t.Helper()
 
-	cmd, err := action.NewFocusWindowCommand(backward, up, down, left, right)
+	cmd, err := action.NewFocusWindowCommand(backward, up, down, left, right, false)
 	if err != nil {
 		t.Fatalf("building %s: %v", action.NameFocusWindow, err)
 	}
@@ -77,8 +77,12 @@ func TestNewFocusWindowCommand_BuildsTheTypedPayload(t *testing.T) {
 		{name: "backward only", backward: true, want: action.FocusWindowArgs{Backward: true}},
 		{name: "up", up: true, want: action.FocusWindowArgs{Direction: "up"}},
 		{name: "down", down: true, want: action.FocusWindowArgs{Direction: "down"}},
-		{name: "left", left: true, want: action.FocusWindowArgs{Direction: "left"}},
-		{name: "right", right: true, want: action.FocusWindowArgs{Direction: "right"}},
+		{name: directionLeft, left: true, want: action.FocusWindowArgs{Direction: directionLeft}},
+		{
+			name:  directionRight,
+			right: true,
+			want:  action.FocusWindowArgs{Direction: directionRight},
+		},
 	}
 
 	for _, testCase := range tests {
@@ -91,6 +95,7 @@ func TestNewFocusWindowCommand_BuildsTheTypedPayload(t *testing.T) {
 				testCase.down,
 				testCase.left,
 				testCase.right,
+				false,
 			)
 			if err != nil {
 				t.Fatalf("NewFocusWindowCommand() error = %v, want nil", err)
@@ -110,7 +115,7 @@ func TestNewFocusWindowCommand_BuildsTheTypedPayload(t *testing.T) {
 func TestNewFocusWindowCommand_RejectsMoreThanOneDirection(t *testing.T) {
 	t.Parallel()
 
-	_, err := action.NewFocusWindowCommand(false, true, true, false, false)
+	_, err := action.NewFocusWindowCommand(false, true, true, false, false, false)
 	if err == nil {
 		t.Fatal("NewFocusWindowCommand(up, down) expected error")
 	}
@@ -123,7 +128,7 @@ func TestNewFocusWindowCommand_RejectsMoreThanOneDirection(t *testing.T) {
 func TestNewFocusWindowCommand_RejectsBackwardWithDirection(t *testing.T) {
 	t.Parallel()
 
-	_, err := action.NewFocusWindowCommand(true, true, false, false, false)
+	_, err := action.NewFocusWindowCommand(true, true, false, false, false, false)
 	if err == nil {
 		t.Fatal("NewFocusWindowCommand(backward, up) expected error")
 	}

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -25,10 +25,12 @@ func NewExecutor(desktop Desktop) *Executor {
 }
 
 // FocusWindow cycles keyboard focus through focusable windows on the active
-// space. When direction is set ("up", "down", "left", "right"), it moves focus
-// spatially to the nearest window in that direction. Otherwise it cycles
-// forward or backward through the sorted window list.
-func (e *Executor) FocusWindow(backward bool, direction string) error {
+// space. When a direction is set ("up", "down", "left", "right"), it moves
+// focus spatially to the nearest window in that direction. Otherwise it cycles
+// forward or backward through the sorted window list. With SameApp, only the
+// windows of the application owning the focused window take part, in either
+// mode.
+func (e *Executor) FocusWindow(args FocusWindowArgs) error {
 	err := e.desktop.EnsureAccessible()
 	if err != nil {
 		return err
@@ -46,8 +48,15 @@ func (e *Executor) FocusWindow(backward bool, direction string) error {
 		)
 	}
 
-	if direction != "" {
-		dir, err := parseFocusDirection(direction)
+	if args.SameApp {
+		windows, focusedIndex, err = sameApplicationOnly(windows, focusedIndex)
+		if err != nil {
+			return err
+		}
+	}
+
+	if args.Direction != "" {
+		dir, err := parseFocusDirection(args.Direction)
 		if err != nil {
 			return err
 		}
@@ -55,7 +64,7 @@ func (e *Executor) FocusWindow(backward bool, direction string) error {
 		return e.focusDirectional(windows, focusedIndex, dir)
 	}
 
-	targetIndex := cycleTarget(focusedIndex, len(windows), backward)
+	targetIndex := cycleTarget(focusedIndex, len(windows), args.Backward)
 
 	err = e.desktop.ActivateWindow(windows[targetIndex].ID)
 	if err != nil {
@@ -170,6 +179,45 @@ func (e *Executor) ResizeWindow(req geometry.Request) error {
 	}
 
 	return e.desktop.SetWindowFrame(win.ID, geometry.Resize(current, screen, req))
+}
+
+// sameApplicationOnly narrows windows to those owned by the same application
+// as windows[focusedIndex], keeping their order, and reports where the focused
+// window now sits. It is the focused window that names the application: with
+// nothing focused there is no application to stay within, and a window whose
+// owner cannot be read (pid 0) names none either.
+func sameApplicationOnly(windows []Window, focusedIndex int) ([]Window, int, error) {
+	if focusedIndex < 0 || focusedIndex >= len(windows) {
+		return nil, -1, derrors.New(
+			derrors.CodeActionFailed,
+			"no focused window, so no application to stay within",
+		)
+	}
+
+	pid := windows[focusedIndex].PID
+	if pid == 0 {
+		return nil, -1, derrors.New(
+			derrors.CodeActionFailed,
+			"cannot tell which application owns the focused window",
+		)
+	}
+
+	kept := make([]Window, 0, len(windows))
+	keptFocused := -1
+
+	for index, win := range windows {
+		if win.PID != pid {
+			continue
+		}
+
+		if index == focusedIndex {
+			keptFocused = len(kept)
+		}
+
+		kept = append(kept, win)
+	}
+
+	return kept, keptFocused, nil
 }
 
 // ensureSpaceExists is the one range check both space actions share. A space

--- a/internal/action/focus_same_app_test.go
+++ b/internal/action/focus_same_app_test.go
@@ -1,0 +1,149 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// Two applications interleaved in a row of five windows: app A owns windows
+// 1, 3 and 5, app B owns 2 and 4. Focus starts on window 3.
+const (
+	appA = 100
+	appB = 200
+)
+
+func twoAppsInterleaved(focused int) *fakeDesktop {
+	desktop := rowOfWindows(5, focused)
+	for index := range desktop.windows {
+		if index%2 == 0 {
+			desktop.windows[index].pid = appA
+		} else {
+			desktop.windows[index].pid = appB
+		}
+	}
+
+	return desktop
+}
+
+func sameApp(args action.FocusWindowArgs) action.FocusWindowArgs {
+	args.SameApp = true
+
+	return args
+}
+
+func TestExecutor_FocusWindow_SameAppSkipsOtherApplicationsWindows(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args action.FocusWindowArgs
+		want action.WindowID
+	}{
+		{name: "forward", args: action.FocusWindowArgs{}, want: 5},
+		{name: "backward", args: action.FocusWindowArgs{Backward: true}, want: 1},
+		{name: directionRight, args: action.FocusWindowArgs{Direction: directionRight}, want: 5},
+		{name: directionLeft, args: action.FocusWindowArgs{Direction: directionLeft}, want: 1},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := twoAppsInterleaved(2)
+
+			err := action.NewExecutor(desktop).FocusWindow(sameApp(testCase.args))
+			if err != nil {
+				t.Fatalf("FocusWindow(same-app %s) error = %v, want nil", testCase.name, err)
+			}
+
+			wantFocused(t, desktop, testCase.want)
+		})
+	}
+}
+
+func TestExecutor_FocusWindow_SameAppWrapsWithinTheApplication(t *testing.T) {
+	t.Parallel()
+
+	desktop := twoAppsInterleaved(4)
+
+	err := action.NewExecutor(desktop).FocusWindow(sameApp(action.FocusWindowArgs{}))
+	if err != nil {
+		t.Fatalf("FocusWindow(same-app) error = %v, want nil", err)
+	}
+
+	wantFocused(t, desktop, 1)
+}
+
+// TestExecutor_FocusWindow_SameAppWithOneWindowStaysPut: an application with
+// a single window has nowhere to cycle to, and that is not an error.
+func TestExecutor_FocusWindow_SameAppWithOneWindowStaysPut(t *testing.T) {
+	t.Parallel()
+
+	desktop := twoAppsInterleaved(1)
+	desktop.windows[3].pid = appA
+
+	err := action.NewExecutor(desktop).FocusWindow(sameApp(action.FocusWindowArgs{}))
+	if err != nil {
+		t.Fatalf("FocusWindow(same-app) error = %v, want nil", err)
+	}
+
+	wantFocused(t, desktop, 2)
+}
+
+func TestExecutor_FocusWindow_SameAppNeedsAFocusedWindow(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		desktop func() *fakeDesktop
+	}{
+		{name: "nothing focused", desktop: func() *fakeDesktop { return twoAppsInterleaved(-1) }},
+		{
+			name: "owner unreadable",
+			desktop: func() *fakeDesktop {
+				desktop := twoAppsInterleaved(2)
+				desktop.windows[2].pid = 0
+
+				return desktop
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := testCase.desktop()
+			before := desktop.focusedID()
+
+			err := action.NewExecutor(desktop).FocusWindow(sameApp(action.FocusWindowArgs{}))
+			if err == nil {
+				t.Fatal("FocusWindow(same-app) error = nil, want an error")
+			}
+
+			if !derrors.IsCode(err, derrors.CodeActionFailed) {
+				t.Fatalf("error = %v, want an action failure", err)
+			}
+
+			wantFocused(t, desktop, before)
+		})
+	}
+}
+
+// TestNewFocusWindowCommand_CarriesSameApp pins the flag onto the payload the
+// socket carries.
+func TestNewFocusWindowCommand_CarriesSameApp(t *testing.T) {
+	t.Parallel()
+
+	cmd, err := action.NewFocusWindowCommand(true, false, false, false, false, true)
+	if err != nil {
+		t.Fatalf("NewFocusWindowCommand(backward, same-app) error = %v, want nil", err)
+	}
+
+	want := action.FocusWindowArgs{Backward: true, SameApp: true}
+	if cmd.FocusWindow != want {
+		t.Fatalf("FocusWindow = %+v, want %+v", cmd.FocusWindow, want)
+	}
+}

--- a/internal/action/focus_test.go
+++ b/internal/action/focus_test.go
@@ -26,7 +26,7 @@ func TestExecutor_FocusWindow_ForwardCyclingWrapsToFirst(t *testing.T) {
 
 	desktop := desktopWithWindows(3, 2)
 
-	err := action.NewExecutor(desktop).FocusWindow(false, "")
+	err := action.NewExecutor(desktop).FocusWindow(action.FocusWindowArgs{})
 	if err != nil {
 		t.Fatalf("FocusWindow() error = %v, want nil", err)
 	}
@@ -39,7 +39,7 @@ func TestExecutor_FocusWindow_BackwardCyclingWrapsToLast(t *testing.T) {
 
 	desktop := desktopWithWindows(3, 0)
 
-	err := action.NewExecutor(desktop).FocusWindow(true, "")
+	err := action.NewExecutor(desktop).FocusWindow(action.FocusWindowArgs{Backward: true})
 	if err != nil {
 		t.Fatalf("FocusWindow() error = %v, want nil", err)
 	}
@@ -56,7 +56,7 @@ func TestExecutor_FocusWindow_DoesNotRefreshWorkspaceTitle(t *testing.T) {
 
 	desktop := desktopWithWindows(3, 2)
 
-	err := action.NewExecutor(desktop).FocusWindow(false, "")
+	err := action.NewExecutor(desktop).FocusWindow(action.FocusWindowArgs{})
 	if err != nil {
 		t.Fatalf("FocusWindow() error = %v, want nil", err)
 	}
@@ -81,7 +81,8 @@ func TestExecutor_FocusWindow_UnfocusedDesktopFallsBackToFirstWindow(t *testing.
 
 			desktop := desktopWithWindows(3, -1)
 
-			err := action.NewExecutor(desktop).FocusWindow(testCase.backward, "")
+			err := action.NewExecutor(desktop).
+				FocusWindow(action.FocusWindowArgs{Backward: testCase.backward})
 			if err != nil {
 				t.Fatalf("FocusWindow() error = %v, want nil", err)
 			}
@@ -100,7 +101,8 @@ func TestExecutor_FocusWindow_DirectionalSkipsAWindowWhoseFrameCannotBeRead(t *t
 		"failed to get window frame",
 	)
 
-	err := action.NewExecutor(desktop).FocusWindow(false, "right")
+	err := action.NewExecutor(desktop).
+		FocusWindow(action.FocusWindowArgs{Direction: directionRight})
 	if err != nil {
 		t.Fatalf("FocusWindow() error = %v, want nil", err)
 	}
@@ -113,7 +115,7 @@ func TestExecutor_FocusWindow_DirectionalErrorsWhenNothingLiesThatWay(t *testing
 
 	desktop := rowOfWindows(3, 0)
 
-	err := action.NewExecutor(desktop).FocusWindow(false, "left")
+	err := action.NewExecutor(desktop).FocusWindow(action.FocusWindowArgs{Direction: directionLeft})
 	if err == nil {
 		t.Fatal("FocusWindow() error = nil, want an error")
 	}
@@ -130,7 +132,7 @@ func TestExecutor_FocusWindow_ErrorsWhenTheActiveSpaceHasNoFocusableWindows(t *t
 
 	desktop := desktopWithWindows(0, -1)
 
-	err := action.NewExecutor(desktop).FocusWindow(false, "")
+	err := action.NewExecutor(desktop).FocusWindow(action.FocusWindowArgs{})
 	if err == nil {
 		t.Fatal("FocusWindow() error = nil, want an error")
 	}

--- a/internal/baseline/focus_integration_test.go
+++ b/internal/baseline/focus_integration_test.go
@@ -128,6 +128,7 @@ func (h *harness) runFocus(t *testing.T, center *native.Element, dir string) bas
 		dir == dirDown,
 		dir == dirLeft,
 		dir == dirRight,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("focus_window --%s is not a command: %v", dir, err)

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -16,7 +16,7 @@ import (
 // older daemon would read wrongly — a renamed or removed field, or a field
 // whose meaning changed. TestRequest_EncodesTheGoldenBytes is what makes such
 // a change visible.
-const ProtocolVersion = 4
+const ProtocolVersion = 5
 
 // Request is the envelope one command travels in over the daemon's Unix
 // socket.

--- a/internal/ipc/wire_test.go
+++ b/internal/ipc/wire_test.go
@@ -41,8 +41,12 @@ func everyPayloadSet() []payloadCase {
 		{
 			name: "focus_window with every field set",
 			cmd: action.Command{
-				Name:        action.NameFocusWindow,
-				FocusWindow: action.FocusWindowArgs{Backward: true, Direction: "right"},
+				Name: action.NameFocusWindow,
+				FocusWindow: action.FocusWindowArgs{
+					Backward:  true,
+					Direction: "right",
+					SameApp:   true,
+				},
 			},
 		},
 		{
@@ -173,24 +177,24 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 		{
 			name: "mimi action focus_window --backward",
 			build: func() (action.Command, error) {
-				return action.NewFocusWindowCommand(true, false, false, false, false)
+				return action.NewFocusWindowCommand(true, false, false, false, false, false)
 			},
-			want: `{"version":4,"command":{"name":"focus_window",` +
-				`"focusWindow":{"backward":true,"direction":""}}}`,
+			want: `{"version":5,"command":{"name":"focus_window",` +
+				`"focusWindow":{"backward":true,"direction":"","sameApp":false}}}`,
 		},
 		{
 			name: "mimi action focus_window",
 			build: func() (action.Command, error) {
-				return action.NewFocusWindowCommand(false, false, false, false, false)
+				return action.NewFocusWindowCommand(false, false, false, false, false, false)
 			},
-			want: `{"version":4,"command":{"name":"focus_window"}}`,
+			want: `{"version":5,"command":{"name":"focus_window"}}`,
 		},
 		{
 			name: "mimi action space 3",
 			build: func() (action.Command, error) {
 				return action.NewSpaceCommand([]string{"3"})
 			},
-			want: `{"version":4,"command":{"name":"space",` +
+			want: `{"version":5,"command":{"name":"space",` +
 				`"space":{"index":3,"direction":0}}}`,
 		},
 		{
@@ -198,7 +202,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewMoveWindowToSpaceCommand([]string{"next"}, true)
 			},
-			want: `{"version":4,"command":{"name":"move_window_to_space",` +
+			want: `{"version":5,"command":{"name":"move_window_to_space",` +
 				`"moveWindowToSpace":{"space":{"index":0,"direction":1},"follow":true}}}`,
 		},
 		{
@@ -206,7 +210,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewMoveWindowToDisplayCommand([]string{"prev"})
 			},
-			want: `{"version":4,"command":{"name":"move_window_to_display",` +
+			want: `{"version":5,"command":{"name":"move_window_to_display",` +
 				`"moveWindowToDisplay":{"index":0,"direction":-1}}}`,
 		},
 		{
@@ -221,7 +225,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 					NoMargin:  true,
 				})
 			},
-			want: `{"version":4,"command":{"name":"resize_window",` +
+			want: `{"version":5,"command":{"name":"resize_window",` +
 				`"resizeWindow":{"preset":"left-half",` +
 				`"width":800,"widthSet":true,` +
 				`"height":0,"heightSet":false,` +


### PR DESCRIPTION
## Description

This PR adds a `--same-app` flag to `focus_window`, so a hotkey can step between the windows of the frontmost application without passing every other application's windows on the way. It is the keyboard's Cmd-backtick, done through mimi so it can be rebound, run backward, or combined with a direction.

Only the windows of the application that owns the focused window take part, in either mode: cycling wraps within them, and a direction flag finds the nearest window of that application in that direction. An application with a single window stays put, which is not an error. With nothing focused there is no application to stay within, and the command says so.

## Commands and flags

| Surface | What it does |
| --- | --- |
| `mimi action focus_window --same-app` | Cycle forward within the focused window's application. Default off. |
| `... --same-app --backward` | Cycle backward within it. |
| `... --same-app --left` (or `--right`, `--up`, `--down`) | Move to that application's nearest window in that direction. |

```bash
# ~/.skhdrc
alt - grave : mimi action focus_window --same-app
```

## Potentially disruptive: the daemon wire version is bumped

The flag rides the command over the daemon socket, so the request protocol version moved from 4 to 5. A daemon left running across the upgrade rejects this build's requests, the CLI prints a warning naming the mismatch, and runs the action on the direct path. The warning stops after `mimi stop && mimi start`, or `mimi services restart` for an installed service. Shipped with #193, #194 and #196, this is still one restart for users.

Existing configs and hotkeys keep working unchanged.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

From a terminal that owns one window on the space:

```
$ ./bin/mimi action focus_window --same-app      # exit 0, focus stays on the terminal
$ ./bin/mimi action focus_window --same-app --backward --left
Error: [INVALID_INPUT] --backward cannot be combined with a direction flag
```

The multi-window behaviour (skipping other applications' windows, wrapping within the application, directional moves within it, and the two failure cases) is pinned by unit tests against the fake desktop, since a scripted check from a single terminal window cannot show a cycle.

## Additional Context

The application is taken from the focused window's process ID, which the window enumeration already carried. The executor's focus entry point now takes the typed focus payload rather than two loose parameters, which is an internal signature only.
