### PR TITLE
docs(tiling): note what matters when picking a layout language

### DIFF
--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -256,8 +256,14 @@ them:
 `bsp.py` keeps its whole tree there.
 
 **Use another language.** `layout` is a command line run through
-`settings.hook_shell`, so arguments are fine and nothing requires Python. A
-whole layout in shell and jq, one column per window:
+`settings.hook_shell`, so arguments are fine and nothing requires Python.
+Anything that reads stdin, speaks JSON, and writes stdout will do: Go, Rust,
+Swift, Ruby, Lua, a shell script. Two things matter more than the language.
+Startup time, since the program runs once per display on every window event
+and a compiled binary starts in a few milliseconds where Node takes tens.
+And a JSON codec, since `state` is how a layout remembers anything. The
+examples are Python because it ships with the Xcode Command Line Tools and
+needs no library. A whole layout in shell and jq, one column per window:
 
 ```sh
 #!/bin/sh


### PR DESCRIPTION
## Description

This PR adds a short note to the tiling guide on writing a layout in a language other than Python.

The guide already said nothing requires Python, then went straight to a shell example. It now says that anything reading stdin, speaking JSON, and writing stdout will do, names a few languages, and flags the two things worth weighing: startup time, since the layout runs once per display on every window event, and a JSON codec, since state is how a layout remembers anything. It also says why the examples are Python.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`) — N/A, docs-only change, fast path (`just fmt && just lint`) run
- [x] Build succeeds (`just build`) — N/A, docs-only change
- [x] Tests added/updated for new or changed functionality — N/A, no code change
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
