### PR TITLE
fix(action,native): open a window when focus_app reaches a windowless application

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -134,7 +134,8 @@ chosen. When it is already in front, running the command again moves on to
 its next window: windows are visited by space, left to right, and by age
 within a space, wrapping at the end, so repeated presses reach every window
 the application has. Minimized windows are skipped. An application with no
-window is brought to the front as it is.
+window is reopened, as if its Dock icon were clicked, so it opens a fresh
+window and comes to the front.
 
 The application has to be running; pair with open for the other case:
   mimi action focus_app Safari || open -a Safari

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -119,7 +119,7 @@ Which window is chosen depends on where focus is:
 - When the application is **not in front**, its most recently used window is chosen, wherever it is.
 - When it **is already in front**, running the command again moves on to its next window. Windows are visited by space, left to right, and by age within a space, wrapping at the end, so repeated presses reach every window the application has, and the order never depends on which window was used last.
 
-Minimized windows are skipped. A window assigned to every space is raised without a switch. An application with no window is brought to the front as it is. The switch across spaces is the same dock-swipe gesture as `space`, including the pointer warp when the window is on another display. **Accessibility permission is required.**
+Minimized windows are skipped. A window assigned to every space is raised without a switch. An application with no window is reopened, as if its Dock icon were clicked, so it opens a fresh window and comes to the front. Finder is the one you will notice, since it is always running and used to end up in front with nothing to show. The switch across spaces is the same dock-swipe gesture as `space`, including the pointer warp when the window is on another display. **Accessibility permission is required.**
 
 ### `mimi action space <number|next|prev>`
 

--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -111,9 +111,9 @@ type Desktop interface {
 	// error for one that is not: the caller switches first.
 	RaiseWindow(pid int, number uint32) error
 
-	// ActivateApplication brings an application to the front without naming
-	// a window, which is what focusing an application with no windows means.
-	ActivateApplication(pid int) error
+	// ReopenApplication reopens an application as a Dock click would. An
+	// application with no window opens one and comes to the front.
+	ReopenApplication(pid int) error
 
 	// MissionControlActive reports whether Mission Control is open, which is
 	// the state the space actions refuse to run in.

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -51,8 +51,8 @@ type fakeDesktop struct {
 	// appWindows lists each application's windows front to back, as
 	// ApplicationWindows reports them; every id is one of windows'.
 	appWindows map[int][]action.AppWindow
-	// activatedApp is the last application activated without a window.
-	activatedApp int
+	// reopenedApp is the last application reopened for having no window.
+	reopenedApp int
 
 	displays    []action.Display
 	displaysErr error
@@ -177,8 +177,8 @@ func (d *fakeDesktop) RaiseWindow(pid int, number uint32) error {
 	return derrors.Newf(derrors.CodeAccessibilityFailed, "window %d is not listed", number)
 }
 
-func (d *fakeDesktop) ActivateApplication(pid int) error {
-	d.activatedApp = pid
+func (d *fakeDesktop) ReopenApplication(pid int) error {
+	d.reopenedApp = pid
 
 	return nil
 }

--- a/internal/action/focus_app.go
+++ b/internal/action/focus_app.go
@@ -19,8 +19,8 @@ import (
 // depends on which window was used last; see
 // docs/adr/0004-focus-app-cycles-in-desktop-order.md.
 //
-// An application with no window is brought to the front as it is, which is
-// what activating it means.
+// An application with no window is reopened, as a Dock click would, so it
+// opens one and comes to the front.
 func (e *Executor) FocusApp(query string) error {
 	err := e.desktop.EnsureAccessible()
 	if err != nil {
@@ -48,9 +48,9 @@ func (e *Executor) FocusApp(query string) error {
 	}
 
 	if len(windows) == 0 {
-		err = e.desktop.ActivateApplication(pid)
+		err = e.desktop.ReopenApplication(pid)
 		if err != nil {
-			return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to activate application")
+			return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to reopen application")
 		}
 
 		return nil

--- a/internal/action/focus_app_test.go
+++ b/internal/action/focus_app_test.go
@@ -175,9 +175,9 @@ func TestExecutor_FocusApp_AWindowOnEverySpaceNeedsNoSwitch(t *testing.T) {
 	}
 }
 
-// TestExecutor_FocusApp_NoWindowsActivatesTheApplication: an application with
-// nothing to raise is still brought to the front.
-func TestExecutor_FocusApp_NoWindowsActivatesTheApplication(t *testing.T) {
+// TestExecutor_FocusApp_NoWindowsReopensTheApplication: an application with
+// nothing to raise is reopened instead.
+func TestExecutor_FocusApp_NoWindowsReopensTheApplication(t *testing.T) {
 	t.Parallel()
 
 	desktop := desktopWithApp(0)
@@ -185,8 +185,8 @@ func TestExecutor_FocusApp_NoWindowsActivatesTheApplication(t *testing.T) {
 
 	focusApp(t, desktop)
 
-	if desktop.activatedApp != appPID {
-		t.Fatalf("activated application = %d, want %d", desktop.activatedApp, appPID)
+	if desktop.reopenedApp != appPID {
+		t.Fatalf("reopened application = %d, want %d", desktop.reopenedApp, appPID)
 	}
 
 	wantFocused(t, desktop, otherWindow)

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -97,9 +97,9 @@ func (d *nativeDesktop) RaiseWindow(pid int, number uint32) error {
 	return native.RaiseWindowNumber(pid, number)
 }
 
-// ActivateApplication brings an application to the front.
-func (d *nativeDesktop) ActivateApplication(pid int) error {
-	return native.ActivateApplication(pid)
+// ReopenApplication reopens an application as a Dock click does.
+func (d *nativeDesktop) ReopenApplication(pid int) error {
+	return native.ReopenApplication(pid)
 }
 
 // FrontmostWindow returns the window currently in front.

--- a/internal/native/application.go
+++ b/internal/native/application.go
@@ -82,11 +82,11 @@ func RaiseWindowNumber(pid int, number uint32) error {
 	return nil
 }
 
-// ActivateApplication brings an application to the front without naming a
-// window, which is what activating an application with no windows means.
-func ActivateApplication(pid int) error {
-	if C.MimiActivateApplication(C.int(pid)) == 0 {
-		return derrors.Newf(derrors.CodeActionFailed, "failed to activate application %d", pid)
+// ReopenApplication reopens an application as a Dock click would. An
+// application with no window opens one and comes to the front.
+func ReopenApplication(pid int) error {
+	if C.MimiReopenApplication(C.int(pid)) == 0 {
+		return derrors.Newf(derrors.CodeActionFailed, "failed to reopen application %d", pid)
 	}
 
 	return nil

--- a/internal/native/application.m
+++ b/internal/native/application.m
@@ -323,12 +323,35 @@ int MimiRaiseWindowNumber(int pid, uint32_t number) {
 	}
 }
 
-int MimiActivateApplication(int pid) {
+/// How long a reopen may take before plain activation stands in for it.
+static const int64_t kMimiReopenTimeout = 2 * NSEC_PER_SEC;
+
+int MimiReopenApplication(int pid) {
 	@autoreleasepool {
 		NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:(pid_t)pid];
 		if (!app)
 			return 0;
 
+		// Launch Services sends a running application the same reopen event
+		// a Dock click does, and the application answers by opening a window
+		// when it has none. Plain activation does not, which is how Finder
+		// used to end up in front with nothing to show.
+		NSURL *bundleURL = app.bundleURL;
+		if (!bundleURL)
+			return [app activateWithOptions:0] ? 1 : 0;
+
+		dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+		__block int reopened = 0;
+		[[NSWorkspace sharedWorkspace] openApplicationAtURL:bundleURL
+		                                      configuration:[NSWorkspaceOpenConfiguration configuration]
+		                                  completionHandler:^(NSRunningApplication *running, NSError *error) {
+			                                  reopened = running != nil && error == nil;
+			                                  dispatch_semaphore_signal(sem);
+		                                  }];
+		if (dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, kMimiReopenTimeout)) == 0 && reopened)
+			return 1;
+
+		MIMI_LOG("reopen of pid %d did not complete, activating instead", pid);
 		return [app activateWithOptions:0] ? 1 : 0;
 	}
 }

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -42,8 +42,9 @@ MimiAppWindow *MimiCopyApplicationWindows(int pid, int *count);
 /// Bring one of an application's windows to the front by number. The window
 /// has to be on the active space, which is when Accessibility lists it.
 int MimiRaiseWindowNumber(int pid, uint32_t number);
-/// Bring an application to the front without naming a window.
-int MimiActivateApplication(int pid);
+/// Reopen an application as a Dock click would. An application with no window
+/// opens one and comes to the front.
+int MimiReopenApplication(int pid);
 
 #pragma mark - Screen Functions
 


### PR DESCRIPTION
## Description

This PR makes `mimi action focus_app` open a window when the application it reaches has none.

Before, a windowless application was only activated, which changes the active application and nothing else. Finder is always running, so `focus_app Finder` with every Finder window closed put Finder in front with nothing on screen.

Now the windowless case reopens the application through Launch Services, which delivers the same reopen event a Dock click does. Applications answer it by opening a window when they have none, then come to the front. Applications that ignore reopen, or whose reopen does not answer within two seconds, fall back to plain activation as before. Applications that already have a window are unaffected.

The `Desktop` seam was renamed from `ActivateApplication` to `ReopenApplication` to match what it now does. CLI help and `docs/CLI.md` describe the new behaviour.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

How to test:

```sh
osascript -e 'tell application "Finder" to close every window'
just build && ./bin/mimi action focus_app Finder
osascript -e 'tell application "Finder" to count windows'   # 1
```

Verified on macOS 26.6. An AppleScript `make new Finder window` special case was considered and rejected: it is Finder-only and needs the Automation permission, while reopen is what the Dock already does for every application.
