### PR TITLE
fix(action,space): raise the moved window after following it to a space

### DIFF
--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -214,8 +214,9 @@ This command uses private APIs (SkyLight) to move the window instantly
 without scripting additions or disabling SIP on macOS.
 
 With --follow, focus switches to the destination space once the window is
-there, the same way "mimi action space" switches. Without it the window
-leaves and the current space stays in front.
+there, the same way "mimi action space" switches, and the moved window is
+brought back to the front on that space. Without it the window leaves and
+the current space stays in front.
 
 Examples:
   mimi action move_window_to_space 2             Move current window to space 2

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -138,7 +138,7 @@ Move the frontmost window to a space by its 1-based index, or cycle to the next/
 | ---------- | ---------------------------------------------------------------- |
 | `--follow` | Switch to the destination space once the window is there         |
 
-Without `--follow` the window leaves and the current space stays in front. With it, the switch is the same dock-swipe gesture `mimi action space` makes, so it is subject to the same timing. If the move lands but the switch fails, the error says the window moved and the window stays on its new space.
+Without `--follow` the window leaves and the current space stays in front. With it, the switch is the same dock-swipe gesture `mimi action space` makes, so it is subject to the same timing, and the moved window is raised again once the switch lands, since macOS would otherwise bring forward whatever was last in front on that space. If the move lands but the switch or the raise fails, the error says the window moved and the window stays on its new space.
 
 ### `mimi action move_window_to_display <number|next|prev>`
 

--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -154,8 +154,11 @@ type Desktop interface {
 
 	// MoveWindowToSpace moves the frontmost window to the Mission Control
 	// space at the given 1-based index, which the caller has already checked
-	// against SpaceCount.
-	MoveWindowToSpace(index int) error
+	// against SpaceCount, and reports the window it moved. The window's ID is
+	// not meaningful afterwards: the window has left the active space, so
+	// only its PID and Number identify it, and those are what RaiseWindow
+	// takes once that space is in front.
+	MoveWindowToSpace(index int) (Window, error)
 
 	// RefreshWorkspaceTitle brings any on-screen UI for the active space (the
 	// systray's title, on the desktop macOS itself runs) up to date after a

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -104,11 +104,17 @@ func (e *Executor) FocusSpace(index int) error {
 }
 
 // MoveWindowToSpace moves the frontmost window to the space at the given
-// 1-based index, and with follow set switches to that space afterwards.
+// 1-based index, and with follow set switches to that space afterwards and
+// raises the moved window there.
 //
 // The switch is the same one the space action makes, so a window that was
 // moved but could not be followed is reported as such and stays where it was
 // moved to: the move landed, and undoing it would be a second surprise.
+//
+// The raise is needed because macOS refocuses the next window on the space
+// the window left the moment it goes, and then brings whatever was last in
+// front on the destination space forward when the switch lands. Without it
+// the user follows the window and ends up in another application.
 func (e *Executor) MoveWindowToSpace(index int, follow bool) error {
 	err := e.desktop.EnsureAccessible()
 	if err != nil {
@@ -127,7 +133,7 @@ func (e *Executor) MoveWindowToSpace(index int, follow bool) error {
 		return err
 	}
 
-	err = e.desktop.MoveWindowToSpace(index)
+	moved, err := e.desktop.MoveWindowToSpace(index)
 	if err != nil {
 		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to move window")
 	}
@@ -141,6 +147,18 @@ func (e *Executor) MoveWindowToSpace(index int, follow bool) error {
 				err,
 				derrors.CodeActionFailed,
 				"window moved, but failed to follow it to space %d",
+				index,
+			)
+		}
+
+		err = e.desktop.RaiseWindow(moved.PID, moved.Number)
+		if err != nil {
+			e.desktop.RefreshWorkspaceTitle()
+
+			return derrors.Wrapf(
+				err,
+				derrors.CodeActionFailed,
+				"window moved to space %d, but failed to focus it there",
 				index,
 			)
 		}

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -74,6 +74,11 @@ type fakeDesktop struct {
 	// windowSpace is the space the frontmost window sits on, which is what
 	// move_window_to_space is observed through.
 	windowSpace int
+	// movedWindow is the window move_window_to_space last moved, so a raise
+	// after the follow can be checked against it.
+	movedWindow action.WindowID
+	// raiseErr fails every RaiseWindow when set.
+	raiseErr error
 
 	// refreshWorkspaceTitleCalls counts how many times the desktop's systray
 	// title was asked to catch up with the active space.
@@ -181,6 +186,29 @@ func (d *fakeDesktop) ApplicationWindows(pid int) ([]action.AppWindow, error) {
 // RaiseWindow models the one constraint the real desktop has: a window is
 // reachable through Accessibility only while its space is in front.
 func (d *fakeDesktop) RaiseWindow(pid int, number uint32) error {
+	if d.raiseErr != nil {
+		return d.raiseErr
+	}
+
+	// A window that was just moved is on windowSpace, which the fake's
+	// appWindows listing does not know about.
+	if d.movedWindow != 0 {
+		index, err := d.indexOf(d.movedWindow)
+		if err == nil && d.windows[index].pid == pid && d.windows[index].number == number {
+			if d.windowSpace != d.activeSpace {
+				return derrors.Newf(
+					derrors.CodeAccessibilityFailed,
+					"window %d is on space %d, not the active space %d",
+					number,
+					d.windowSpace,
+					d.activeSpace,
+				)
+			}
+
+			return d.ActivateWindow(d.movedWindow)
+		}
+	}
+
 	for _, win := range d.appWindows[pid] {
 		if win.Number != number {
 			continue
@@ -295,14 +323,25 @@ func (d *fakeDesktop) FocusSpace(index int) error {
 	return nil
 }
 
-func (d *fakeDesktop) MoveWindowToSpace(index int) error {
+func (d *fakeDesktop) MoveWindowToSpace(index int) (action.Window, error) {
 	if d.moveErr != nil {
-		return d.moveErr
+		return action.Window{}, d.moveErr
+	}
+
+	moved, err := d.FrontmostWindow()
+	if err != nil {
+		return action.Window{}, err
 	}
 
 	d.windowSpace = index
+	d.movedWindow = moved.ID
 
-	return nil
+	// macOS focuses the next window on the space the moved one left; the
+	// fake forgets the frontmost window to stand in for that.
+	d.frontmost = 0
+	d.focused = -1
+
+	return action.Window{PID: moved.PID, Number: moved.Number}, nil
 }
 
 func (d *fakeDesktop) RefreshWorkspaceTitle() {

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -279,9 +279,14 @@ func (d *nativeDesktop) FocusSpace(index int) error {
 }
 
 // MoveWindowToSpace moves the frontmost window to the space at the given
-// 1-based index.
-func (d *nativeDesktop) MoveWindowToSpace(index int) error {
-	return native.MoveWindowToSpace(index)
+// 1-based index and reports which window it moved.
+func (d *nativeDesktop) MoveWindowToSpace(index int) (Window, error) {
+	pid, number, err := native.MoveWindowToSpace(index)
+	if err != nil {
+		return Window{}, err
+	}
+
+	return Window{PID: pid, Number: number}, nil
 }
 
 // RefreshWorkspaceTitle brings the systray's title up to date with the active

--- a/internal/action/space_test.go
+++ b/internal/action/space_test.go
@@ -355,3 +355,77 @@ func TestExecuteCommand_MoveWindowToSpace_CarriesFollowOverTheWire(t *testing.T)
 		)
 	}
 }
+
+// TestExecutor_MoveWindowToSpace_FollowRaisesTheMovedWindow pins the fix for
+// following a window to a space and landing in another application: macOS
+// brings the destination space's last frontmost window forward when the
+// switch lands, so the moved window has to be raised again afterwards.
+func TestExecutor_MoveWindowToSpace_FollowRaisesTheMovedWindow(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(1)
+	desktop.windows[0].number = 42
+	moved := desktop.windows[0].id
+
+	err := action.NewExecutor(desktop).MoveWindowToSpace(3, true)
+	if err != nil {
+		t.Fatalf("MoveWindowToSpace(3, follow) error = %v, want nil", err)
+	}
+
+	if desktop.activeSpace != 3 || desktop.windowSpace != 3 {
+		t.Fatalf(
+			"active space = %d, window space = %d, want both 3",
+			desktop.activeSpace,
+			desktop.windowSpace,
+		)
+	}
+
+	wantFocused(t, desktop, moved)
+	wantRefreshCalls(t, desktop, 1)
+}
+
+// TestExecutor_MoveWindowToSpace_WithoutFollowDoesNotRaise checks the raise
+// is tied to following: a plain move leaves focus where macOS put it.
+func TestExecutor_MoveWindowToSpace_WithoutFollowDoesNotRaise(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(1)
+
+	err := action.NewExecutor(desktop).MoveWindowToSpace(3, false)
+	if err != nil {
+		t.Fatalf("MoveWindowToSpace(3) error = %v, want nil", err)
+	}
+
+	if desktop.frontmost != 0 {
+		t.Fatalf("frontmost = %d, want no window raised", desktop.frontmost)
+	}
+}
+
+// TestExecutor_MoveWindowToSpace_FollowReportsRaiseFailure checks a raise
+// that fails after the move and switch landed is reported as an action
+// failure, with the window left where it was moved to.
+func TestExecutor_MoveWindowToSpace_FollowReportsRaiseFailure(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithSpaces(1)
+	desktop.raiseErr = derrors.New(derrors.CodeAccessibilityFailed, "boom")
+
+	err := action.NewExecutor(desktop).MoveWindowToSpace(3, true)
+	if err == nil {
+		t.Fatal("MoveWindowToSpace(3, follow) error = nil, want an error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeActionFailed) {
+		t.Fatalf("MoveWindowToSpace(3, follow) error = %v, want an action failure", err)
+	}
+
+	if desktop.activeSpace != 3 || desktop.windowSpace != 3 {
+		t.Fatalf(
+			"active space = %d, window space = %d, want both 3",
+			desktop.activeSpace,
+			desktop.windowSpace,
+		)
+	}
+
+	wantRefreshCalls(t, desktop, 1)
+}

--- a/internal/native/space.go
+++ b/internal/native/space.go
@@ -86,31 +86,44 @@ func ActiveSpaceIndexes(displayIDs []uint32) map[uint32]int {
 	return active
 }
 
-// MoveWindowToSpace moves the frontmost window to the space at the given 1-based index.
+// MoveWindowToSpace moves the frontmost window to the space at the given
+// 1-based index and returns the pid and window number of the window it moved,
+// which is what a caller that follows the window needs to raise it again once
+// the destination space is in front. The number is 0 when the window server
+// reports none.
 //
 // As with FocusSpace, the index is expected to name a space that exists.
-func MoveWindowToSpace(index int) error {
+func MoveWindowToSpace(index int) (int, uint32, error) {
 	sid := uint64(C.MimiMissionControlSpaceID(C.int(index)))
 	if sid == 0 {
-		return derrors.Newf(
+		return 0, 0, derrors.Newf(
 			derrors.CodeActionFailed,
 			"failed to resolve Mission Control space at index %d",
 			index,
 		)
 	}
 
-	frontmost := C.MimiGetFrontmostWindow()
+	frontmost := FrontmostWindow()
 	if frontmost == nil {
-		return derrors.New(
+		return 0, 0, derrors.New(
 			derrors.CodeActionFailed,
 			"no active window found to move",
 		)
 	}
 
-	defer C.MimiReleaseElement(frontmost) //nolint:nlreturn
+	defer frontmost.Release()
 
-	if C.MimiMoveWindowToSpace(frontmost, C.uint64_t(sid)) == 0 { //nolint:nlreturn
-		return derrors.New(derrors.CodeActionFailed, "failed to move window to space")
+	// Read the identity before the move: once the window leaves the active
+	// space its application stops listing it through Accessibility.
+	pid, err := frontmost.PID()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	number := frontmost.Number()
+
+	if C.MimiMoveWindowToSpace(frontmost.ref, C.uint64_t(sid)) == 0 { //nolint:nlreturn
+		return 0, 0, derrors.New(derrors.CodeActionFailed, "failed to move window to space")
 	}
 
 	targetDid := uint32(C.MimiSpaceDisplayID(C.uint64_t(sid)))
@@ -118,5 +131,5 @@ func MoveWindowToSpace(index int) error {
 		C.MimiActivateDisplay(C.uint32_t(targetDid))
 	}
 
-	return nil
+	return pid, number, nil
 }


### PR DESCRIPTION
## Description

This PR fixes `move_window_to_space --follow` leaving focus on another application once it reaches the destination space.

When the window left its space, macOS focused the next window there, and when the switch to the destination landed it brought forward whatever had last been in front on that space. The moved window was on the space but not in front. The follow now raises the moved window once the switch lands, so the user arrives in the application they moved. A plain move without `--follow` is unchanged.

If the switch lands but the raise fails, the error says the window moved and could not be focused, and the window stays on its new space.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The raise reuses the retrying lookup `focus_app` already relies on after a space switch, since Accessibility lists a window on the new space only a moment after the swipe lands. The raise fires a normal window focus hook event, which reflects a real focus change. Verified manually on macOS 26 with a space that already held another application.
