### PR TITLE
feat(tiling): step and reverse the strip example's column width

### DIFF
--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -73,7 +73,7 @@ The three layouts shipped:
 | `columns.py` | Equal columns. | `togglemax` |
 | `master-stack.py [ratio]` | One master on the left, the rest stacked on the right. | `swap`, `ratio <delta>`, `togglemax` |
 | `bsp.py` | Dwindle BSP, as Hyprland tiles by default. | `swap <dir>`, `togglesplit`, `ratio <delta>`, `togglefloat`, `togglemax` |
-| `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. | `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction]`, `center`, `scroll <dir> [fraction]`, `togglemax` |
+| `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. | `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction|prev|+d|-d]`, `center`, `scroll <dir> [fraction]`, `togglemax` |
 
 None of them takes a gap: the gap is `tiling.gap` in the config when you set
 it, and otherwise the macOS tiled-window margin, the same setting

--- a/examples/tiling/README.md
+++ b/examples/tiling/README.md
@@ -23,7 +23,7 @@ Command Line Tools is enough. Each reads stdin, prints stdout, and imports
 | `monocle.py` | Every window fills the display; move between them with focus. The smallest layout there is, and the one to copy when starting your own. |
 | `columns.py` | Equal-width columns. No state, no commands. |
 | `master-stack.py [ratio]` | One master on the left, the rest stacked on the right. Remembers the master and ratio in `state`, answers `swap` and `ratio +0.05`, reads a drag of the split from either side, and makes a stack window dropped on the master the master. |
-| `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. Answers `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction]`, `center`, `scroll <dir> [fraction]`, `togglemax`; a dragged edge sets a column's width and a window dropped on a column joins it. |
+| `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. Answers `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction|prev|+d|-d]`, `center`, `scroll <dir> [fraction]`, `togglemax`; a dragged edge sets a column's width and a window dropped on a column joins it. |
 | `bsp.py` | Dwindle BSP, as Hyprland tiles by default: a new window splits the focused one, closing hands the area back, any dragged edge resizes its split, a window dropped on another swaps with it. Answers `swap <dir>`, `togglesplit`, `ratio <delta>`, `togglefloat`. |
 | `rules.py` | What the others share: the float rules (edit the bundle ids and title patterns here), the area to fill, reading the input and writing the output, and the temporary maximise every layout answers as `togglemax`. |
 

--- a/examples/tiling/strip.py
+++ b/examples/tiling/strip.py
@@ -19,8 +19,11 @@ Commands the layout answers (mimi gives them no meaning; this file does):
                                          on its left, stacked below
   mimi tiling cmd expel                  push the focused window out into a
                                          column of its own, to the right
-  mimi tiling cmd width [fraction]       cycle the focused column through a
-                                         third, a half, two thirds; or set one
+  mimi tiling cmd width [fraction|prev|+d|-d]
+                                        cycle the focused column through a
+                                        third, a half, two thirds (prev goes
+                                        back); set a fraction; or nudge it by
+                                        d, as niri's +10%
   mimi tiling cmd center                 scroll the focused column to the middle
   mimi tiling cmd scroll <left|right> [fraction]
                                         scroll the strip a step that way, a
@@ -206,8 +209,14 @@ def main():
             columns.insert(at + 1, {"windows": [focused], "width": column["width"]})
             at += 1
         elif name == "width":
-            if args:
-                column["width"] = clamp(float(args[0]), MIN_WIDTH, MAX_WIDTH)
+            arg = args[0] if args else ""
+            if arg.startswith(("+", "-")):
+                column["width"] = clamp(column["width"] + float(arg), MIN_WIDTH, MAX_WIDTH)
+            elif arg == "prev":
+                earlier = [p for p in PRESETS if p < column["width"] - 0.01]
+                column["width"] = earlier[-1] if earlier else PRESETS[-1]
+            elif arg:
+                column["width"] = clamp(float(arg), MIN_WIDTH, MAX_WIDTH)
             else:
                 later = [p for p in PRESETS if p > column["width"] + 0.01]
                 column["width"] = later[0] if later else PRESETS[0]


### PR DESCRIPTION
## Description

This PR adds two ways to resize a column in the strip layout example. The width command could only cycle the presets forward or set an exact fraction. It can now cycle them backward and nudge the column wider or narrower by a fraction of the display, matching niri's default resize keys.

The presets stay at a third, a half, and two thirds, with a half as the default, the same as niri. Full width is not a preset, as in niri; set it with a fraction of 1.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — N/A, Python example and docs only; fast path taken
- [x] Build succeeds (`just build`) — N/A, no Go changes
- [x] Tests added/updated for new or changed functionality — N/A, example layouts carry no tests
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Command changes

The strip example's `width` command accepts new arguments. Existing uses keep working.

```
mimi tiling cmd width          # next preset, as before
mimi tiling cmd width 0.75     # set a fraction, as before
mimi tiling cmd width prev     # previous preset
mimi tiling cmd width +0.1     # wider by a tenth of the display
mimi tiling cmd width -0.1     # narrower by a tenth
```

Nudges clamp to the existing range of 0.2 to 1.0.

## Additional Context

Verified by hand with a running daemon.
