### PR TITLE
test(baseline): record the five thirds presets into the window baseline

### DIFF
--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/y3owk1n/mimi/internal/baseline"
 )
 
-// The counts the recorder covers: ten presets in two margin states plus one
-// system-default case, nine anchors in two margin states, ten explicit-flag
-// combinations, and four focus directions.
+// The counts the recorder covers: fifteen presets in two margin states plus
+// one system-default case, nine anchors in two margin states, ten
+// explicit-flag combinations, and four focus directions.
 const (
-	wantResizeCases = 10*2 + 1 + 9*2 + 10
+	wantResizeCases = 15*2 + 1 + 9*2 + 10
 	wantFocusCases  = 4
 )
 

--- a/internal/baseline/geometry_baseline_test.go
+++ b/internal/baseline/geometry_baseline_test.go
@@ -13,7 +13,7 @@ import (
 //
 // macOS stores window frames in whole points: every frame in the recording was
 // read back after the Accessibility API had truncated the one it was handed.
-// Forty-seven of the forty-nine recorded cases are whole points already and
+// Fifty-seven of the fifty-nine recorded cases are whole points already and
 // match exactly; the two percentage ones are fractional, and the truncation
 // moves them by less than a point. Nothing the geometry itself could get wrong
 // is that small — the margin rules move an edge by four points, the anchors

--- a/internal/baseline/window_baseline.json
+++ b/internal/baseline/window_baseline.json
@@ -316,6 +316,196 @@
 			}
 		},
 		{
+			"name": "preset/left-third/margin",
+			"args": {
+				"preset": "left-third",
+				"useMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 38,
+				"w": 628,
+				"h": 1034
+			}
+		},
+		{
+			"name": "preset/left-third/no-margin",
+			"args": {
+				"preset": "left-third",
+				"noMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 30,
+				"w": 640,
+				"h": 1050
+			}
+		},
+		{
+			"name": "preset/center-third/margin",
+			"args": {
+				"preset": "center-third",
+				"useMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 644,
+				"y": 38,
+				"w": 632,
+				"h": 1034
+			}
+		},
+		{
+			"name": "preset/center-third/no-margin",
+			"args": {
+				"preset": "center-third",
+				"noMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 640,
+				"y": 30,
+				"w": 640,
+				"h": 1050
+			}
+		},
+		{
+			"name": "preset/right-third/margin",
+			"args": {
+				"preset": "right-third",
+				"useMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 1284,
+				"y": 38,
+				"w": 628,
+				"h": 1034
+			}
+		},
+		{
+			"name": "preset/right-third/no-margin",
+			"args": {
+				"preset": "right-third",
+				"noMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 1280,
+				"y": 30,
+				"w": 640,
+				"h": 1050
+			}
+		},
+		{
+			"name": "preset/left-two-thirds/margin",
+			"args": {
+				"preset": "left-two-thirds",
+				"useMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 8,
+				"y": 38,
+				"w": 1268,
+				"h": 1034
+			}
+		},
+		{
+			"name": "preset/left-two-thirds/no-margin",
+			"args": {
+				"preset": "left-two-thirds",
+				"noMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": -0,
+				"y": 30,
+				"w": 1280,
+				"h": 1050
+			}
+		},
+		{
+			"name": "preset/right-two-thirds/margin",
+			"args": {
+				"preset": "right-two-thirds",
+				"useMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 644,
+				"y": 38,
+				"w": 1268,
+				"h": 1034
+			}
+		},
+		{
+			"name": "preset/right-two-thirds/no-margin",
+			"args": {
+				"preset": "right-two-thirds",
+				"noMargin": true
+			},
+			"start": {
+				"x": 300,
+				"y": 180,
+				"w": 700,
+				"h": 500
+			},
+			"want": {
+				"x": 640,
+				"y": 30,
+				"w": 1280,
+				"h": 1050
+			}
+		},
+		{
 			"name": "preset/center/margin",
 			"args": {
 				"preset": "center",
@@ -739,7 +929,7 @@
 				"h": 500
 			},
 			"want": {
-				"x": 0,
+				"x": -0,
 				"y": 480,
 				"w": 800,
 				"h": 600
@@ -1057,7 +1247,7 @@
 				"h": 500
 			},
 			"want": {
-				"x": 0,
+				"x": -0,
 				"y": 30,
 				"w": 800,
 				"h": 1050

--- a/internal/baseline/window_integration_test.go
+++ b/internal/baseline/window_integration_test.go
@@ -315,12 +315,13 @@ func (h *harness) runResize(
 }
 
 // resizeSpecs enumerates every resize_window invocation the baseline covers:
-// all ten presets in both margin states, all nine anchors in both margin
+// all fifteen presets in both margin states, all nine anchors in both margin
 // states, and the explicit-flag combinations.
 func (h *harness) resizeSpecs() []resizeSpec {
 	presets := []string{
 		presetLeftHalf, "right-half", "top-half", "bottom-half",
 		"top-left", "top-right", "bottom-left", "bottom-right",
+		"left-third", "center-third", "right-third", "left-two-thirds", "right-two-thirds",
 		"center", "fill",
 	}
 	anchors := []string{"tl", "tc", "tr", "cl", "cc", "cr", "bl", "bc", "br"}


### PR DESCRIPTION
## Description

This PR extends the recorded window baseline to the five thirds presets added in #196. The baseline is the oracle the resize geometry is replayed against, and until now it covered the ten presets that existed when it was recorded; the thirds were pinned by geometry unit tests only.

The recorder now covers all fifteen presets in both margin states, and the recording was made again on a display of the same shape as the original (1920x1080, 30-point menu bar, tiled margins on at 8 points). Every one of the 49 existing cases is unchanged byte for byte, the display block is identical, and the ten new cases land on exactly the frames the geometry tests predicted.

No user-facing surface changes.

## Related Issues

Follow-up to #196.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [x] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, nothing user-facing changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

The ten new cases, as macOS placed them:

```
left-third        margin 8,38 628x1034     no-margin 0,30 640x1050
center-third      margin 644,38 632x1034   no-margin 640,30 640x1050
right-third       margin 1284,38 628x1034  no-margin 1280,30 640x1050
left-two-thirds   margin 8,38 1268x1034    no-margin 0,30 1280x1050
right-two-thirds  margin 644,38 1268x1034  no-margin 640,30 1280x1050
```

## Additional Context

Re-recorded with `MIMI_RECORD_BASELINE=1 go test -tags=integration -run TestWindowBaseline_ResizeAndFocus ./internal/baseline`, with a second display attached; the recorder's windows opened on the primary and the recorded display block matches the original, which is what makes the diff additions only.
