### PR TITLE
feat(action,native,cli): bring an application to the front across spaces with focus_app

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | Cycle focus between windows      | `mimi action focus_window`                                                |
 | Cycle focus backward             | `mimi action focus_window --backward`                                     |
 | Cycle within the frontmost app   | `mimi action focus_window --same-app`                                     |
+| Jump to an app, switching space  | `mimi action focus_app Safari`                                            |
 | Focus window to the left         | `mimi action focus_window --left`                                         |
 | Focus window to the right        | `mimi action focus_window --right`                                        |
 | Focus window above               | `mimi action focus_window --up`                                           |

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -17,6 +17,7 @@ func newActionCmd(state *cliState) *cobra.Command {
 
 Available subcommands:
   Window control:   focus_window, resize_window
+  Application:      focus_app
   Space control:    space, move_window_to_space
   Display control:  move_window_to_display
 
@@ -24,6 +25,7 @@ Examples:
   mimi action focus_window
   mimi action focus_window --backward
   mimi action focus_window --same-app
+  mimi action focus_app Safari
   mimi action space 1
   mimi action space next
   mimi action space prev
@@ -52,6 +54,7 @@ Examples:
 	}
 
 	cmd.AddCommand(buildFocusWindowCommand(state))
+	cmd.AddCommand(buildFocusAppCommand(state))
 	cmd.AddCommand(buildSpaceCommand(state))
 	cmd.AddCommand(buildMoveWindowToSpaceCommand(state))
 	cmd.AddCommand(buildMoveWindowToDisplayCommand(state))
@@ -115,6 +118,40 @@ moving in a direction.`,
 		BoolVar(&sameApp, "same-app", false, "Stay within the focused window's application")
 
 	return cmd
+}
+
+func buildFocusAppCommand(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "focus_app <name|bundle-id>",
+		Short: "Bring an application's window to the front, switching space first",
+		Long: `Bring an application's window to the front, switching to the space it is on
+first with the same instant gesture "mimi action space" uses, so macOS has
+nothing left to animate. The application is named by its name (case does not
+matter) or its bundle identifier.
+
+When the application is not in front, its most recently used window is
+chosen. When it is already in front, running the command again moves on to
+its next window: windows are visited by space, left to right, and by age
+within a space, wrapping at the end, so repeated presses reach every window
+the application has. Minimized windows are skipped. An application with no
+window is brought to the front as it is.
+
+The application has to be running; pair with open for the other case:
+  mimi action focus_app Safari || open -a Safari
+
+Examples:
+  mimi action focus_app Safari
+  mimi action focus_app com.apple.Safari`,
+		Args: validateFocusAppArg,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			focusCmd, err := action.NewFocusAppCommand(args)
+			if err != nil {
+				return err
+			}
+
+			return state.runAction(cobraCmd, focusCmd)
+		},
+	}
 }
 
 func buildSpaceCommand(state *cliState) *cobra.Command {
@@ -421,6 +458,15 @@ func validateSpaceArg(name action.Name) cobra.PositionalArgs {
 
 		return err
 	}
+}
+
+// validateFocusAppArg is validateSpaceArg for focus_app: cobra rejects the
+// argument before RunE runs, with action.ParseFocusAppArg as the rule, which
+// is the rule the constructor in RunE calls.
+func validateFocusAppArg(_ *cobra.Command, args []string) error {
+	_, err := action.ParseFocusAppArg(args)
+
+	return err
 }
 
 // validateDisplayArg is validateSpaceArg for move_window_to_display: cobra

--- a/cmd/mimi/cmd/action_test.go
+++ b/cmd/mimi/cmd/action_test.go
@@ -526,6 +526,7 @@ func malformedActionArgv() []malformedAction {
 		},
 		{name: "space zero", argv: []string{string(action.NameSpace), "0"}},
 		{name: "display zero", argv: []string{string(action.NameMoveWindowToDisplay), "0"}},
+		{name: "focus_app blank", argv: []string{string(action.NameFocusApp), whitespaceOnlyArg}},
 		{
 			name: "move_window_to_space nonsense",
 			argv: []string{string(action.NameMoveWindowToSpace), "nxt"},

--- a/cmd/mimi/cmd/interrupt_audit_test.go
+++ b/cmd/mimi/cmd/interrupt_audit_test.go
@@ -66,7 +66,7 @@ func audited(command string, response interruptResponse, why string) auditEntry 
 // no longer reaches the work, is invisible from the command's own code.
 //
 // What the audit found: six commands honor the context, one runs its own
-// signal handler, and fifteen ignore it. Thirteen of those fifteen are local
+// signal handler, and sixteen ignore it. Fourteen of those sixteen are local
 // file work, one-shot syscalls or desktop reads, over before an interrupt could
 // be typed. The two that are not are in the action family — `action space` on the direct path
 // pumps the run loop for a stretch proportional to the spaces it crosses, and
@@ -87,6 +87,9 @@ var interruptAudit = []auditEntry{
 		"runAction consults no context on either path: the daemon path "+
 			"writes a request and waits for the reply, the direct path calls "+
 			"into Objective-C that runs to completion"),
+	audited("action focus_app", interruptRunsOn,
+		"as space when the window is on another space, the same dock swipe; "+
+			"otherwise as focus_window, an activation that runs to completion"),
 	audited("action space", interruptRunsOn,
 		"as focus_window, and the direct path's synthetic dock swipe "+
 			"pumps the run loop for a stretch proportional to the spaces it "+

--- a/cmd/mimi/cmd/root_test.go
+++ b/cmd/mimi/cmd/root_test.go
@@ -292,6 +292,7 @@ func TestActionCommand_WithoutASubcommandStillListsItsSubcommands(t *testing.T) 
 		string(action.NameSpace),
 		string(action.NameMoveWindowToSpace),
 		string(action.NameMoveWindowToDisplay),
+		string(action.NameFocusApp),
 	} {
 		if !strings.Contains(out, name) {
 			t.Errorf("mimi action never named the %q subcommand, got: %s", name, out)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,6 +51,7 @@ it is what checks that the real desktop behaves the way the fake pretends to.
 | Action | API |
 | ------ | --- |
 | `focus_window` | Accessibility (`AXUIElement`) |
+| `focus_app` | Private SkyLight for the window list and their spaces (`SLSCopyWindowsWithOptionsAndTags`, `SLSCopySpacesForWindows`), the `space` gesture, then Accessibility to raise |
 | `space` | Synthetic dock-swipe gesture via `CGEvent` |
 | `move_window_to_space` | Private SkyLight (`SLSMoveWindowsToManagedSpace`) |
 | `move_window_to_display` | Accessibility (`AXUIElement`), `NSScreen` for the display list |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -77,6 +77,7 @@ mimi action focus_window --right
 mimi action focus_window --up
 mimi action focus_window --down
 mimi action focus_window --same-app
+mimi action focus_app Safari
 mimi action space 1
 mimi action space next
 mimi action space prev
@@ -104,6 +105,21 @@ Cycle keyboard focus through all focusable windows on the current space, or move
 | `--same-app` | Stay within the focused window's application, cycling or directional |
 
 `--same-app` is the keyboard's Cmd-backtick: it cycles through the windows of the frontmost application only, and combines with `--backward` or a direction flag. It needs a focused window to take the application from, and reports so when there is none.
+
+### `mimi action focus_app <name|bundle-id>`
+
+Bring an application's window to the front, switching to the space it is on first with the same instant gesture `mimi action space` uses, so macOS has nothing left to animate. This is the fast replacement for `open -a Safari` when Safari's window is on another space. The application is named by its name (case does not matter) or its bundle identifier, and has to be running: pair with `open` for the other case.
+
+```bash
+mimi action focus_app Safari || open -a Safari
+```
+
+Which window is chosen depends on where focus is:
+
+- When the application is **not in front**, its most recently used window is chosen, wherever it is.
+- When it **is already in front**, running the command again moves on to its next window. Windows are visited by space, left to right, and by age within a space, wrapping at the end, so repeated presses reach every window the application has, and the order never depends on which window was used last.
+
+Minimized windows are skipped. A window assigned to every space is raised without a switch. An application with no window is brought to the front as it is. The switch across spaces is the same dock-swipe gesture as `space`, including the pointer warp when the window is on another display. **Accessibility permission is required.**
 
 ### `mimi action space <number|next|prev>`
 

--- a/docs/adr/0004-focus-app-cycles-in-desktop-order.md
+++ b/docs/adr/0004-focus-app-cycles-in-desktop-order.md
@@ -1,0 +1,62 @@
+# focus_app cycles through an application's windows in desktop order
+
+**Status:** accepted
+
+`mimi action focus_app <app>` brings one of an application's windows to the
+front, switching to its space first. Run again while that application is in
+front, it moves to another of its windows. We decided that the window it moves
+to is the next one in an order read off the desktop each time, by space and
+then by the window server's number, and never the next one in a list mimi
+remembers.
+
+## Considered options
+
+- **Most recently used order, like Cmd-Tab.** Rejected: the window server
+  lists an application's windows front to back, so the "next" window is always
+  the second most recent, and two presses only ever swap the same two windows.
+  Reaching a third takes remembering which ones were visited, which is the
+  option below.
+- **Remember the cycle position.** Rejected: mimi's commands are one-shot and
+  run on either of two paths, a CLI process that exits and a daemon that may or
+  may not be listening. State that lives in one of them is invisible to the
+  other, and the same hotkey would cycle differently depending on whether the
+  daemon was up. `docs/ARCHITECTURE.md` treats that difference as a bug class.
+- **Order by space, then by window number (chosen).** The space index walks
+  the spaces left to right as Mission Control lays them out; the window number
+  is assigned at creation and stable for the window's life, so within a space
+  the order is by age. Both are read fresh on every press, so the cycle is the
+  same from the CLI, from the daemon, and after either restarts.
+
+## Consequences
+
+- **The first press goes to the most recently used window.** From another
+  application, the user wants the window they last left, and the window
+  server's order says which that is. Only once the application is in front
+  does the stable order apply, because only then is there a "next".
+- **The cycle is predictable, not adaptive.** A user who bounces between two
+  of five windows visits the other three on the way round. That is the price
+  of an order that needs no memory, and `focus_window --same-app` remains the
+  tool for stepping within one space.
+- **The application's windows come from the window server, not from
+  Accessibility.** An application's Accessibility window list holds only the
+  windows on the active space; a window on another space, the one this action
+  exists to reach, is simply absent from it. The window server lists every
+  window, so the candidates are read there, narrowed to real windows by the
+  same tags, attributes, parent and level tests yabai uses, and given their
+  space by `SLSCopySpacesForWindows`. Those are private SkyLight calls with the
+  usual caveat: they may break on a macOS update.
+- **The switch comes before the raise.** Because Accessibility only lists a
+  window once its space is in front, the action switches space first and only
+  then looks the window up by number to raise it. The seam says so: an
+  application's windows cross it as numbers, not handles, and raising takes a
+  pid and a number.
+- **Recognising the current window needs a stable identity.** The window in
+  front is found through Accessibility, the application's windows through the
+  window server, and the two are matched by the window server's number, which
+  is the same however a window was reached. Windows cross the Desktop seam
+  carrying that number for this reason.
+- **The remote-token workaround was rejected.** yabai can build an
+  Accessibility element for a window the list omits by sweeping element ids
+  with `_AXUIElementCreateWithRemoteToken`. Measured here, a sweep that finds
+  nothing runs 0.4s, and it runs on every press for any application with an
+  auxiliary window the sweep cannot resolve. Switching first costs nothing.

--- a/internal/action/accessibility_test.go
+++ b/internal/action/accessibility_test.go
@@ -59,6 +59,12 @@ func TestExecutor_DeniedAccessibilityLeavesTheDesktopAlone(t *testing.T) {
 			},
 		},
 		{
+			name: string(action.NameFocusApp),
+			run: func(e *action.Executor) error {
+				return e.FocusApp(appQuery)
+			},
+		},
+		{
 			name: string(action.NameResizeWindow),
 			run: func(e *action.Executor) error {
 				return e.ExecuteCommand(resizeCommandFor(t, action.ResizeWindowArgs{
@@ -94,6 +100,7 @@ func TestExecutor_DeniedAccessibilityLeavesTheDesktopAlone(t *testing.T) {
 			desktop.focusSpaceErr = denied
 			desktop.moveErr = denied
 			desktop.displaysErr = denied
+			desktop.apps = map[string]int{appQuery: appPID}
 
 			before := desktop.windows[0].frame
 

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -22,6 +22,7 @@ const (
 	NameResizeWindow      Name = "resize_window"
 
 	NameMoveWindowToDisplay Name = "move_window_to_display"
+	NameFocusApp            Name = "focus_app"
 )
 
 // Nouns the index-argument rule reports in: what a space argument and a

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -38,6 +38,61 @@ type Command struct {
 	MoveWindowToSpace   MoveWindowToSpaceArgs `json:"moveWindowToSpace,omitzero"`
 	MoveWindowToDisplay DisplayArg            `json:"moveWindowToDisplay,omitzero"`
 	ResizeWindow        ResizeWindowArgs      `json:"resizeWindow,omitzero"`
+	FocusApp            FocusAppArgs          `json:"focusApp,omitzero"`
+}
+
+// FocusAppArgs is focus_app's typed payload: the application, as a bundle
+// identifier or a name.
+type FocusAppArgs struct {
+	App string `json:"app"`
+}
+
+// NewFocusAppCommand builds focus_app's command from the one positional
+// argument the action takes. The rule is ParseFocusAppArg's, called rather
+// than restated.
+func NewFocusAppCommand(args []string) (Command, error) {
+	app, err := ParseFocusAppArg(args)
+	if err != nil {
+		return Command{}, err
+	}
+
+	return Command{Name: NameFocusApp, FocusApp: FocusAppArgs{App: app}}, nil
+}
+
+// ParseFocusAppArg is the only place focus_app's argument is read: exactly one,
+// naming an application by bundle identifier or name, with surrounding
+// whitespace not part of the name. It runs validateFocusAppArgs on what it
+// read, the check ExecuteCommand applies to a payload off the socket, so the
+// two cannot disagree about what names an application.
+func ParseFocusAppArg(args []string) (string, error) {
+	if len(args) != 1 {
+		return "", derrors.New(
+			derrors.CodeInvalidInput,
+			"focus_app requires exactly one argument: an application name or bundle identifier",
+		)
+	}
+
+	app := strings.TrimSpace(args[0])
+
+	err := validateFocusAppArgs(FocusAppArgs{App: app})
+	if err != nil {
+		return "", err
+	}
+
+	return app, nil
+}
+
+// validateFocusAppArgs holds focus_app's one payload rule: the application
+// has to be named.
+func validateFocusAppArgs(args FocusAppArgs) error {
+	if strings.TrimSpace(args.App) == "" {
+		return derrors.New(
+			derrors.CodeInvalidInput,
+			"focus_app argument cannot be empty: give an application name or bundle identifier",
+		)
+	}
+
+	return nil
 }
 
 // MoveWindowToSpaceArgs is move_window_to_space's typed payload: the space the
@@ -472,6 +527,13 @@ func (e *Executor) ExecuteCommand(cmd Command) error {
 		return e.MoveWindowToSpace(index, cmd.MoveWindowToSpace.Follow)
 	case NameMoveWindowToDisplay:
 		return e.MoveWindowToDisplay(cmd.MoveWindowToDisplay)
+	case NameFocusApp:
+		err := validateFocusAppArgs(cmd.FocusApp)
+		if err != nil {
+			return err
+		}
+
+		return e.FocusApp(cmd.FocusApp.App)
 	case NameResizeWindow:
 		req, err := ResizeRequestFromArgs(cmd.ResizeWindow)
 		if err != nil {
@@ -482,7 +544,7 @@ func (e *Executor) ExecuteCommand(cmd Command) error {
 	default:
 		return derrors.Newf(
 			derrors.CodeInvalidInput,
-			"unknown action %q (supported: focus_window, space, move_window_to_space, move_window_to_display, resize_window)",
+			"unknown action %q (supported: focus_window, focus_app, space, move_window_to_space, move_window_to_display, resize_window)",
 			cmd.Name,
 		)
 	}

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -37,7 +37,8 @@ func spaceCommandFor(t *testing.T, name action.Name, arg string) action.Command 
 		cmd, err = action.NewSpaceCommand([]string{arg})
 	case action.NameMoveWindowToSpace:
 		cmd, err = action.NewMoveWindowToSpaceCommand([]string{arg}, false)
-	case action.NameFocusWindow, action.NameResizeWindow, action.NameMoveWindowToDisplay:
+	case action.NameFocusWindow, action.NameResizeWindow, action.NameMoveWindowToDisplay,
+		action.NameFocusApp:
 		t.Fatalf("%s takes no space argument", name)
 	default:
 		t.Fatalf("unknown action %q", name)
@@ -516,6 +517,24 @@ func TestExecuteCommand_ReachesEveryAction(t *testing.T) {
 		wantRefreshCalls(t, desktop, 1)
 	})
 
+	t.Run("focus_app", func(t *testing.T) {
+		t.Parallel()
+
+		desktop := desktopWithApp(0)
+
+		err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
+			Name:     action.NameFocusApp,
+			FocusApp: action.FocusAppArgs{App: appQuery},
+		})
+		if err != nil {
+			t.Fatalf("ExecuteCommand(focus_app) error = %v, want nil", err)
+		}
+
+		// The application was not in front, so its most recently used
+		// window, the first the desktop lists, is the one raised.
+		wantFocused(t, desktop, appWindowOnSpaceOne)
+	})
+
 	t.Run("resize_window", func(t *testing.T) {
 		t.Parallel()
 
@@ -604,6 +623,17 @@ func TestExecuteCommand_RejectsAPayloadNoConstructorWouldBuild(t *testing.T) {
 			cmd: action.Command{
 				Name:                action.NameMoveWindowToDisplay,
 				MoveWindowToDisplay: action.DisplayArg{Index: 1, Direction: 1},
+			},
+		},
+		{
+			name: "focus_app naming no application",
+			cmd:  action.Command{Name: action.NameFocusApp},
+		},
+		{
+			name: "focus_app naming only whitespace",
+			cmd: action.Command{
+				Name:     action.NameFocusApp,
+				FocusApp: action.FocusAppArgs{App: "  "},
 			},
 		},
 		{

--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -18,6 +18,20 @@ type Window struct {
 	// PID is the process ID of the application the window belongs to, which is
 	// how one application's windows are told from another's.
 	PID int
+	// Number is the window server's number for the window: stable for the
+	// window's lifetime and the same however the window was reached, which is
+	// how a window found one way is recognized when found another. It is 0
+	// when the desktop cannot read it.
+	Number uint32
+}
+
+// AppWindow is one window of an application as the window server lists it:
+// its number, and the 1-based index of the space it is on, or 0 when it is on
+// every space or none. It carries no handle: a window on another space cannot
+// be driven until that space is in front, which is what RaiseWindow needs.
+type AppWindow struct {
+	Number     uint32
+	SpaceIndex int
 }
 
 // Display is one connected display as the actions see it: an identifier to
@@ -81,6 +95,25 @@ type Desktop interface {
 	// ActivateDisplay makes a display the active one for the menu bar and
 	// event routing, which is what a window landing on it expects.
 	ActivateDisplay(id uint32)
+
+	// FindApplication resolves a bundle identifier or an application name to
+	// the pid of the running application it names, reporting an error when
+	// nothing running matches.
+	FindApplication(query string) (int, error)
+
+	// ApplicationWindows lists an application's real windows on every space,
+	// front to back, which is most recently used first. Minimized and
+	// auxiliary windows are left out.
+	ApplicationWindows(pid int) ([]AppWindow, error)
+
+	// RaiseWindow brings one of an application's windows to the front by
+	// number. It works for a window on the active space and reports an
+	// error for one that is not: the caller switches first.
+	RaiseWindow(pid int, number uint32) error
+
+	// ActivateApplication brings an application to the front without naming
+	// a window, which is what focusing an application with no windows means.
+	ActivateApplication(pid int) error
 
 	// MissionControlActive reports whether Mission Control is open, which is
 	// the state the space actions refuse to run in.

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -14,6 +14,7 @@ import (
 type fakeWindow struct {
 	id          action.WindowID
 	pid         int
+	number      uint32
 	frame       geometry.Rect
 	frameErr    error
 	activateErr error
@@ -45,6 +46,14 @@ type fakeDesktop struct {
 
 	missionControlActive bool
 
+	// apps maps a query focus_app may be given to the pid it names.
+	apps map[string]int
+	// appWindows lists each application's windows front to back, as
+	// ApplicationWindows reports them; every id is one of windows'.
+	appWindows map[int][]action.AppWindow
+	// activatedApp is the last application activated without a window.
+	activatedApp int
+
 	displays    []action.Display
 	displaysErr error
 	// activatedDisplay is the display last made active, or 0 for none.
@@ -75,7 +84,7 @@ func (d *fakeDesktop) FocusableWindows() ([]action.Window, int, error) {
 
 	windows := make([]action.Window, len(d.windows))
 	for index, win := range d.windows {
-		windows[index] = action.Window{ID: win.id, PID: win.pid}
+		windows[index] = action.Window{ID: win.id, PID: win.pid, Number: win.number}
 	}
 
 	return windows, d.focused, nil
@@ -120,7 +129,58 @@ func (d *fakeDesktop) FrontmostWindow() (action.Window, error) {
 		return action.Window{}, err
 	}
 
-	return action.Window{ID: d.frontmost, PID: d.windows[index].pid}, nil
+	return action.Window{
+		ID:     d.frontmost,
+		PID:    d.windows[index].pid,
+		Number: d.windows[index].number,
+	}, nil
+}
+
+func (d *fakeDesktop) FindApplication(query string) (int, error) {
+	pid, ok := d.apps[query]
+	if !ok {
+		return 0, derrors.Newf(derrors.CodeActionFailed, "no running application named %q", query)
+	}
+
+	return pid, nil
+}
+
+func (d *fakeDesktop) ApplicationWindows(pid int) ([]action.AppWindow, error) {
+	return slices.Clone(d.appWindows[pid]), nil
+}
+
+// RaiseWindow models the one constraint the real desktop has: a window is
+// reachable through Accessibility only while its space is in front.
+func (d *fakeDesktop) RaiseWindow(pid int, number uint32) error {
+	for _, win := range d.appWindows[pid] {
+		if win.Number != number {
+			continue
+		}
+
+		if win.SpaceIndex != 0 && win.SpaceIndex != d.activeSpace {
+			return derrors.Newf(
+				derrors.CodeAccessibilityFailed,
+				"window %d is on space %d, not the active space %d",
+				number,
+				win.SpaceIndex,
+				d.activeSpace,
+			)
+		}
+
+		for _, candidate := range d.windows {
+			if candidate.pid == pid && candidate.number == number {
+				return d.ActivateWindow(candidate.id)
+			}
+		}
+	}
+
+	return derrors.Newf(derrors.CodeAccessibilityFailed, "window %d is not listed", number)
+}
+
+func (d *fakeDesktop) ActivateApplication(pid int) error {
+	d.activatedApp = pid
+
+	return nil
 }
 
 func (d *fakeDesktop) SetWindowFrame(windowID action.WindowID, frame geometry.Rect) error {

--- a/internal/action/focus_app.go
+++ b/internal/action/focus_app.go
@@ -1,0 +1,155 @@
+package action
+
+import (
+	"slices"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// FocusApp brings an application's window to the front, switching to the
+// space it is on first so that macOS has nothing left to animate.
+//
+// Which window depends on where focus is now. When the application is not in
+// front, its most recently used window is the one the user last left, and is
+// chosen. When the application is already in front, the command was run
+// again to move on: the next window in a stable order is chosen, wrapping at
+// the end, so repeated presses visit every window of the application once.
+// That order is by space and then by the window server's number, which is
+// creation order, so a cycle walks the spaces from left to right and never
+// depends on which window was used last; see
+// docs/adr/0004-focus-app-cycles-in-desktop-order.md.
+//
+// An application with no window is brought to the front as it is, which is
+// what activating it means.
+func (e *Executor) FocusApp(query string) error {
+	err := e.desktop.EnsureAccessible()
+	if err != nil {
+		return err
+	}
+
+	pid, err := e.desktop.FindApplication(query)
+	if err != nil {
+		return err
+	}
+
+	// The window in front is read before the application's windows are, so
+	// that it is still a value of its own when the list replaces it; only its
+	// application and its number are needed. An error here means nothing is
+	// in front, which is a state, not a failure.
+	current, currentErr := e.desktop.FrontmostWindow()
+
+	windows, err := e.desktop.ApplicationWindows(pid)
+	if err != nil {
+		return derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to list the application's windows",
+		)
+	}
+
+	if len(windows) == 0 {
+		err = e.desktop.ActivateApplication(pid)
+		if err != nil {
+			return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to activate application")
+		}
+
+		return nil
+	}
+
+	target := windows[0]
+
+	if currentErr == nil && current.PID == pid {
+		ordered := inDesktopOrder(windows)
+
+		at := slices.IndexFunc(ordered, func(win AppWindow) bool {
+			return win.Number != 0 && win.Number == current.Number
+		})
+		if at >= 0 {
+			target = ordered[(at+1)%len(ordered)]
+		}
+	}
+
+	switched, err := e.bringSpaceForward(target.SpaceIndex)
+	if err != nil {
+		return err
+	}
+
+	// The switch comes first because the window can only be raised once its
+	// space is in front: Accessibility lists an application's windows on the
+	// active space alone.
+	err = e.desktop.RaiseWindow(pid, target.Number)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to raise window")
+	}
+
+	if switched {
+		e.desktop.RefreshWorkspaceTitle()
+	}
+
+	return nil
+}
+
+// inDesktopOrder sorts an application's windows the way a cycle visits them:
+// by the space they are on, left to right, then by the window server's
+// number within a space. Windows on every space or none (index 0) come last.
+// The sort is stable, so windows the desktop cannot number keep the order
+// they arrived in.
+func inDesktopOrder(windows []AppWindow) []AppWindow {
+	ordered := slices.Clone(windows)
+
+	slices.SortStableFunc(ordered, func(first, second AppWindow) int {
+		switch {
+		case first.SpaceIndex == second.SpaceIndex:
+			return int(first.Number) - int(second.Number)
+		case first.SpaceIndex == 0:
+			return 1
+		case second.SpaceIndex == 0:
+			return -1
+		default:
+			return first.SpaceIndex - second.SpaceIndex
+		}
+	})
+
+	return ordered
+}
+
+// bringSpaceForward switches to the space at index when it is not already in
+// front, on the same terms as the space action, and reports whether it did.
+// Index 0 names no particular space and asks for nothing.
+func (e *Executor) bringSpaceForward(index int) (bool, error) {
+	if index == 0 {
+		return false, nil
+	}
+
+	active, err := e.desktop.ActiveSpaceIndex()
+	if err != nil {
+		return false, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to resolve the active space",
+		)
+	}
+
+	if active == index {
+		return false, nil
+	}
+
+	if e.desktop.MissionControlActive() {
+		return false, derrors.New(
+			derrors.CodeActionFailed,
+			"cannot switch spaces while Mission Control is active",
+		)
+	}
+
+	err = e.desktop.FocusSpace(index)
+	if err != nil {
+		return false, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to switch to space %d",
+			index,
+		)
+	}
+
+	return true, nil
+}

--- a/internal/action/focus_app_test.go
+++ b/internal/action/focus_app_test.go
@@ -1,0 +1,276 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// The application the focus_app tests reach for: three windows across the
+// spaces, listed front to back as macOS lists them, most recently used first.
+// Window 3 (space 1) is the one used last, window 2 (space 2) before it, and
+// window 4 (space 3) least recently. One window of another application, id 1,
+// sits on space 1 and holds focus at the start.
+const (
+	appQuery = "Safari"
+	appPID   = 500
+	otherPID = 600
+
+	otherWindow          action.WindowID = 1
+	appWindowOnSpaceTwo  action.WindowID = 2
+	appWindowOnSpaceOne  action.WindowID = 3
+	appWindowOnSpaceThre action.WindowID = 4
+)
+
+// desktopWithApp builds that desktop, focused on the window at the given
+// 0-based index (window id index+1), sitting on space 1 of three.
+func desktopWithApp(focused int) *fakeDesktop {
+	desktop := desktopWithWindows(4, focused)
+	desktop.spaceCount = 3
+	desktop.activeSpace = 1
+
+	for index := range desktop.windows {
+		desktop.windows[index].number = uint32(desktop.windows[index].id) * 10
+		desktop.windows[index].pid = appPID
+	}
+
+	desktop.windows[0].pid = otherPID
+
+	desktop.apps = map[string]int{appQuery: appPID}
+	desktop.appWindows = map[int][]action.AppWindow{
+		appPID: {
+			appWindowFor(desktop, appWindowOnSpaceOne, 1),
+			appWindowFor(desktop, appWindowOnSpaceTwo, 2),
+			appWindowFor(desktop, appWindowOnSpaceThre, 3),
+		},
+	}
+
+	return desktop
+}
+
+func appWindowFor(desktop *fakeDesktop, id action.WindowID, space int) action.AppWindow {
+	index, _ := desktop.indexOf(id)
+
+	return action.AppWindow{Number: desktop.windows[index].number, SpaceIndex: space}
+}
+
+func focusApp(t *testing.T, desktop *fakeDesktop) {
+	t.Helper()
+
+	err := action.NewExecutor(desktop).FocusApp(appQuery)
+	if err != nil {
+		t.Fatalf("FocusApp(%q) error = %v, want nil", appQuery, err)
+	}
+}
+
+// TestExecutor_FocusApp_NotInFrontGoesToTheMostRecentWindow: the first press
+// from another application lands on the window the user last used, on the
+// space it is on. Here that window is on the current space, so no switch.
+func TestExecutor_FocusApp_NotInFrontGoesToTheMostRecentWindow(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithApp(0)
+
+	focusApp(t, desktop)
+
+	wantFocused(t, desktop, appWindowOnSpaceOne)
+
+	if desktop.activeSpace != 1 {
+		t.Fatalf("active space = %d, want it left on 1", desktop.activeSpace)
+	}
+
+	wantRefreshCalls(t, desktop, 0)
+}
+
+// TestExecutor_FocusApp_SwitchesToTheWindowsSpaceFirst: a window on another
+// space is reached by switching there, then raising it, and the systray learns
+// of the switch.
+func TestExecutor_FocusApp_SwitchesToTheWindowsSpaceFirst(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithApp(0)
+	// The most recently used window is now the one on space 2.
+	desktop.appWindows[appPID] = []action.AppWindow{
+		appWindowFor(desktop, appWindowOnSpaceTwo, 2),
+		appWindowFor(desktop, appWindowOnSpaceOne, 1),
+	}
+
+	focusApp(t, desktop)
+
+	wantFocused(t, desktop, appWindowOnSpaceTwo)
+
+	if desktop.activeSpace != 2 {
+		t.Fatalf("active space = %d, want 2", desktop.activeSpace)
+	}
+
+	wantRefreshCalls(t, desktop, 1)
+}
+
+// TestExecutor_FocusApp_InFrontCyclesInDesktopOrder pins the cycle: with the
+// application already in front, each press moves to the next window by space
+// and then by age, whatever was used last, and wraps.
+func TestExecutor_FocusApp_InFrontCyclesInDesktopOrder(t *testing.T) {
+	t.Parallel()
+
+	// Focus starts on the app's window on space 1.
+	desktop := desktopWithApp(2)
+
+	steps := []struct {
+		want  action.WindowID
+		space int
+	}{
+		{want: appWindowOnSpaceTwo, space: 2},
+		{want: appWindowOnSpaceThre, space: 3},
+		{want: appWindowOnSpaceOne, space: 1},
+		{want: appWindowOnSpaceTwo, space: 2},
+	}
+
+	for press, step := range steps {
+		focusApp(t, desktop)
+
+		if got := desktop.focusedID(); got != step.want {
+			t.Fatalf("press %d: focused = %d, want %d", press+1, got, step.want)
+		}
+
+		if desktop.activeSpace != step.space {
+			t.Fatalf(
+				"press %d: active space = %d, want %d",
+				press+1,
+				desktop.activeSpace,
+				step.space,
+			)
+		}
+	}
+}
+
+// TestExecutor_FocusApp_InFrontWithOneWindowStaysPut: one window has nowhere
+// to cycle to, and that is not an error.
+func TestExecutor_FocusApp_InFrontWithOneWindowStaysPut(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithApp(2)
+	desktop.appWindows[appPID] = []action.AppWindow{appWindowFor(desktop, appWindowOnSpaceOne, 1)}
+
+	focusApp(t, desktop)
+
+	wantFocused(t, desktop, appWindowOnSpaceOne)
+	wantRefreshCalls(t, desktop, 0)
+}
+
+// TestExecutor_FocusApp_AWindowOnEverySpaceNeedsNoSwitch: index 0 names no
+// particular space, so the window is raised where the user is.
+func TestExecutor_FocusApp_AWindowOnEverySpaceNeedsNoSwitch(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithApp(0)
+	desktop.appWindows[appPID] = []action.AppWindow{appWindowFor(desktop, appWindowOnSpaceTwo, 0)}
+
+	focusApp(t, desktop)
+
+	wantFocused(t, desktop, appWindowOnSpaceTwo)
+
+	if desktop.activeSpace != 1 {
+		t.Fatalf("active space = %d, want it left on 1", desktop.activeSpace)
+	}
+}
+
+// TestExecutor_FocusApp_NoWindowsActivatesTheApplication: an application with
+// nothing to raise is still brought to the front.
+func TestExecutor_FocusApp_NoWindowsActivatesTheApplication(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithApp(0)
+	desktop.appWindows[appPID] = nil
+
+	focusApp(t, desktop)
+
+	if desktop.activatedApp != appPID {
+		t.Fatalf("activated application = %d, want %d", desktop.activatedApp, appPID)
+	}
+
+	wantFocused(t, desktop, otherWindow)
+}
+
+func TestExecutor_FocusApp_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		desktop  func() *fakeDesktop
+		wantCode derrors.Code
+	}{
+		{
+			name: "application not running",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithApp(0)
+				desktop.apps = nil
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+		{
+			name: "mission control open when a switch is needed",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithApp(0)
+				desktop.missionControlActive = true
+				desktop.appWindows[appPID] = []action.AppWindow{
+					appWindowFor(desktop, appWindowOnSpaceTwo, 2),
+				}
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+		{
+			name: "the switch fails",
+			desktop: func() *fakeDesktop {
+				desktop := desktopWithApp(0)
+				desktop.focusSpaceErr = derrors.New(derrors.CodeActionFailed, "swipe failed")
+				desktop.appWindows[appPID] = []action.AppWindow{
+					appWindowFor(desktop, appWindowOnSpaceTwo, 2),
+				}
+
+				return desktop
+			},
+			wantCode: derrors.CodeActionFailed,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := testCase.desktop()
+
+			err := action.NewExecutor(desktop).FocusApp(appQuery)
+			if err == nil {
+				t.Fatal("FocusApp() error = nil, want an error")
+			}
+
+			if !derrors.IsCode(err, testCase.wantCode) {
+				t.Fatalf("error code = %q, want %q", derrors.GetCode(err), testCase.wantCode)
+			}
+
+			wantFocused(t, desktop, otherWindow)
+			wantRefreshCalls(t, desktop, 0)
+		})
+	}
+}
+
+func TestParseFocusAppArg(t *testing.T) {
+	t.Parallel()
+
+	got, err := action.ParseFocusAppArg([]string{"  com.apple.Safari "})
+	if err != nil || got != "com.apple.Safari" {
+		t.Fatalf("ParseFocusAppArg(padded) = %q, %v, want the trimmed name and nil", got, err)
+	}
+
+	for _, args := range [][]string{nil, {""}, {"   "}, {"Safari", "Mail"}} {
+		_, err := action.ParseFocusAppArg(args)
+		if err == nil || !derrors.IsCode(err, derrors.CodeInvalidInput) {
+			t.Errorf("ParseFocusAppArg(%q) error = %v, want invalid input", args, err)
+		}
+	}
+}

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -59,10 +59,47 @@ func (d *nativeDesktop) FocusableWindows() ([]Window, int, error) {
 			pid = 0
 		}
 
-		windows = append(windows, Window{ID: d.registerLocked(element), PID: pid})
+		windows = append(windows, Window{
+			ID:     d.registerLocked(element),
+			PID:    pid,
+			Number: element.Number(),
+		})
 	}
 
 	return windows, focused, nil
+}
+
+// FindApplication resolves a bundle identifier or a name to a running pid.
+func (d *nativeDesktop) FindApplication(query string) (int, error) {
+	return native.FindApplication(query)
+}
+
+// ApplicationWindows lists an application's real windows on every space,
+// front to back, with each space id resolved to its Mission Control index.
+func (d *nativeDesktop) ApplicationWindows(pid int) ([]AppWindow, error) {
+	found, err := native.ApplicationWindows(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	indexes := native.SpaceIndexes()
+	windows := make([]AppWindow, len(found))
+
+	for index, window := range found {
+		windows[index] = AppWindow{Number: window.Number, SpaceIndex: indexes[window.SpaceID]}
+	}
+
+	return windows, nil
+}
+
+// RaiseWindow brings one of an application's windows to the front by number.
+func (d *nativeDesktop) RaiseWindow(pid int, number uint32) error {
+	return native.RaiseWindowNumber(pid, number)
+}
+
+// ActivateApplication brings an application to the front.
+func (d *nativeDesktop) ActivateApplication(pid int) error {
+	return native.ActivateApplication(pid)
 }
 
 // FrontmostWindow returns the window currently in front.
@@ -85,7 +122,7 @@ func (d *nativeDesktop) FrontmostWindow() (Window, error) {
 
 	d.releaseLocked()
 
-	return Window{ID: d.registerLocked(element), PID: pid}, nil
+	return Window{ID: d.registerLocked(element), PID: pid, Number: element.Number()}, nil
 }
 
 // WindowFrame reads one window's frame.

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -16,7 +16,7 @@ import (
 // older daemon would read wrongly — a renamed or removed field, or a field
 // whose meaning changed. TestRequest_EncodesTheGoldenBytes is what makes such
 // a change visible.
-const ProtocolVersion = 5
+const ProtocolVersion = 6
 
 // Request is the envelope one command travels in over the daemon's Unix
 // socket.

--- a/internal/ipc/wire_test.go
+++ b/internal/ipc/wire_test.go
@@ -86,6 +86,17 @@ func everyPayloadSet() []payloadCase {
 			},
 		},
 		{
+			name: "focus_app with nothing set",
+			cmd:  action.Command{Name: action.NameFocusApp},
+		},
+		{
+			name: "focus_app with every field set",
+			cmd: action.Command{
+				Name:     action.NameFocusApp,
+				FocusApp: action.FocusAppArgs{App: "com.apple.Safari"},
+			},
+		},
+		{
 			name: "resize_window with nothing set",
 			cmd:  action.Command{Name: action.NameResizeWindow},
 		},
@@ -179,7 +190,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewFocusWindowCommand(true, false, false, false, false, false)
 			},
-			want: `{"version":5,"command":{"name":"focus_window",` +
+			want: `{"version":6,"command":{"name":"focus_window",` +
 				`"focusWindow":{"backward":true,"direction":"","sameApp":false}}}`,
 		},
 		{
@@ -187,14 +198,14 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewFocusWindowCommand(false, false, false, false, false, false)
 			},
-			want: `{"version":5,"command":{"name":"focus_window"}}`,
+			want: `{"version":6,"command":{"name":"focus_window"}}`,
 		},
 		{
 			name: "mimi action space 3",
 			build: func() (action.Command, error) {
 				return action.NewSpaceCommand([]string{"3"})
 			},
-			want: `{"version":5,"command":{"name":"space",` +
+			want: `{"version":6,"command":{"name":"space",` +
 				`"space":{"index":3,"direction":0}}}`,
 		},
 		{
@@ -202,7 +213,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewMoveWindowToSpaceCommand([]string{"next"}, true)
 			},
-			want: `{"version":5,"command":{"name":"move_window_to_space",` +
+			want: `{"version":6,"command":{"name":"move_window_to_space",` +
 				`"moveWindowToSpace":{"space":{"index":0,"direction":1},"follow":true}}}`,
 		},
 		{
@@ -210,8 +221,16 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 			build: func() (action.Command, error) {
 				return action.NewMoveWindowToDisplayCommand([]string{"prev"})
 			},
-			want: `{"version":5,"command":{"name":"move_window_to_display",` +
+			want: `{"version":6,"command":{"name":"move_window_to_display",` +
 				`"moveWindowToDisplay":{"index":0,"direction":-1}}}`,
+		},
+		{
+			name: "mimi action focus_app Safari",
+			build: func() (action.Command, error) {
+				return action.NewFocusAppCommand([]string{"Safari"})
+			},
+			want: `{"version":6,"command":{"name":"focus_app",` +
+				`"focusApp":{"app":"Safari"}}}`,
 		},
 		{
 			name: "mimi action resize_window left-half --width 800 --anchor cc --no-margin",
@@ -225,7 +244,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 					NoMargin:  true,
 				})
 			},
-			want: `{"version":5,"command":{"name":"resize_window",` +
+			want: `{"version":6,"command":{"name":"resize_window",` +
 				`"resizeWindow":{"preset":"left-half",` +
 				`"width":800,"widthSet":true,` +
 				`"height":0,"heightSet":false,` +

--- a/internal/native/application.go
+++ b/internal/native/application.go
@@ -1,0 +1,108 @@
+package native
+
+/*
+#include "mimi.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// AppWindow is one window of an application as the window server lists it:
+// its number, and the id of the space it is on, which is 0 when it is on
+// every space or none.
+type AppWindow struct {
+	Number  uint32
+	SpaceID uint64
+}
+
+// FindApplication resolves a bundle identifier or a localized application
+// name, case-insensitively, to the pid of the running application it names.
+func FindApplication(query string) (int, error) {
+	cQuery := C.CString(query)
+	defer C.free(unsafe.Pointer(cQuery)) //nolint:nlreturn
+
+	pid := int(C.MimiFindApplication(cQuery))
+	if pid == 0 {
+		return 0, derrors.Newf(
+			derrors.CodeActionFailed,
+			"no running application named %q",
+			query,
+		)
+	}
+
+	return pid, nil
+}
+
+// ApplicationWindows lists an application's real, unminimized windows on
+// every space, front to back, which is most recently used first.
+func ApplicationWindows(pid int) ([]AppWindow, error) {
+	var count C.int
+
+	rows := C.MimiCopyApplicationWindows(C.int(pid), &count)
+	if rows == nil || count == 0 {
+		if rows != nil {
+			C.free(unsafe.Pointer(rows))
+		}
+
+		return nil, nil
+	}
+	defer C.free(unsafe.Pointer(rows)) //nolint:nlreturn
+
+	values := unsafe.Slice(rows, int(count))
+	windows := make([]AppWindow, int(count))
+
+	for index, row := range values {
+		windows[index] = AppWindow{
+			Number:  uint32(row.number),
+			SpaceID: uint64(row.space),
+		}
+	}
+
+	return windows, nil
+}
+
+// RaiseWindowNumber brings one of an application's windows to the front by
+// its window server number. The window has to be on the active space: that
+// is when its application lists it through Accessibility.
+func RaiseWindowNumber(pid int, number uint32) error {
+	if C.MimiRaiseWindowNumber(C.int(pid), C.uint32_t(number)) == 0 {
+		return derrors.Newf(
+			derrors.CodeAccessibilityFailed,
+			"window %d of application %d could not be raised",
+			number,
+			pid,
+		)
+	}
+
+	return nil
+}
+
+// ActivateApplication brings an application to the front without naming a
+// window, which is what activating an application with no windows means.
+func ActivateApplication(pid int) error {
+	if C.MimiActivateApplication(C.int(pid)) == 0 {
+		return derrors.Newf(derrors.CodeActionFailed, "failed to activate application %d", pid)
+	}
+
+	return nil
+}
+
+// SpaceIndexes maps every Mission Control space id to its 1-based index, in
+// one pass over the enumeration.
+func SpaceIndexes() map[uint64]int {
+	count := SpaceCount()
+	indexes := make(map[uint64]int, count)
+
+	for index := 1; index <= count; index++ {
+		if sid := uint64(C.MimiMissionControlSpaceID(C.int(index))); sid != 0 {
+			indexes[sid] = index
+		}
+	}
+
+	return indexes
+}

--- a/internal/native/application.m
+++ b/internal/native/application.m
@@ -1,0 +1,334 @@
+//
+//  application.m
+//  mimi
+//
+
+#import "mimi.h"
+#import "mimi_log.h"
+
+#import <Cocoa/Cocoa.h>
+
+#pragma mark - SkyLight External Declarations
+
+extern int SLSMainConnectionID(void);
+extern CFArrayRef SLSCopyManagedDisplaySpaces(int cid);
+extern CFArrayRef SLSCopySpacesForWindows(int cid, int mask, CFArrayRef window_ids);
+extern CFArrayRef SLSCopyWindowsWithOptionsAndTags(
+    int cid, uint32_t owner, CFArrayRef spaces, uint32_t options, uint64_t *set_tags, uint64_t *clear_tags);
+extern CFTypeRef SLSWindowQueryWindows(int cid, CFArrayRef windows, int count);
+extern CFTypeRef SLSWindowQueryResultCopyWindows(CFTypeRef query);
+extern bool SLSWindowIteratorAdvance(CFTypeRef iterator);
+extern uint32_t SLSWindowIteratorGetParentID(CFTypeRef iterator);
+extern uint32_t SLSWindowIteratorGetWindowID(CFTypeRef iterator);
+extern uint64_t SLSWindowIteratorGetTags(CFTypeRef iterator);
+extern uint64_t SLSWindowIteratorGetAttributes(CFTypeRef iterator);
+extern int SLSWindowIteratorGetLevel(CFTypeRef iterator);
+extern AXError _AXUIElementGetWindow(AXUIElementRef element, CGWindowID *out);
+
+/// Every space a window can be on: current, other, and full-screen ones.
+static const int kMimiAllSpacesMask = 0x7;
+
+/// SLSCopyWindowsWithOptionsAndTags option: windows that are not minimized.
+static const uint32_t kMimiWindowsNotMinimized = 0x2;
+
+// The window server's own notion of a real window, as yabai reads it: a
+// top-level window (no parent) at a normal level, ordered in, and either a
+// document-style window or one an application asked to be treated as such.
+// The tags and attributes are undocumented bit fields; the tests below are
+// the ones yabai has kept working across macOS releases.
+static const uint64_t kMimiAttributeReal = 0x2;
+static const uint64_t kMimiTagReal = 0x400000000000000;
+static const uint64_t kMimiTagOrderedIn = 0x1;
+static const uint64_t kMimiTagStandard = 0x2;
+static const uint64_t kMimiTagVisible = 0x80000000;
+
+static bool mimiWindowLevelIsNormal(int level) { return level == 0 || level == 3 || level == 8; }
+
+static bool mimiWindowIsReal(uint64_t tags, uint64_t attributes, uint32_t parent, int level) {
+	if (parent != 0 || !mimiWindowLevelIsNormal(level))
+		return false;
+	bool documentLike = (attributes & kMimiAttributeReal) || (tags & kMimiTagReal);
+	bool shown = (tags & kMimiTagOrderedIn) || ((tags & kMimiTagStandard) && (tags & kMimiTagVisible));
+	return documentLike && shown;
+}
+
+/// Every Mission Control space id on every display, full-screen ones included.
+static NSArray<NSNumber *> *mimiAllSpaceIDs(void) {
+	NSMutableArray<NSNumber *> *ids = [NSMutableArray array];
+	CFArrayRef displaySpaces = SLSCopyManagedDisplaySpaces(SLSMainConnectionID());
+	if (!displaySpaces)
+		return ids;
+
+	for (NSDictionary *display in (__bridge NSArray *)displaySpaces) {
+		for (NSDictionary *space in display[@"Spaces"]) {
+			NSNumber *sid = space[@"id64"];
+			if (sid)
+				[ids addObject:sid];
+		}
+	}
+
+	CFRelease(displaySpaces);
+	return ids;
+}
+
+/// Window numbers of every real, unminimized window on any space, whoever
+/// owns them.
+static NSSet<NSNumber *> *mimiRealWindowNumbers(void) {
+	NSMutableSet<NSNumber *> *real = [NSMutableSet set];
+	NSArray<NSNumber *> *spaces = mimiAllSpaceIDs();
+	if (spaces.count == 0)
+		return real;
+
+	uint64_t setTags = 0;
+	uint64_t clearTags = 0;
+	CFArrayRef windows = SLSCopyWindowsWithOptionsAndTags(
+	    SLSMainConnectionID(), 0, (__bridge CFArrayRef)spaces, kMimiWindowsNotMinimized, &setTags, &clearTags);
+	if (!windows)
+		return real;
+
+	CFIndex count = CFArrayGetCount(windows);
+	if (count > 0) {
+		CFTypeRef query = SLSWindowQueryWindows(SLSMainConnectionID(), windows, (int)count);
+		if (query) {
+			CFTypeRef iterator = SLSWindowQueryResultCopyWindows(query);
+			if (iterator) {
+				while (SLSWindowIteratorAdvance(iterator)) {
+					if (mimiWindowIsReal(
+					        SLSWindowIteratorGetTags(iterator), SLSWindowIteratorGetAttributes(iterator),
+					        SLSWindowIteratorGetParentID(iterator), SLSWindowIteratorGetLevel(iterator))) {
+						[real addObject:@(SLSWindowIteratorGetWindowID(iterator))];
+					}
+				}
+				CFRelease(iterator);
+			}
+			CFRelease(query);
+		}
+	}
+
+	CFRelease(windows);
+	return real;
+}
+
+#pragma mark - Helpers
+
+/// Window numbers of the layer-0 windows a process owns, on every space, in
+/// the window server's order: front to back, which is most recently used
+/// first.
+static NSArray<NSNumber *> *mimiWindowNumbersForPID(pid_t pid) {
+	CFArrayRef windowList =
+	    CGWindowListCopyWindowInfo(kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+	if (!windowList)
+		return @[];
+
+	NSMutableArray<NSNumber *> *numbers = [NSMutableArray array];
+	CFIndex count = CFArrayGetCount(windowList);
+	for (CFIndex i = 0; i < count; i++) {
+		NSDictionary *info = (__bridge NSDictionary *)CFArrayGetValueAtIndex(windowList, i);
+		if ([info[(__bridge NSString *)kCGWindowOwnerPID] intValue] != pid)
+			continue;
+		if ([info[(__bridge NSString *)kCGWindowLayer] intValue] != 0)
+			continue;
+
+		NSNumber *number = info[(__bridge NSString *)kCGWindowNumber];
+		if (number)
+			[numbers addObject:number];
+	}
+
+	CFRelease(windowList);
+	return numbers;
+}
+
+/// Process identifiers of every process owning a window on any space.
+static NSArray<NSNumber *> *mimiAllWindowOwnerPIDs(void) {
+	CFArrayRef windowList =
+	    CGWindowListCopyWindowInfo(kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+	if (!windowList)
+		return @[];
+
+	NSMutableOrderedSet<NSNumber *> *pids = [NSMutableOrderedSet orderedSet];
+	CFIndex count = CFArrayGetCount(windowList);
+	for (CFIndex i = 0; i < count; i++) {
+		NSDictionary *info = (__bridge NSDictionary *)CFArrayGetValueAtIndex(windowList, i);
+		NSNumber *pid = info[(__bridge NSString *)kCGWindowOwnerPID];
+		if (pid && pid.intValue > 0)
+			[pids addObject:pid];
+	}
+
+	CFRelease(windowList);
+	return pids.array;
+}
+
+static bool mimiApplicationMatches(NSRunningApplication *app, NSString *query) {
+	if (!app || app.activationPolicy != NSApplicationActivationPolicyRegular)
+		return false;
+	if (app.bundleIdentifier && [app.bundleIdentifier caseInsensitiveCompare:query] == NSOrderedSame)
+		return true;
+	if (app.localizedName && [app.localizedName caseInsensitiveCompare:query] == NSOrderedSame)
+		return true;
+	return false;
+}
+
+/// The space a window sits on: its one space, or 0 when it is on every space
+/// (assigned to all desktops) or on none.
+static uint64_t mimiSpaceForWindowNumber(CGWindowID number) {
+	CFNumberRef numberRef = CFNumberCreate(NULL, kCFNumberSInt32Type, &number);
+	if (!numberRef)
+		return 0;
+
+	CFArrayRef windowIDs = CFArrayCreate(NULL, (const void **)&numberRef, 1, &kCFTypeArrayCallBacks);
+	CFRelease(numberRef);
+	if (!windowIDs)
+		return 0;
+
+	CFArrayRef spaces = SLSCopySpacesForWindows(SLSMainConnectionID(), kMimiAllSpacesMask, windowIDs);
+	CFRelease(windowIDs);
+	if (!spaces)
+		return 0;
+
+	uint64_t space = 0;
+	if (CFArrayGetCount(spaces) == 1) {
+		CFNumberRef spaceRef = (CFNumberRef)CFArrayGetValueAtIndex(spaces, 0);
+		if (spaceRef)
+			CFNumberGetValue(spaceRef, CFNumberGetType(spaceRef), &space);
+	}
+
+	CFRelease(spaces);
+	return space;
+}
+
+#pragma mark - Public Application API
+
+int MimiFindApplication(const char *query) {
+	if (!query)
+		return 0;
+
+	@autoreleasepool {
+		NSString *wanted = [NSString stringWithUTF8String:query];
+		if (wanted.length == 0)
+			return 0;
+
+		// A bundle identifier is answered by Launch Services, which is live
+		// on every thread.
+		for (NSRunningApplication *app in [NSRunningApplication runningApplicationsWithBundleIdentifier:wanted]) {
+			if (mimiApplicationMatches(app, wanted))
+				return (int)app.processIdentifier;
+		}
+
+		// A name is matched against the owners of the windows on every space,
+		// each looked up live by pid. -[NSWorkspace runningApplications] is
+		// refreshed only from the main thread's run loop, which the daemon's
+		// action thread never pumps, so it is the last resort below rather
+		// than the first stop.
+		for (NSNumber *pid in mimiAllWindowOwnerPIDs()) {
+			NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid.intValue];
+			if (mimiApplicationMatches(app, wanted))
+				return (int)app.processIdentifier;
+		}
+
+		for (NSRunningApplication *app in [NSWorkspace sharedWorkspace].runningApplications) {
+			if (mimiApplicationMatches(app, wanted))
+				return (int)app.processIdentifier;
+		}
+
+		return 0;
+	}
+}
+
+MimiAppWindow *MimiCopyApplicationWindows(int pid, int *count) {
+	if (!count)
+		return NULL;
+	*count = 0;
+
+	@autoreleasepool {
+		// The application's windows in the window server's order, front to
+		// back, narrowed to the ones the window server itself counts as real
+		// and not minimized. Accessibility is not consulted here on purpose:
+		// its window list leaves out every window on another space, which is
+		// exactly the window this action exists to reach.
+		NSArray<NSNumber *> *order = mimiWindowNumbersForPID((pid_t)pid);
+		if (order.count == 0)
+			return NULL;
+
+		NSSet<NSNumber *> *real = mimiRealWindowNumbers();
+		NSMutableArray<NSNumber *> *kept = [NSMutableArray array];
+		for (NSNumber *number in order) {
+			if ([real containsObject:number])
+				[kept addObject:number];
+		}
+		if (kept.count == 0)
+			return NULL;
+
+		MimiAppWindow *result = (MimiAppWindow *)calloc(kept.count, sizeof(MimiAppWindow));
+		if (!result)
+			return NULL;
+
+		for (NSUInteger i = 0; i < kept.count; i++) {
+			CGWindowID number = kept[i].unsignedIntValue;
+			result[i].number = number;
+			result[i].space = mimiSpaceForWindowNumber(number);
+		}
+
+		*count = (int)kept.count;
+		return result;
+	}
+}
+
+/// Accessibility lists an application's windows on the active space only, and
+/// updates that list a moment after a space switch lands, so the lookup is
+/// tried a few times before giving up.
+static const int kMimiRaiseAttempts = 5;
+static const useconds_t kMimiRaiseRetryDelay = 30000;
+
+static AXUIElementRef mimiCopyWindowElement(int pid, uint32_t number) {
+	AXUIElementRef appElement = AXUIElementCreateApplication((pid_t)pid);
+	if (!appElement)
+		return NULL;
+
+	CFTypeRef windowsValue = NULL;
+	AXError error = AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute, &windowsValue);
+	CFRelease(appElement);
+	if (error != kAXErrorSuccess || !windowsValue)
+		return NULL;
+
+	AXUIElementRef found = NULL;
+	if (CFGetTypeID(windowsValue) == CFArrayGetTypeID()) {
+		CFArrayRef windows = (CFArrayRef)windowsValue;
+		CFIndex windowCount = CFArrayGetCount(windows);
+		for (CFIndex i = 0; i < windowCount && !found; i++) {
+			AXUIElementRef window = (AXUIElementRef)CFArrayGetValueAtIndex(windows, i);
+			CGWindowID candidate = 0;
+			if (window && _AXUIElementGetWindow(window, &candidate) == kAXErrorSuccess && candidate == number)
+				found = (AXUIElementRef)CFRetain(window);
+		}
+	}
+
+	CFRelease(windowsValue);
+	return found;
+}
+
+int MimiRaiseWindowNumber(int pid, uint32_t number) {
+	@autoreleasepool {
+		for (int attempt = 0; attempt < kMimiRaiseAttempts; attempt++) {
+			AXUIElementRef window = mimiCopyWindowElement(pid, number);
+			if (window) {
+				int raised = MimiActivateWindow((void *)window);
+				CFRelease(window);
+				return raised;
+			}
+			usleep(kMimiRaiseRetryDelay);
+		}
+
+		MIMI_LOG("window %u of pid %d is not in its application's Accessibility window list", (unsigned)number, pid);
+		return 0;
+	}
+}
+
+int MimiActivateApplication(int pid) {
+	@autoreleasepool {
+		NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:(pid_t)pid];
+		if (!app)
+			return 0;
+
+		return [app activateWithOptions:0] ? 1 : 0;
+	}
+}

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -19,6 +19,31 @@ void *MimiGetFrontmostWindow(void);
 int MimiActivateWindow(void *window);
 /// Return the process identifier of the application owning the window, or 0.
 int MimiGetWindowPID(void *window);
+/// Return the window server's number for the window, or 0 when it has none.
+uint32_t MimiGetWindowNumber(void *window);
+
+#pragma mark - Application Functions
+
+/// One window of an application as the window server lists it.
+typedef struct {
+	/// The window server's number for the window.
+	uint32_t number;
+	/// The space the window is on, or 0 when it is on every space or none.
+	uint64_t space;
+} MimiAppWindow;
+
+/// Resolve a running application by bundle identifier or localized name
+/// (case-insensitive). Returns its pid, or 0 when nothing running matches.
+int MimiFindApplication(const char *query);
+/// Copy an application's real, unminimized windows on every space, front to
+/// back. Sets *count; the caller frees the array. Auxiliary windows (popovers,
+/// sheets, tab previews) are left out.
+MimiAppWindow *MimiCopyApplicationWindows(int pid, int *count);
+/// Bring one of an application's windows to the front by number. The window
+/// has to be on the active space, which is when Accessibility lists it.
+int MimiRaiseWindowNumber(int pid, uint32_t number);
+/// Bring an application to the front without naming a window.
+int MimiActivateApplication(int pid);
 
 #pragma mark - Screen Functions
 

--- a/internal/native/window.go
+++ b/internal/native/window.go
@@ -139,6 +139,17 @@ func (e *Element) PID() (int, error) {
 	return pid, nil
 }
 
+// Number returns the window server's number for the window, which is stable
+// for the window's lifetime and the same however the window was reached, or 0
+// when it has none.
+func (e *Element) Number() uint32 {
+	if e.ref == nil {
+		return 0
+	}
+
+	return uint32(C.MimiGetWindowNumber(e.ref)) //nolint:nlreturn // cgo call expansion
+}
+
 // GetFrame returns the window's position and size [x, y, w, h] in screen coordinates.
 func (e *Element) GetFrame() (float64, float64, float64, float64, error) {
 	if e.ref == nil {

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -9,6 +9,8 @@
 #import <Cocoa/Cocoa.h>
 #import <CoreGraphics/CoreGraphics.h>
 
+extern AXError _AXUIElementGetWindow(AXUIElementRef element, CGWindowID *out);
+
 /// Process identifiers of every process owning an on-screen, layer-0 window,
 /// in ascending order. This is the source of the applications to enumerate, so
 /// it is deliberately fetched fresh on every call.
@@ -518,6 +520,17 @@ int MimiSetWindowFrame(void *window, double x, double y, double w, double h) {
 
 		return (posError == kAXErrorSuccess && sizeError == kAXErrorSuccess) ? 1 : 0;
 	}
+}
+
+uint32_t MimiGetWindowNumber(void *window) {
+	if (!window)
+		return 0;
+
+	CGWindowID number = 0;
+	if (_AXUIElementGetWindow((AXUIElementRef)window, &number) != kAXErrorSuccess)
+		return 0;
+
+	return (uint32_t)number;
 }
 
 int MimiActivateWindow(void *window) {


### PR DESCRIPTION
## Description

This PR adds `mimi action focus_app <name|bundle-id>`, the instant replacement for `open -a Safari` when Safari's window is on another space. macOS switches there too, but through its own slide animation; mimi already knew how to switch instantly and nothing drove that from an application's name.

The action lists the application's windows through the window server, keeping only real, unminimized windows (popovers, sheets and tab previews are dropped, using the same window-server tests yabai relies on), and reads each window's space through SkyLight. It switches to the chosen window's space with the same gesture `mimi action space` makes, then raises the window. The switch comes first for a reason worth knowing: an application's Accessibility window list contains only the windows on the active space, so a window on another space cannot be raised until that space is in front.

Run again while the application is already in front, it moves to the application's next window: by space, left to right, then by age within a space, wrapping at the end. The first press from elsewhere lands on the most recently used window. The order is read off the desktop every time, so it needs no memory and behaves the same from the CLI and the daemon. `docs/adr/0004-focus-app-cycles-in-desktop-order.md` records why this order and not most-recently-used, and why the remote-token workaround yabai uses to resolve hidden windows was rejected (a sweep that finds nothing costs 0.4s per press here).

## Commands

| Surface | What it does |
| --- | --- |
| `mimi action focus_app <name\|bundle-id>` | Switches to the space of one of the application's windows and raises it. Name matching is case-insensitive; a bundle identifier is tried first. |
| Repeated with the application in front | Steps to the application's next window across spaces, wrapping. |
| Not running | Fails with `no running application named "X"`, so `mimi action focus_app Safari \|\| open -a Safari` covers launching. |

An application with no window is brought to the front as it is. A window on every space is raised without a switch. Minimized windows are skipped. Cross-display switches carry the same pointer warp as `space`.

## Potentially disruptive: the daemon wire version is bumped

The new action rides the daemon socket, so the request protocol version moved from 5 to 6. A daemon left running across the upgrade rejects this build's requests, the CLI warns and runs the action on the direct path, and the warning stops after `mimi stop && mimi start` or `mimi services restart`. Still one restart per release.

Existing configs and hotkeys keep working unchanged.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Two displays, ten spaces. Safari given a second window and that window moved to space 2; the terminal on space 2. Four presses from the terminal:

```
at terminal: {"index":2} {"pid":90234}            ghostty, space 2
press 1:     {"index":2} {"pid":59818, x=0}       Safari, most recently used window, no switch
press 2:     {"index":1} {"pid":59818, x=8}       Safari's other window, switched to space 1
press 3:     {"index":2} {"pid":59818, x=0}       back to the first, switched to space 2
press 4:     {"index":1} {"pid":59818, x=8}       and round again
```

With a single Safari window, repeated presses stay on it. `focus_app NoSuchApp` fails with the message above, exit 1.

## Additional Context

The first attempt read the application's windows through Accessibility and found none for Safari, whose only window was on another space; the same probe showed 18 helper windows in the window server for Safari with no space at all, and one auxiliary window on a space that Accessibility never exposes as a window. The window-server filter is what separates those from the two real windows, and the ADR documents the measurements.

Name lookup goes bundle identifier first (Launch Services, live on every thread), then the owners of windows on any space looked up live by pid, and only last the workspace's running-applications list, which is refreshed only from a main run loop the daemon's action thread never pumps. An application with no windows launched after the daemon started may therefore be reported as not running on the daemon path only.

Private API added: `SLSCopyWindowsWithOptionsAndTags`, the `SLSWindowQuery*` and `SLSWindowIterator*` family, and `SLSCopySpacesForWindows`, all in one Objective-C file. Also `_AXUIElementGetWindow` to number a window, which `move_window_to_space` already used.
