### PR TITLE
fix(tiling): scroll the strip example in steps instead of whole columns

### DIFF
--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -73,7 +73,7 @@ The three layouts shipped:
 | `columns.py` | Equal columns. | `togglemax` |
 | `master-stack.py [ratio]` | One master on the left, the rest stacked on the right. | `swap`, `ratio <delta>`, `togglemax` |
 | `bsp.py` | Dwindle BSP, as Hyprland tiles by default. | `swap <dir>`, `togglesplit`, `ratio <delta>`, `togglefloat`, `togglemax` |
-| `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, columns that do not fit park at the edge as slivers. | `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction]`, `center`, `scroll <dir>`, `togglemax` |
+| `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. | `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction]`, `center`, `scroll <dir> [fraction]`, `togglemax` |
 
 None of them takes a gap: the gap is `tiling.gap` in the config when you set
 it, and otherwise the macOS tiled-window margin, the same setting

--- a/examples/tiling/README.md
+++ b/examples/tiling/README.md
@@ -23,7 +23,7 @@ Command Line Tools is enough. Each reads stdin, prints stdout, and imports
 | `monocle.py` | Every window fills the display; move between them with focus. The smallest layout there is, and the one to copy when starting your own. |
 | `columns.py` | Equal-width columns. No state, no commands. |
 | `master-stack.py [ratio]` | One master on the left, the rest stacked on the right. Remembers the master and ratio in `state`, answers `swap` and `ratio +0.05`, reads a drag of the split from either side, and makes a stack window dropped on the master the master. |
-| `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. Answers `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction]`, `center`, `scroll <dir>`, `togglemax`; a dragged edge sets a column's width and a window dropped on a column joins it. |
+| `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. Answers `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction]`, `center`, `scroll <dir> [fraction]`, `togglemax`; a dragged edge sets a column's width and a window dropped on a column joins it. |
 | `bsp.py` | Dwindle BSP, as Hyprland tiles by default: a new window splits the focused one, closing hands the area back, any dragged edge resizes its split, a window dropped on another swaps with it. Answers `swap <dir>`, `togglesplit`, `ratio <delta>`, `togglefloat`. |
 | `rules.py` | What the others share: the float rules (edit the bundle ids and title patterns here), the area to fill, reading the input and writing the output, and the temporary maximise every layout answers as `togglemax`. |
 

--- a/examples/tiling/strip.py
+++ b/examples/tiling/strip.py
@@ -22,7 +22,9 @@ Commands the layout answers (mimi gives them no meaning; this file does):
   mimi tiling cmd width [fraction]       cycle the focused column through a
                                          third, a half, two thirds; or set one
   mimi tiling cmd center                 scroll the focused column to the middle
-  mimi tiling cmd scroll <left|right>    scroll the strip by one column
+  mimi tiling cmd scroll <left|right> [fraction]
+                                        scroll the strip a step that way, a
+                                        quarter of the display unless given
   mimi tiling cmd togglemax              fill the display with the focused
                                          window, for now
 
@@ -39,6 +41,7 @@ from rules import area, clamp, command, gap, maximised, read_input, write_output
 
 PRESETS = [1 / 3, 1 / 2, 2 / 3]
 DEFAULT = 1 / 2
+SCROLL_STEP = 1 / 4
 MIN_WIDTH, MAX_WIDTH = 0.2, 1.0
 # How much of a column wholly off the strip's visible part stays at the
 # display's edge, in points. macOS refuses to put a window entirely off
@@ -92,21 +95,14 @@ def starts(columns, box, gap):
 
 
 def scroll_into_view(columns, index, box, gap, offset):
-    """The offset that shows column index whole, moving as little as needed,
-    and snapped to a column boundary when one lies in the range that keeps
-    it whole, so a neighbour is either fully in view or off the edge rather
-    than cut somewhere across."""
+    """The offset that shows column index whole, moving as little as
+    needed, so a position the user scrolled to stays until the focused
+    column would leave the view."""
     xs, total = starts(columns, box, gap)
     if index is None:
         return clamp(offset, 0, max(0, total - box["width"]))
     left, width = xs[index], col_width(columns[index], box, gap)
-    # The strip may scroll past its end to land on a boundary: empty space
-    # after the last column beats a neighbour parked over it.
-    lo, hi = max(0, left + width - box["width"]), max(0, left)
-    boundaries = [x for x in xs if lo - 0.5 <= x <= hi + 0.5]
-    if boundaries:
-        return min(boundaries, key=lambda x: abs(x - offset))
-    return clamp(offset, lo, hi)
+    return clamp(offset, max(0, left + width - box["width"]), max(0, left))
 
 
 def frames_for(columns, box, edge, gap, offset):
@@ -223,16 +219,13 @@ def main():
             write_output(maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box), state)
             return
         elif name == "scroll" and args:
-            # To the next column boundary past the viewport's left edge, in
-            # the direction asked, so every scroll moves a whole column.
-            xs, total = starts(columns, box, GAP)
-            if args[0] == "right":
-                ahead = [x for x in xs if x > offset + 0.5]
-                offset = ahead[0] if ahead else offset
-            else:
-                behind = [x for x in xs if x < offset - 0.5]
-                offset = behind[-1] if behind else 0
-            offset = max(0, offset)
+            # A step along the strip, in the direction asked, kept within
+            # the strip's ends. Focus stays where it is: the view floats
+            # until the next event would leave the focused column hidden.
+            _, total = starts(columns, box, GAP)
+            step = (float(args[1]) if len(args) > 1 else SCROLL_STEP) * box["width"]
+            offset += step if args[0] == "right" else -step
+            offset = clamp(offset, 0, max(0, total - box["width"]))
             state.update(columns=columns, offset=offset)
             write_output(maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box), state)
             return


### PR DESCRIPTION
## Description

This PR reworks scrolling in the strip layout example. The scroll command jumped the strip to the next column boundary, so every scroll moved a whole column. Now that a column can sit partly off the edge, that felt like paging rather than scrolling.

The strip now moves by a step, a quarter of the display width unless a fraction is given, kept within the strip's ends. A scrolled position also sticks: the strip is only pulled back when the focused column would otherwise leave the view, and then by the smallest amount that keeps it whole, instead of snapping to a column boundary on the next window event. Focus stays where it is while scrolling.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — N/A, Python example and docs only; fast path taken
- [x] Build succeeds (`just build`) — N/A, no Go changes
- [x] Tests added/updated for new or changed functionality — N/A, example layouts carry no tests
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command changes

The strip example's `scroll` command takes an optional step:

```
mimi tiling cmd scroll <left|right> [fraction]
```

`fraction` is a share of the display width and defaults to `0.25`. Existing bindings of `scroll left` and `scroll right` keep working, but move a quarter of the display instead of one column.

## Additional Context

Verified by hand with a running daemon on a four column strip: scrolling moves in steps, a scrolled view survives later window events while the focused column still fits, and is pulled in by the minimum amount when it does not.
