### PR TITLE
fix(tiling): scroll the strip while a floating window has focus

### DIFF
--- a/examples/tiling/strip.py
+++ b/examples/tiling/strip.py
@@ -194,6 +194,22 @@ def main():
     at = column_of(columns, focused)
     focus = None
 
+    if event["kind"] == "command":
+        name, args = event.get("name"), event.get("args", [])
+        if name == "scroll" and args:
+            # A step along the strip, in the direction asked, kept within
+            # the strip's ends. Focus stays where it is: the view floats
+            # until the next event would leave the focused column hidden.
+            # This needs no focused column, so it works while a floating
+            # window has focus too.
+            _, total = starts(columns, box, GAP)
+            step = (float(args[1]) if len(args) > 1 else SCROLL_STEP) * box["width"]
+            offset += step if args[0] == "right" else -step
+            offset = clamp(offset, 0, max(0, total - box["width"]))
+            state.update(columns=columns, offset=offset)
+            write_output(maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box), state)
+            return
+
     if event["kind"] == "command" and at is not None:
         name, args = event.get("name"), event.get("args", [])
         column = columns[at]
@@ -239,18 +255,6 @@ def main():
             state.update(columns=columns, offset=offset)
             write_output(maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box), state)
             return
-        elif name == "scroll" and args:
-            # A step along the strip, in the direction asked, kept within
-            # the strip's ends. Focus stays where it is: the view floats
-            # until the next event would leave the focused column hidden.
-            _, total = starts(columns, box, GAP)
-            step = (float(args[1]) if len(args) > 1 else SCROLL_STEP) * box["width"]
-            offset += step if args[0] == "right" else -step
-            offset = clamp(offset, 0, max(0, total - box["width"]))
-            state.update(columns=columns, offset=offset)
-            write_output(maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box), state)
-            return
-
     elif event["kind"] == "window_resize":
         placed = state.get("placed", {})
         for number in event.get("windows", []):


### PR DESCRIPTION
## Description

This PR fixes `mimi tiling cmd scroll` in the strip example being ignored while a floating window has focus.

Every strip command sat behind a guard that required the focused window to be in a column. After `togglefloat`, focus stays on the floated window, which is no longer on the strip, so scroll did nothing until a tiled window was focused again. Scroll only moves the viewport and needs no focused column, so it now runs before that guard. The other commands (focus, move, consume, expel, width, center) still act on the focused column and are unchanged.

How to test: run the strip layout, open a few windows so the strip is wider than the display, `mimi tiling cmd togglefloat` one of them, then `mimi tiling cmd scroll left` / `right`. The strip moves while the floating window keeps focus.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [ ] Tests pass (`just test`) (Python example only, no Go tests cover it)
- [ ] Build succeeds (`just build`) (Go surface unchanged)
- [ ] Tests added/updated for new or changed functionality (examples are untested)
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)