### PR TITLE
feat(config,hooks): filter workspace hooks by space and negate any hook filter with !

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The `[systray]` block shows the active space number in your menu bar while the d
 | Window resized         | `on_window_resize`                       | Yes                 |
 | Active space changed   | `on_workspace_changed`                   | No                  |
 
-Hooks support app/title filters, async execution, and per-hook timeouts.
+Hooks support app, bundle, title and space filters, each negatable with a leading `!`, plus async execution and per-hook timeouts.
 Full details → [Configuration Guide](docs/CONFIGURATION.md)
 
 ### Daemon commands

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -141,5 +141,7 @@ show_workspace_number = true
 
 # Active Space / Desktop changed (Mission Control).
 # on_workspace_changed = [
-#     "echo 'workspace changed'"
+#     "echo 'workspace changed'",
+#     { run = "echo on the second space", space = 2 },
+#     { run = "echo on any other space", space = "!2" },
 # ]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -255,8 +255,24 @@ on_window_focus = [
 | `app` | Filter by app name (glob) |
 | `bundle_id` | Filter by bundle ID (exact) |
 | `title` | Filter by window title (regex) |
+| `space` | Filter by the space now in front, as a 1-based number. Workspace hooks only |
 | `timeout_secs` | Override global timeout |
 | `async` | Run in background (default: false) |
+
+**Negating a filter:** an `app`, `bundle_id`, `title` or `space` filter that begins with `!` matches everything the pattern does not. `app = "!Safari"` fires for every application but Safari; `space = "!2"` fires for every space but the second. A filter that is only `!` is rejected. The space filter is written as a bare number (`space = 2`) or, when negated, as a string.
+
+```toml
+[hooks]
+on_workspace_changed = [
+  { run = "sketchybar --trigger work_mode", space = 2 },
+  { run = "sketchybar --trigger normal_mode", space = "!2" },
+]
+on_window_focus = [
+  { run = "echo focus", app = "!Terminal" }
+]
+```
+
+A workspace event that could not resolve its space (Mission Control could not be enumerated) carries no space number; it fails every `space` filter and passes every negated one.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
@@ -80,11 +81,17 @@ type HooksConfig struct {
 }
 
 // HookEntry defines a single hook command and its optional filters.
+//
+// App, BundleID, Title and Space may each begin with "!" to match everything
+// the pattern does not; see SplitNegation. Space is a 1-based space number
+// kept as a string so that the negated form has somewhere to live, and is
+// accepted as a bare number in TOML as well.
 type HookEntry struct {
 	Run         string `json:"run"         toml:"run"`
 	App         string `json:"app"         toml:"app"`
 	BundleID    string `json:"bundleId"    toml:"bundle_id"`
 	Title       string `json:"title"       toml:"title"`
+	Space       string `json:"space"       toml:"space"`
 	TimeoutSecs int    `json:"timeoutSecs" toml:"timeout_secs"`
 	Async       bool   `json:"async"       toml:"async"`
 }
@@ -137,6 +144,22 @@ func decodeHooks(raw rawHooksConfig) (HooksConfig, []string, error) {
 					BundleID: getString(val, "bundle_id"),
 					Title:    getString(val, "title"),
 				}
+
+				space, ok := getSpace(val)
+				if !ok {
+					errs = append(
+						errs,
+						fmt.Sprintf(
+							"hooks.%s[%d]: space must be a number or a string, got %T",
+							field,
+							idx,
+							val["space"],
+						),
+					)
+				}
+
+				entry.Space = space
+
 				if timeout, ok := getInt(val, "timeout_secs"); ok {
 					entry.TimeoutSecs = timeout
 				}
@@ -236,6 +259,28 @@ func getString(m map[string]any, key string) string {
 	}
 
 	return ""
+}
+
+// getSpace reads a hook's space filter, which TOML delivers as a number when
+// written bare (space = 2) and as a string when negated (space = "!2"). Both
+// spell the same filter. An absent key is the empty filter; a value of any
+// other type is reported as false.
+func getSpace(m map[string]any) (string, bool) {
+	value, ok := m["space"]
+	if !ok {
+		return "", true
+	}
+
+	switch space := value.(type) {
+	case string:
+		return space, true
+	case int64:
+		return strconv.FormatInt(space, 10), true
+	case float64:
+		return strconv.Itoa(int(space)), true
+	default:
+		return "", false
+	}
 }
 
 func getInt(m map[string]any, key string) (int, bool) {

--- a/internal/config/filters.go
+++ b/internal/config/filters.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// negation is the prefix that inverts a hook filter: "!Safari" matches every
+// application but Safari.
+const negation = "!"
+
+// SplitNegation reads a hook filter's negation prefix off the front of it,
+// returning the pattern that is left and whether it was negated. It is the
+// one place the prefix is read, shared by validation and by the registry
+// that matches events against it, so both agree on what "!" means.
+func SplitNegation(pattern string) (string, bool) {
+	rest, negated := strings.CutPrefix(pattern, negation)
+
+	return rest, negated
+}
+
+// ParseSpaceFilter reads a hook's space filter: a 1-based space number,
+// optionally negated, as a string so that "!2" has somewhere to live. It
+// returns the number in the form workspace events carry it, so the registry
+// compares two strings written by the same function, and whether the filter
+// is negated.
+func ParseSpaceFilter(filter string) (string, bool, error) {
+	pattern, negated := SplitNegation(filter)
+
+	index, err := strconv.Atoi(strings.TrimSpace(pattern))
+	if err != nil || index < 1 {
+		return "", false, derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"space must be a 1-based space number, optionally prefixed with %s (got %q)",
+			negation,
+			filter,
+		)
+	}
+
+	return strconv.Itoa(index), negated, nil
+}
+
+// validateFilters holds the rules a hook entry's filters are held to beyond
+// what compiles: a filter that is nothing but the negation prefix names
+// nothing to negate, and a space filter only means something on a hook whose
+// events carry a space.
+func validateFilters(kind HookKind, entry HookEntry) []string {
+	var errs []string
+
+	for name, filter := range map[string]string{
+		"app":       entry.App,
+		"bundle_id": entry.BundleID,
+		"title":     entry.Title,
+	} {
+		if filter == negation {
+			errs = append(errs, name+" filter is only a "+negation+", with nothing to negate")
+		}
+	}
+
+	if entry.Space == "" {
+		return sortedErrs(errs)
+	}
+
+	if kind.Group != GroupWorkspace {
+		errs = append(errs, "space applies to workspace hooks only")
+	}
+
+	_, _, err := ParseSpaceFilter(entry.Space)
+	if err != nil {
+		errs = append(errs, derrors.Message(err))
+	}
+
+	return sortedErrs(errs)
+}
+
+// sortedErrs orders a filter's problems so the same config reports the same
+// way on every run; the filters are checked out of a map.
+func sortedErrs(errs []string) []string {
+	slices.Sort(errs)
+
+	return errs
+}

--- a/internal/config/filters_test.go
+++ b/internal/config/filters_test.go
@@ -1,0 +1,133 @@
+package config //nolint:testpackage // uses the writeConfig helper beside decode_test.go
+
+import (
+	"strings"
+	"testing"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+func TestParseSpaceFilter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		filter      string
+		wantIndex   string
+		wantNegated bool
+		wantErr     bool
+	}{
+		{filter: "2", wantIndex: "2"},
+		{filter: "!2", wantIndex: "2", wantNegated: true},
+		{filter: " 07 ", wantIndex: "7"},
+		{filter: "0", wantErr: true},
+		{filter: "!", wantErr: true},
+		{filter: "next", wantErr: true},
+		{filter: "", wantErr: true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.filter, func(t *testing.T) {
+			t.Parallel()
+
+			index, negated, err := ParseSpaceFilter(testCase.filter)
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSpaceFilter(%q) error = nil, want an error", testCase.filter)
+				}
+
+				if !derrors.IsCode(err, derrors.CodeInvalidConfig) {
+					t.Fatalf("error = %v, want invalid config", err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseSpaceFilter(%q) error = %v, want nil", testCase.filter, err)
+			}
+
+			if index != testCase.wantIndex || negated != testCase.wantNegated {
+				t.Fatalf(
+					"ParseSpaceFilter(%q) = %q, %v, want %q, %v",
+					testCase.filter, index, negated, testCase.wantIndex, testCase.wantNegated,
+				)
+			}
+		})
+	}
+}
+
+// TestLoad_SpaceFilterIsAcceptedAsANumberOrAString pins the two spellings a
+// space filter takes in TOML: a bare number, and a string when negated.
+func TestLoad_SpaceFilterIsAcceptedAsANumberOrAString(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"number":         "[hooks]\non_workspace_changed = [{ run = \"true\", space = 2 }]\n",
+		"string":         "[hooks]\non_workspace_changed = [{ run = \"true\", space = \"2\" }]\n",
+		"negated string": "[hooks]\non_workspace_changed = [{ run = \"true\", space = \"!2\" }]\n",
+	}
+	want := map[string]string{"number": "2", "string": "2", "negated string": "!2"}
+
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := Load(writeConfig(t, src))
+			if err != nil {
+				t.Fatalf("Load() error = %v, want nil", err)
+			}
+
+			if got := cfg.Hooks.WorkspaceChanged[0].Space; got != want[name] {
+				t.Fatalf("Space = %q, want %q", got, want[name])
+			}
+		})
+	}
+}
+
+// TestLoad_RejectsFiltersThatCannotMean: a space filter on a hook whose
+// events carry no space, a space that is not one, and a filter that is only
+// the negation prefix are all reported by the key the user typed.
+func TestLoad_RejectsFiltersThatCannotMean(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		src  string
+		want string
+	}{
+		"space on a window hook": {
+			src:  "[hooks]\non_window_focus = [{ run = \"true\", space = 2 }]\n",
+			want: "hooks.on_window_focus[0]: space applies to workspace hooks only",
+		},
+		"space zero": {
+			src:  "[hooks]\non_workspace_changed = [{ run = \"true\", space = 0 }]\n",
+			want: "hooks.on_workspace_changed[0]: space must be a 1-based space number",
+		},
+		"space that is a word": {
+			src:  "[hooks]\non_workspace_changed = [{ run = \"true\", space = \"next\" }]\n",
+			want: "hooks.on_workspace_changed[0]: space must be a 1-based space number",
+		},
+		"space of another type": {
+			src:  "[hooks]\non_workspace_changed = [{ run = \"true\", space = true }]\n",
+			want: "hooks.on_workspace_changed[0]: space must be a number or a string",
+		},
+		"app filter that is only a !": {
+			src:  "[hooks]\non_app_activate = [{ run = \"true\", app = \"!\" }]\n",
+			want: "hooks.on_app_activate[0]: app filter is only a !",
+		},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Load(writeConfig(t, testCase.src))
+			if err == nil {
+				t.Fatal("Load() error = nil, want a rejection")
+			}
+
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("Load() error = %v, want it to contain %q", err, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -209,11 +209,18 @@ func validate(cfg *Config) error {
 	// it alone so that a hook written as a bare string and one written as a
 	// table report the same way.
 	for _, kind := range HookKinds {
-		for i, e := range *kind.Entries(&cfg.Hooks) {
-			if e.Run == "" {
+		for index, entry := range *kind.Entries(&cfg.Hooks) {
+			if entry.Run == "" {
 				errs = append(
 					errs,
-					fmt.Sprintf("hooks.%s[%d]: run command is empty", kind.TOMLKey, i),
+					fmt.Sprintf("hooks.%s[%d]: run command is empty", kind.TOMLKey, index),
+				)
+			}
+
+			for _, problem := range validateFilters(kind, entry) {
+				errs = append(
+					errs,
+					fmt.Sprintf("hooks.%s[%d]: %s", kind.TOMLKey, index, problem),
 				)
 			}
 		}

--- a/internal/hooks/registry.go
+++ b/internal/hooks/registry.go
@@ -12,13 +12,33 @@ import (
 // Hook wraps a HookEntry with its compiled title regex and any precomputed
 // filter regexes so that per-event matching is allocation-free.
 type Hook struct {
-	Entry       config.HookEntry
-	titleRegexp *regexp.Regexp
-	// appRegexp is the compiled glob from Entry.App, or nil when not set.
-	appRegexp *regexp.Regexp
-	// bundleRegexp is the compiled glob from Entry.BundleID, or nil when
-	// not set. Glob is used for symmetry with Entry.App.
-	bundleRegexp *regexp.Regexp
+	Entry config.HookEntry
+	title filter
+	app   filter
+	// bundle is the compiled glob from Entry.BundleID. Glob is used for
+	// symmetry with Entry.App.
+	bundle filter
+	// space is the space index the hook is filtered to, in the form
+	// workspace events carry it, or "" for no filter.
+	space        string
+	spaceNegated bool
+}
+
+// filter is one compiled pattern filter: nil when the entry set none, and
+// inverted when the entry negated it.
+type filter struct {
+	re      *regexp.Regexp
+	negated bool
+}
+
+// matches reports whether the filter admits value. An unset filter, or the
+// catch-all "*", admits everything; negated, the catch-all admits nothing.
+func (f filter) matches(value string) bool {
+	if f.re == nil {
+		return !f.negated
+	}
+
+	return f.re.MatchString(value) != f.negated
 }
 
 // Registry maps event kinds to their registered hooks.
@@ -67,18 +87,28 @@ func (r *Registry) KindFilter() events.KindFilter {
 	}
 }
 
-// Matches checks whether a hook's filters (app, bundle_id, title) match an event.
+// Matches checks whether a hook's filters (app, bundle_id, title, space)
+// match an event.
+//
+// The space filter reads the index a workspace event carries. An event that
+// carries none, because Mission Control could not be enumerated when it was
+// published, matches no positive space filter and every negated one: the
+// event does not say it is on that space.
 func (h *Hook) Matches(evt events.Event) (bool, string) {
-	if h.appRegexp != nil && !h.appRegexp.MatchString(evt.AppName) {
+	if !h.app.matches(evt.AppName) {
 		return false, "app filter mismatch"
 	}
 
-	if h.bundleRegexp != nil && !h.bundleRegexp.MatchString(evt.BundleID) {
+	if !h.bundle.matches(evt.BundleID) {
 		return false, "bundle_id filter mismatch"
 	}
 
-	if h.titleRegexp != nil && !h.titleRegexp.MatchString(evt.WindowTitle) {
+	if !h.title.matches(evt.WindowTitle) {
 		return false, "title filter mismatch"
+	}
+
+	if h.space != "" && (evt.Extra["space_index"] == h.space) == h.spaceNegated {
+		return false, "space filter mismatch"
 	}
 
 	return true, ""
@@ -96,31 +126,29 @@ func buildMap(cfg *config.Config) (map[events.EventKind][]Hook, error) {
 		var hooks []Hook
 		for _, entry := range *kind.Entries(&cfg.Hooks) {
 			hook := Hook{Entry: entry}
-			if entry.Title != "" {
-				re, err := regexp.Compile(entry.Title)
-				if err != nil {
-					return nil, err
-				}
 
-				hook.titleRegexp = re
+			var err error
+
+			hook.title, err = compileFilter(entry.Title, regexp.Compile)
+			if err != nil {
+				return nil, err
 			}
 
-			if entry.App != "" {
-				re, err := compileGlob(entry.App)
-				if err != nil {
-					return nil, err
-				}
-
-				hook.appRegexp = re
+			hook.app, err = compileFilter(entry.App, compileGlob)
+			if err != nil {
+				return nil, err
 			}
 
-			if entry.BundleID != "" {
-				re, err := compileGlob(entry.BundleID)
+			hook.bundle, err = compileFilter(entry.BundleID, compileGlob)
+			if err != nil {
+				return nil, err
+			}
+
+			if entry.Space != "" {
+				hook.space, hook.spaceNegated, err = config.ParseSpaceFilter(entry.Space)
 				if err != nil {
 					return nil, err
 				}
-
-				hook.bundleRegexp = re
 			}
 
 			hooks = append(hooks, hook)
@@ -132,6 +160,26 @@ func buildMap(cfg *config.Config) (map[events.EventKind][]Hook, error) {
 	}
 
 	return hookMap, nil
+}
+
+// compileFilter compiles one pattern filter with the given compiler, reading
+// the negation prefix off it first. An empty pattern is no filter.
+func compileFilter(
+	pattern string,
+	compile func(string) (*regexp.Regexp, error),
+) (filter, error) {
+	if pattern == "" {
+		return filter{}, nil
+	}
+
+	rest, negated := config.SplitNegation(pattern)
+
+	re, err := compile(rest)
+	if err != nil {
+		return filter{}, err
+	}
+
+	return filter{re: re, negated: negated}, nil
 }
 
 // compileGlob converts a glob-style pattern (with `*` wildcards) to an

--- a/internal/hooks/registry_test.go
+++ b/internal/hooks/registry_test.go
@@ -19,6 +19,9 @@ const (
 	testBundleGlob   = "org.example.*"
 	testBundleIDHit  = "org.example.App"
 	testBundleIDMiss = "com.other.App"
+	// testSpaceIndexKey is the Extra key a workspace event carries its space
+	// under, which the space filter reads.
+	testSpaceIndexKey = "space_index"
 )
 
 // allHookableKinds mirrors the twelve entries buildMap's literal map wires
@@ -213,6 +216,72 @@ func TestHookMatches(t *testing.T) {
 			entry: config.HookEntry{Run: testHookRun, BundleID: testBundleGlob},
 			evt:   events.Event{BundleID: testBundleIDMiss},
 			want:  false,
+		},
+		{
+			name:  "negated app glob admits every other app",
+			entry: config.HookEntry{Run: testHookRun, App: "!" + testAppGlob},
+			evt:   events.Event{AppName: testAppNameMiss},
+			want:  true,
+		},
+		{
+			name:  "negated app glob refuses the app it names",
+			entry: config.HookEntry{Run: testHookRun, App: "!" + testAppGlob},
+			evt:   events.Event{AppName: testAppName},
+			want:  false,
+		},
+		{
+			name:  "negated title regexp refuses a title it matches",
+			entry: config.HookEntry{Run: testHookRun, Title: "!" + testTitleRegex},
+			evt:   events.Event{WindowTitle: testWindowTitle},
+			want:  false,
+		},
+		{
+			name:  "negated bundle_id glob admits another bundle",
+			entry: config.HookEntry{Run: testHookRun, BundleID: "!" + testBundleGlob},
+			evt:   events.Event{BundleID: testBundleIDMiss},
+			want:  true,
+		},
+		{
+			name:  "negated catch-all admits nothing",
+			entry: config.HookEntry{Run: testHookRun, App: "!*"},
+			evt:   events.Event{AppName: testAppName},
+			want:  false,
+		},
+		{
+			name:  "space filter hit",
+			entry: config.HookEntry{Run: testHookRun, Space: "2"},
+			evt:   events.Event{Extra: map[string]string{testSpaceIndexKey: "2"}},
+			want:  true,
+		},
+		{
+			name:  "space filter miss",
+			entry: config.HookEntry{Run: testHookRun, Space: "2"},
+			evt:   events.Event{Extra: map[string]string{testSpaceIndexKey: "3"}},
+			want:  false,
+		},
+		{
+			name:  "space filter written with a leading zero still names the space",
+			entry: config.HookEntry{Run: testHookRun, Space: "02"},
+			evt:   events.Event{Extra: map[string]string{testSpaceIndexKey: "2"}},
+			want:  true,
+		},
+		{
+			name:  "negated space filter admits another space",
+			entry: config.HookEntry{Run: testHookRun, Space: "!2"},
+			evt:   events.Event{Extra: map[string]string{testSpaceIndexKey: "3"}},
+			want:  true,
+		},
+		{
+			name:  "an event carrying no space misses a space filter",
+			entry: config.HookEntry{Run: testHookRun, Space: "2"},
+			evt:   events.Event{},
+			want:  false,
+		},
+		{
+			name:  "an event carrying no space passes a negated space filter",
+			entry: config.HookEntry{Run: testHookRun, Space: "!2"},
+			evt:   events.Event{},
+			want:  true,
 		},
 		{
 			name:  "app and title filters both match",


### PR DESCRIPTION
## Description

This PR lets hooks filter on the space a workspace event landed on, and lets any hook filter be negated. Workspace events have carried the space index since #191, but no filter could read it, and no filter could be inverted, so "every application but Terminal" took one hook per other application.

A hook entry now takes `space = 2` on workspace hooks, and `app`, `bundle_id`, `title` and `space` may each begin with `!` to match everything the pattern does not. Validation and matching read the prefix and the space number through one shared rule, so a filter `mimi config validate` accepts is a filter the daemon matches.

## Config

| Key | What it does |
| --- | --- |
| `space = 2` | Fires only when the space now in front is the second. Workspace hooks only; on any other hook kind it is rejected. Written as a bare number, or as a string. |
| `space = "!2"` | Fires on every space but the second. |
| `app = "!Safari"`, `bundle_id = "!com.*"`, `title = "!^Inbox"` | The existing filters, inverted. A filter that is only `!` is rejected. `"!*"` matches nothing. |

```toml
[hooks]
on_workspace_changed = [
  { run = "sketchybar --trigger work_mode", space = 2 },
  { run = "sketchybar --trigger normal_mode", space = "!2" },
]
on_window_focus = [
  { run = "echo focus", app = "!Terminal" }
]
```

A workspace event that could not resolve its space carries no number; it fails every `space` filter and passes every negated one. `mimi config dump` now prints a `space` field on every entry.

Existing configs keep working: no existing filter begins with `!`, and `space` was not a recognised key. The one hypothetical break is a title regex written to start with a literal `!`; that now negates, and `\!` or `[!]` restores the literal.

## Related Issues

Builds on #191, which put `mimi_SPACE_INDEX` on workspace events.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

A throwaway daemon with the two workspace hooks above (echoing to a log instead of sketchybar), driven through several space switches on a two-display machine:

```
not-2 idx=1
on-2 idx=2
not-2 idx=1
on-2 idx=2
not-2 idx=1
on-2 idx=2
```

Every switch fired exactly one of the two hooks, the one whose filter matched the index the event carried.

```
$ mimi config validate   # with space = 2 on an on_window_focus hook
Config invalid:
  hooks.on_window_focus[0]: space applies to workspace hooks only
```

## Additional Context

The space filter is kept as a string on the entry so the negated form has somewhere to live; TOML's bare `space = 2` is accepted and normalised, and `"02"` names the same space as `"2"`. Nothing here reaches the daemon socket, so the wire version is unchanged.
