### PR TITLE
feat(tiling): animate windows into the frames a layout returns

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -81,6 +81,15 @@ relayout_on_drag = false
 # follow the macOS tiled-window margin, the setting resize_window honours.
 # gap = 12
 
+# Move the frames into place over time instead of at once. The window server
+# draws the animation from pictures of the windows, which needs the Screen
+# Recording permission. The daemon asks for it only when this is on.
+# duration_ms is 1 to 1000. easing is linear, ease-in, ease-out or ease-in-out.
+[tiling.animation]
+enabled = false
+duration_ms = 150
+easing = "ease-out"
+
 # =============================================================================
 # Hooks
 # =============================================================================

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -215,6 +215,11 @@ debounce_ms = 100     # settle a burst of window events into one pass
 timeout_secs = 5      # kill the layout past this
 relayout_on_drag = false     # a window the user moves or resizes runs a pass too
 # gap = 12                   # points between windows; unset follows the macOS tiled-window margin
+
+[tiling.animation]
+enabled = false       # move the frames into place over time instead of at once
+duration_ms = 150     # how long the move takes
+easing = "ease-out"   # linear, ease-in, ease-out or ease-in-out
 ```
 
 mimi ships no layout. `layout` is a command line, run through
@@ -272,6 +277,20 @@ keyboard focus once the frames are applied. Printing nothing changes nothing:
 layout can refuse an input it was not written for. A layout that exits
 non-zero, times out, or prints something that is not this shape is logged and
 applies nothing; the next event tries again.
+
+With `[tiling.animation]` enabled, the windows move to the frames a pass
+returns over `duration_ms`, along the `easing` curve, instead of at once. The
+window server draws the animation from pictures of the windows, so the
+applications do no more work than for an instant move. A pass that arrives
+while an animation is running continues from where the windows are on
+screen. A window the user just dragged moves at once, and a layout can
+exclude any window with `animate: false` on its frame (see
+[TILING.md](TILING.md)). Taking the pictures needs the Screen Recording
+permission. With the animation enabled the daemon asks for it once, at
+startup and on reload. Until it is granted the windows move at once and a
+warning says so. macOS applies a grant when mimi next starts. With the
+animation disabled, the default, the daemon captures nothing and asks for
+nothing.
 
 `enabled = true` requires `layout`, and Accessibility permission, which the
 daemon checks at startup and on every reload: without it tiling stays off and

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -183,7 +183,7 @@ Your program reads one JSON document on stdin and prints one on stdout.
 
 | Field | Meaning |
 | --- | --- |
-| `frames` | The windows to place. Leave a window out to leave it where it is. Print nothing, or an empty list, to change nothing. |
+| `frames` | The windows to place. Leave a window out to leave it where it is. Print nothing, or an empty list, to change nothing. With `[tiling.animation]` on, a frame may carry `"animate": false` to move that one window at once while the rest animate, for a window with no sensible starting position. |
 | `state` | Any JSON. Handed back next run. Omit the key and the previous state is kept. Print `null` to clear it. |
 | `focus` | Optional. A window number to give keyboard focus once the frames land. For moving focus along a layout's own structure where spatial `focus_window` cannot, such as a strip's parked columns. |
 

--- a/internal/action/apply_frames.go
+++ b/internal/action/apply_frames.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
@@ -9,16 +10,48 @@ import (
 
 // WindowFrame is one entry of apply_frames' payload: a window, by the number
 // "mimi query windows" reported for it, and the frame to give it, in window
-// coordinates.
+// coordinates. Animate, when the payload animates at all, excludes one
+// window from the animation. It is placed at its frame as the others begin
+// to move, for a window with no sensible starting position on screen.
 type WindowFrame struct {
-	Number uint32 `json:"number"`
-	Frame  Frame  `json:"frame"`
+	Number  uint32 `json:"number"`
+	Frame   Frame  `json:"frame"`
+	Animate *bool  `json:"animate,omitempty"`
 }
 
+// Animation is how apply_frames moves the windows when it is asked to: over
+// how long, in milliseconds, and along which curve, named as in Easings.
+type Animation struct {
+	DurationMS int    `json:"durationMs"`
+	Easing     string `json:"easing"`
+}
+
+// Easings are the curves an Animation names, in the order native numbers
+// them.
+var Easings = []string{"linear", "ease-in", "ease-out", "ease-in-out"}
+
+// MaxAnimationMS is the longest an animation may run. Past a second the
+// windows are unusable for too long after every pass.
+const MaxAnimationMS = 1000
+
 // ApplyFramesArgs is apply_frames' typed payload: the frames to apply, in the
-// order they are applied.
+// order they are applied, and how to animate them, or nil to move them at
+// once.
 type ApplyFramesArgs struct {
-	Frames []WindowFrame `json:"frames"`
+	Frames    []WindowFrame `json:"frames"`
+	Animation *Animation    `json:"animation,omitempty"`
+}
+
+// FrameAnimator is what a Desktop offers when it can animate frames. A
+// desktop that cannot is used as it is, and the frames move at once.
+type FrameAnimator interface {
+	// BeginFrameAnimation prepares to move the given windows to their
+	// frames over the animation, hiding the move the frame writes make, and
+	// reports how many windows it will animate.
+	BeginFrameAnimation(targets []WindowFrame, animation Animation) (int, error)
+	// StartFrameAnimation runs the prepared animation, leaving out the
+	// windows whose frames did not land.
+	StartFrameAnimation(dropped []uint32)
 }
 
 // NewApplyFramesCommand builds apply_frames' command from the decoded
@@ -41,6 +74,13 @@ func NewApplyFramesCommand(frames []WindowFrame) (Command, error) {
 func validateApplyFramesArgs(args ApplyFramesArgs) error {
 	if len(args.Frames) == 0 {
 		return derrors.New(derrors.CodeInvalidInput, "apply_frames needs at least one frame")
+	}
+
+	if args.Animation != nil {
+		err := validateAnimation(*args.Animation)
+		if err != nil {
+			return err
+		}
 	}
 
 	seen := make(map[uint32]struct{}, len(args.Frames))
@@ -73,6 +113,28 @@ func validateApplyFramesArgs(args ApplyFramesArgs) error {
 				entry.Number,
 			)
 		}
+	}
+
+	return nil
+}
+
+// validateAnimation holds an Animation to a duration that is positive and
+// bounded, and a curve that has a name.
+func validateAnimation(animation Animation) error {
+	if animation.DurationMS <= 0 || animation.DurationMS > MaxAnimationMS {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"animation.durationMs must be between 1 and %d",
+			MaxAnimationMS,
+		)
+	}
+
+	if !slices.Contains(Easings, animation.Easing) {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"animation.easing must be one of %s",
+			strings.Join(Easings, ", "),
+		)
 	}
 
 	return nil
@@ -128,7 +190,37 @@ func (e *Executor) ApplyFrames(args ApplyFramesArgs) error {
 		byNumber[win.Number] = win.ID
 	}
 
-	var failures []string
+	// The animation is prepared before the first write and started after
+	// the last, so the writes happen while the animation hides them. A
+	// desktop that cannot animate, or an animation that cannot begin, moves
+	// the frames at once. Without an animation in the payload none of this
+	// runs.
+	var (
+		animator  FrameAnimator
+		animating bool
+	)
+
+	if args.Animation != nil {
+		animator, animating = e.desktop.(FrameAnimator)
+	}
+
+	if animating {
+		targets := make([]WindowFrame, 0, len(args.Frames))
+
+		for _, entry := range args.Frames {
+			if _, ok := byNumber[entry.Number]; ok && (entry.Animate == nil || *entry.Animate) {
+				targets = append(targets, entry)
+			}
+		}
+
+		count, beginErr := animator.BeginFrameAnimation(targets, *args.Animation)
+		animating = beginErr == nil && count > 0
+	}
+
+	var (
+		failures []string
+		dropped  []uint32
+	)
 
 	for _, entry := range args.Frames {
 		windowID, ok := byNumber[entry.Number]
@@ -143,11 +235,16 @@ func (e *Executor) ApplyFrames(args ApplyFramesArgs) error {
 
 		setErr := e.desktop.SetWindowFrame(windowID, rectOfFrame(entry.Frame))
 		if setErr != nil {
+			dropped = append(dropped, entry.Number)
 			failures = append(
 				failures,
 				fmt.Sprintf("window %d: %s", entry.Number, derrors.Message(setErr)),
 			)
 		}
+	}
+
+	if animating {
+		animator.StartFrameAnimation(dropped)
 	}
 
 	if len(failures) > 0 {

--- a/internal/action/apply_frames_test.go
+++ b/internal/action/apply_frames_test.go
@@ -1,6 +1,7 @@
 package action_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -193,5 +194,249 @@ func TestApplyFramesCommand_RejectsAMalformedPayloadOnBothPaths(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+// animatingDesktop is a fake desktop that can animate: it records what the
+// executor asks of the animation and when, relative to the frame writes.
+type animatingDesktop struct {
+	*fakeDesktop
+
+	beginTargets   []action.WindowFrame
+	beginAnimation action.Animation
+	// writesAtBegin is how many frames had been written when the animation
+	// began; the animation must be prepared before the first one.
+	writesAtBegin int
+	beginErr      error
+	started       bool
+	dropped       []uint32
+}
+
+func (d *animatingDesktop) BeginFrameAnimation(
+	targets []action.WindowFrame,
+	animation action.Animation,
+) (int, error) {
+	d.beginTargets = targets
+	d.beginAnimation = animation
+
+	for _, win := range d.windows {
+		d.writesAtBegin += win.setFrameWrites
+	}
+
+	if d.beginErr != nil {
+		return 0, d.beginErr
+	}
+
+	return len(targets), nil
+}
+
+func (d *animatingDesktop) StartFrameAnimation(dropped []uint32) {
+	d.started = true
+	d.dropped = dropped
+}
+
+const linearEasing = "linear"
+
+func animatedApplyFramesCommand(
+	animation *action.Animation,
+	frames ...action.WindowFrame,
+) action.Command {
+	return action.Command{
+		Name:        action.NameApplyFrames,
+		ApplyFrames: action.ApplyFramesArgs{Frames: frames, Animation: animation},
+	}
+}
+
+func TestExecutor_ApplyFrames_BracketsTheWritesWithTheAnimation(t *testing.T) {
+	t.Parallel()
+
+	desktop := &animatingDesktop{fakeDesktop: desktopWithListedWindows()}
+	desktop.windows[1].setFrameErr = derrors.New(derrors.CodeAccessibilityFailed, "refused")
+	animation := action.Animation{DurationMS: 150, Easing: "ease-out"}
+	still := false
+	cmd := animatedApplyFramesCommand(
+		&animation,
+		action.WindowFrame{
+			Number: 4242,
+			Frame:  action.Frame{X: 0, Y: 25, Width: 640, Height: 1055},
+		},
+		action.WindowFrame{
+			Number: 4243,
+			Frame:  action.Frame{X: 640, Y: 25, Width: 640, Height: 1055},
+		},
+		action.WindowFrame{Number: 9999, Frame: action.Frame{Width: 100, Height: 100}},
+		action.WindowFrame{
+			Number:  4244,
+			Frame:   action.Frame{Width: 100, Height: 100},
+			Animate: &still,
+		},
+	)
+
+	desktop.windows = append(desktop.windows, fakeWindow{id: 3, pid: 101, number: 4244})
+
+	err := action.NewExecutor(desktop).ExecuteCommand(cmd)
+	if !derrors.IsCode(err, derrors.CodeActionFailed) {
+		t.Fatalf(
+			"ExecuteCommand(apply_frames) error = %v, want CodeActionFailed for the refused frame",
+			err,
+		)
+	}
+
+	if desktop.writesAtBegin != 0 {
+		t.Fatalf(
+			"animation began after %d frame writes, want before the first",
+			desktop.writesAtBegin,
+		)
+	}
+
+	if desktop.beginAnimation != animation {
+		t.Fatalf("animation = %+v, want %+v", desktop.beginAnimation, animation)
+	}
+
+	// Only windows on the space and not opted out are animated: 9999 is not
+	// listed and 4244 said animate: false.
+	targets := make([]uint32, 0, len(desktop.beginTargets))
+	for _, target := range desktop.beginTargets {
+		targets = append(targets, target.Number)
+	}
+
+	if want := []uint32{4242, 4243}; !slices.Equal(targets, want) {
+		t.Fatalf("animated windows = %v, want %v", targets, want)
+	}
+
+	if !desktop.started {
+		t.Fatal("the animation was prepared but never started")
+	}
+
+	// The refused write is dropped from the animation; the missing window
+	// was never in it.
+	if want := []uint32{4243}; !slices.Equal(desktop.dropped, want) {
+		t.Fatalf("dropped = %v, want %v", desktop.dropped, want)
+	}
+
+	if got, want := desktop.windows[0].frame, (geometry.Rect{X: 0, Y: 25, W: 640, H: 1055}); got != want {
+		t.Fatalf("window 4242 frame = %v, want %v (the frames still land)", got, want)
+	}
+}
+
+func TestExecutor_ApplyFrames_MovesAtOnceWhenTheAnimationCannotBegin(t *testing.T) {
+	t.Parallel()
+
+	animation := &action.Animation{DurationMS: 150, Easing: linearEasing}
+	frame := action.WindowFrame{
+		Number: 4242,
+		Frame:  action.Frame{X: 0, Y: 25, Width: 640, Height: 1055},
+	}
+
+	cases := map[string]action.Desktop{
+		"desktop that cannot animate": desktopWithListedWindows(),
+		"animation refused": &animatingDesktop{
+			fakeDesktop: desktopWithListedWindows(),
+			beginErr:    derrors.New(derrors.CodeActionFailed, "no screen recording"),
+		},
+	}
+
+	for name, desktop := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := action.NewExecutor(desktop).
+				ExecuteCommand(animatedApplyFramesCommand(animation, frame))
+			if err != nil {
+				t.Fatalf("ExecuteCommand(apply_frames) error = %v, want nil", err)
+			}
+
+			var fake *fakeDesktop
+			switch typed := desktop.(type) {
+			case *fakeDesktop:
+				fake = typed
+			case *animatingDesktop:
+				fake = typed.fakeDesktop
+
+				if typed.started {
+					t.Fatal("an animation that could not begin was started")
+				}
+			}
+
+			if got, want := fake.windows[0].frame, (geometry.Rect{X: 0, Y: 25, W: 640, H: 1055}); got != want {
+				t.Fatalf("window 4242 frame = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestExecutor_ApplyFrames_RejectsAnAnimationItCannotRun(t *testing.T) {
+	t.Parallel()
+
+	frame := action.WindowFrame{Number: 4242, Frame: action.Frame{Width: 100, Height: 100}}
+
+	cases := map[string]struct {
+		animation action.Animation
+		fragment  string
+	}{
+		"zero duration": {
+			action.Animation{DurationMS: 0, Easing: linearEasing},
+			"animation.durationMs",
+		},
+		"too long": {
+			action.Animation{DurationMS: 5000, Easing: linearEasing},
+			"animation.durationMs",
+		},
+		"unknown easing": {action.Animation{DurationMS: 100, Easing: "bouncy"}, "animation.easing"},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := desktopWithListedWindows()
+			cmd := animatedApplyFramesCommand(&testCase.animation, frame)
+
+			err := action.NewExecutor(desktop).ExecuteCommand(cmd)
+			if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Fatalf("error = %v, want CodeInvalidInput", err)
+			}
+
+			if !strings.Contains(err.Error(), testCase.fragment) {
+				t.Errorf("error %q does not mention %q", err.Error(), testCase.fragment)
+			}
+
+			if desktop.windows[0].setFrameWrites != 0 {
+				t.Error("a rejected payload wrote a frame")
+			}
+		})
+	}
+}
+
+// TestExecutor_ApplyFrames_WithoutAnAnimationNeverTouchesTheAnimator pins
+// the off switch: a payload with no animation drives a desktop that could
+// animate exactly as one that cannot.
+func TestExecutor_ApplyFrames_WithoutAnAnimationNeverTouchesTheAnimator(t *testing.T) {
+	t.Parallel()
+
+	desktop := &animatingDesktop{fakeDesktop: desktopWithListedWindows()}
+	cmd := applyFramesCommandFor(
+		t,
+		action.WindowFrame{
+			Number: 4242,
+			Frame:  action.Frame{X: 0, Y: 25, Width: 640, Height: 1055},
+		},
+	)
+
+	err := action.NewExecutor(desktop).ExecuteCommand(cmd)
+	if err != nil {
+		t.Fatalf("ExecuteCommand(apply_frames) error = %v, want nil", err)
+	}
+
+	if desktop.beginTargets != nil || desktop.started {
+		t.Fatalf(
+			"animator was used: begin targets %v, started %v",
+			desktop.beginTargets,
+			desktop.started,
+		)
+	}
+
+	if got, want := desktop.windows[0].frame, (geometry.Rect{X: 0, Y: 25, W: 640, H: 1055}); got != want {
+		t.Fatalf("window 4242 frame = %v, want %v", got, want)
 	}
 }

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -1,7 +1,9 @@
 package action
 
 import (
+	"slices"
 	"sync"
+	"time"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/geometry"
@@ -171,6 +173,34 @@ func (d *nativeDesktop) SetWindowFrame(id WindowID, frame geometry.Rect) error {
 	return d.withWindow(id, func(element *native.Element) error {
 		return element.SetFrame(frame.X, frame.Y, frame.W, frame.H)
 	})
+}
+
+// BeginFrameAnimation prepares to fly the given windows to their frames.
+func (d *nativeDesktop) BeginFrameAnimation(
+	targets []WindowFrame,
+	animation Animation,
+) (int, error) {
+	frames := make([]native.FrameTarget, 0, len(targets))
+	for _, target := range targets {
+		frames = append(frames, native.FrameTarget{
+			Number: target.Number,
+			X:      target.Frame.X,
+			Y:      target.Frame.Y,
+			Width:  target.Frame.Width,
+			Height: target.Frame.Height,
+		})
+	}
+
+	return native.BeginFrameAnimation(
+		frames,
+		time.Duration(animation.DurationMS)*time.Millisecond,
+		native.Easing(slices.Index(Easings, animation.Easing)),
+	)
+}
+
+// StartFrameAnimation runs the animation BeginFrameAnimation prepared.
+func (d *nativeDesktop) StartFrameAnimation(dropped []uint32) {
+	native.StartFrameAnimation(dropped)
 }
 
 // ActivateWindow raises a window's application and focuses the window.

--- a/internal/config/animation_test.go
+++ b/internal/config/animation_test.go
@@ -1,0 +1,67 @@
+package config //nolint:testpackage // reads the validated config directly
+
+import (
+	"strings"
+	"testing"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+const animatedTiling = "[tiling]\nenabled = true\nlayout = \"cat\"\n[tiling.animation]\nenabled = true\n"
+
+func TestLoad_TilingAnimationDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(writeConfig(t, animatedTiling))
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	if !cfg.Tiling.Animation.Enabled {
+		t.Fatal("tiling.animation.enabled = false, want true")
+	}
+
+	if got, want := cfg.Tiling.Animation.DurationMS, defaultTilingAnimationMS; got != want {
+		t.Errorf("tiling.animation.duration_ms = %d, want %d", got, want)
+	}
+
+	if got, want := cfg.Tiling.Animation.Easing, defaultTilingAnimationEasing; got != want {
+		t.Errorf("tiling.animation.easing = %q, want %q", got, want)
+	}
+
+	// Off is the default, whatever [tiling] says.
+	cfg, err = Load(writeConfig(t, "[tiling]\nenabled = true\nlayout = \"cat\"\n"))
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	if cfg.Tiling.Animation.Enabled {
+		t.Fatal("tiling.animation.enabled defaults to true, want false")
+	}
+}
+
+func TestLoad_RejectsATilingAnimationItCannotRun(t *testing.T) {
+	t.Parallel()
+
+	for name, testCase := range map[string]struct {
+		extra    string
+		fragment string
+	}{
+		"negative duration": {"duration_ms = -1\n", "tiling.animation.duration_ms must be between 1 and 1000"},
+		"too long":          {"duration_ms = 1001\n", "tiling.animation.duration_ms must be between 1 and 1000"},
+		"unknown easing":    {"easing = \"bounce\"\n", "tiling.animation.easing must be one of linear, ease-in, ease-out, ease-in-out"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Load(writeConfig(t, animatedTiling+testCase.extra))
+			if !derrors.IsCode(err, derrors.CodeInvalidConfig) {
+				t.Fatalf("Load() error = %v, want CodeInvalidConfig", err)
+			}
+
+			if !strings.Contains(err.Error(), testCase.fragment) {
+				t.Errorf("error %q does not mention %q", err.Error(), testCase.fragment)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,18 @@ type TilingConfig struct {
 	// setting resize_window honors; set, it replaces that setting for
 	// layouts, 0 included.
 	Gap *int `json:"gap" toml:"gap"`
+	// Animation is how the frames a layout returns move into place.
+	Animation AnimationConfig `json:"animation" toml:"animation"`
+}
+
+// AnimationConfig holds the [tiling.animation] section: whether windows
+// move to the frames a layout returns over time rather than at once, over
+// how long, and along which curve. Off, the daemon neither captures the
+// screen nor asks for the Screen Recording permission that takes.
+type AnimationConfig struct {
+	Enabled    bool   `json:"enabled"    toml:"enabled"`
+	DurationMS int    `json:"durationMs" toml:"duration_ms"`
+	Easing     string `json:"easing"     toml:"easing"`
 }
 
 // HooksConfig holds all hook entries grouped by event kind.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 
 	"github.com/y3owk1n/mimi/configs"
+	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/paths"
 )
@@ -148,10 +150,13 @@ func Load(path string) (*Config, error) {
 }
 
 // The [tiling] defaults: how long a burst of window events settles before one
-// relayout runs, and how long the layout program may take.
+// relayout runs, how long the layout program may take, and how the frames
+// move when animated.
 const (
-	defaultTilingDebounceMS  = 100
-	defaultTilingTimeoutSecs = 5
+	defaultTilingDebounceMS      = 100
+	defaultTilingTimeoutSecs     = 5
+	defaultTilingAnimationMS     = 150
+	defaultTilingAnimationEasing = "ease-out"
 )
 
 func applyDefaults(cfg *Config, systrayEnabledSet bool) {
@@ -182,6 +187,14 @@ func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 
 	if cfg.Tiling.TimeoutSecs == 0 {
 		cfg.Tiling.TimeoutSecs = defaultTilingTimeoutSecs
+	}
+
+	if cfg.Tiling.Animation.DurationMS == 0 {
+		cfg.Tiling.Animation.DurationMS = defaultTilingAnimationMS
+	}
+
+	if cfg.Tiling.Animation.Easing == "" {
+		cfg.Tiling.Animation.Easing = defaultTilingAnimationEasing
 	}
 
 	if settings.PIDFile == "" {
@@ -229,6 +242,24 @@ func validate(cfg *Config) error {
 
 	if cfg.Tiling.TimeoutSecs < 1 {
 		errs = append(errs, "tiling.timeout_secs must be >= 1")
+	}
+
+	animationMS := cfg.Tiling.Animation.DurationMS
+	if animationMS < 1 || animationMS > action.MaxAnimationMS {
+		errs = append(
+			errs,
+			fmt.Sprintf(
+				"tiling.animation.duration_ms must be between 1 and %d",
+				action.MaxAnimationMS,
+			),
+		)
+	}
+
+	if !slices.Contains(action.Easings, cfg.Tiling.Animation.Easing) {
+		errs = append(
+			errs,
+			"tiling.animation.easing must be one of "+strings.Join(action.Easings, ", "),
+		)
 	}
 
 	// HookKinds is a slice, so these errors come out in its declared order.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -155,6 +155,7 @@ func runCore(
 		pipeline.axTracker,
 		pipeline.router,
 		pipeline.tiler,
+		logger,
 	)
 
 	onChange := func() {
@@ -264,7 +265,7 @@ func setupEventPipeline(
 	// the config says: it could read no window, and would log a failure on
 	// every event.
 	tiler := tiling.New(tiling.LiveDesktop{}, serialize, logger)
-	tiler.Update(tilingConfigFor(cfg, accessibilityGranted), cfg.Settings.HookShell)
+	tiler.Update(tilingConfigFor(cfg, accessibilityGranted, logger), cfg.Settings.HookShell)
 	tileSub := bus.SubscribeWithFilter(tileSubBufSize, tiler.KindFilter())
 
 	// The event log is opt-in via [settings].log_file; when present, write
@@ -524,11 +525,30 @@ func hasWindowEvents(cfg *config.Config) bool {
 }
 
 // tilingConfigFor is the [tiling] section as the engine gets it: as written,
-// except that without Accessibility it is disabled.
-func tilingConfigFor(cfg *config.Config, accessibilityGranted bool) config.TilingConfig {
+// except that without Accessibility it is disabled, and without Screen
+// Recording its animation is. The daemon asks for Screen Recording only when
+// the animation is on, so a config that leaves it off never prompts. macOS
+// prompts once and keeps the answer, and a grant takes effect on the next
+// start.
+func tilingConfigFor(
+	cfg *config.Config,
+	accessibilityGranted bool,
+	logger *zap.SugaredLogger,
+) config.TilingConfig {
 	tilingCfg := cfg.Tiling
 	if !accessibilityGranted {
 		tilingCfg.Enabled = false
+	}
+
+	if tilingCfg.Enabled && tilingCfg.Animation.Enabled && !native.ScreenCaptureGranted() {
+		if !permissions.RequestScreenCapture() {
+			logger.Warn(
+				"screen recording permission not granted, tiling animation disabled. " +
+					"Grant it in System Settings > Privacy & Security > Screen & System Audio Recording, then restart mimi",
+			)
+
+			tilingCfg.Animation.Enabled = false
+		}
 	}
 
 	return tilingCfg

--- a/internal/daemon/reloader.go
+++ b/internal/daemon/reloader.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/y3owk1n/mimi/internal/config"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/hooks"
@@ -42,6 +44,7 @@ type reloader struct {
 	axTracker *observe.AXTracker
 	router    *observe.Router
 	tiler     *tiling.Engine
+	logger    *zap.SugaredLogger
 }
 
 // newReloader bundles the dependencies a reload touches — the config the
@@ -60,7 +63,12 @@ func newReloader(
 	axTracker *observe.AXTracker,
 	router *observe.Router,
 	tiler *tiling.Engine,
+	logger *zap.SugaredLogger,
 ) *reloader {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
 	return &reloader{
 		running:   running,
 		reg:       reg,
@@ -68,6 +76,7 @@ func newReloader(
 		axTracker: axTracker,
 		router:    router,
 		tiler:     tiler,
+		logger:    logger,
 	}
 }
 
@@ -118,7 +127,7 @@ func (rl *reloader) Apply(cfg *config.Config) (reloadChanges, error) {
 	}
 
 	if rl.tiler != nil {
-		rl.tiler.Update(tilingConfigFor(cfg, perm.Accessibility), cfg.Settings.HookShell)
+		rl.tiler.Update(tilingConfigFor(cfg, perm.Accessibility, rl.logger), cfg.Settings.HookShell)
 	}
 
 	return reloadChanges{

--- a/internal/daemon/reloader_test.go
+++ b/internal/daemon/reloader_test.go
@@ -54,7 +54,7 @@ func newTestReloader(
 	)
 	executor := hooks.NewExecutor(reg, &initialCfg.Settings, logger)
 
-	cfgReloader := newReloader(initialCfg, reg, executor, axTracker, router, nil)
+	cfgReloader := newReloader(initialCfg, reg, executor, axTracker, router, nil, nil)
 
 	return cfgReloader, reg
 }

--- a/internal/native/animate.go
+++ b/internal/native/animate.go
@@ -1,0 +1,102 @@
+package native
+
+/*
+#include "animate.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"time"
+	"unsafe"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// Easing is the curve a frame animation follows.
+type Easing int
+
+// The easing curves, in the order animate.h numbers them.
+const (
+	EasingLinear Easing = iota
+	EasingEaseIn
+	EasingEaseOut
+	EasingEaseInOut
+)
+
+// FrameTarget is one window a frame animation moves, by number, and the
+// frame it is being given, in window coordinates.
+type FrameTarget struct {
+	Number uint32
+	X      float64
+	Y      float64
+	Width  float64
+	Height float64
+}
+
+// BeginFrameAnimation puts a still of the screen over the given windows and
+// prepares to move pictures of them to their new frames, so the caller can
+// write the real frames without anything moving on screen, then call
+// StartFrameAnimation. It reports how many windows will animate. Without
+// Screen Recording permission it prepares nothing and fails. It never asks
+// for the permission.
+func BeginFrameAnimation(
+	targets []FrameTarget,
+	duration time.Duration,
+	easing Easing,
+) (int, error) {
+	if len(targets) == 0 {
+		return 0, nil
+	}
+
+	cTargets := (*C.MimiAnimationTarget)(
+		C.calloc(C.size_t(len(targets)), C.size_t(unsafe.Sizeof(C.MimiAnimationTarget{}))),
+	)
+	defer C.free(unsafe.Pointer(cTargets)) //nolint:nlreturn
+
+	slice := unsafe.Slice(cTargets, len(targets))
+	for index, target := range targets {
+		slice[index] = C.MimiAnimationTarget{
+			number: C.uint32_t(target.Number),
+			x:      C.double(target.X),
+			y:      C.double(target.Y),
+			w:      C.double(target.Width),
+			h:      C.double(target.Height),
+		}
+	}
+
+	count := int(
+		C.MimiAnimationBegin(
+			cTargets,
+			C.int(len(targets)),
+			C.double(duration.Seconds()),
+			C.int(easing),
+		),
+	)
+	if count < 0 {
+		return 0, derrors.New(
+			derrors.CodeActionFailed,
+			"screen recording permission is required to animate frames",
+		)
+	}
+
+	return count, nil
+}
+
+// StartFrameAnimation runs the animation BeginFrameAnimation prepared,
+// leaving out the windows whose frames did not land.
+func StartFrameAnimation(dropped []uint32) {
+	if len(dropped) == 0 {
+		C.MimiAnimationStart(nil, 0)
+
+		return
+	}
+
+	C.MimiAnimationStart((*C.uint32_t)(unsafe.Pointer(&dropped[0])), C.int(len(dropped)))
+}
+
+// ScreenCaptureGranted reports whether macOS lets mimi capture the screen,
+// which animating frames needs. It never prompts.
+func ScreenCaptureGranted() bool {
+	return C.MimiScreenCaptureGranted() != 0
+}

--- a/internal/native/animate.h
+++ b/internal/native/animate.h
@@ -1,0 +1,42 @@
+#ifndef MIMI_ANIMATE_H
+#define MIMI_ANIMATE_H
+
+#import <Foundation/Foundation.h>
+
+/// One window a frame animation moves: the window server's number and the
+/// frame it is being given, in window coordinates.
+typedef struct {
+	uint32_t number;
+	double x;
+	double y;
+	double w;
+	double h;
+} MimiAnimationTarget;
+
+/// The easing curves MimiAnimationBegin takes.
+enum {
+	MimiEasingLinear = 0,
+	MimiEasingEaseIn = 1,
+	MimiEasingEaseOut = 2,
+	MimiEasingEaseInOut = 3,
+};
+
+/// Prepare an animation of the given windows from where they are now to the
+/// given frames, over duration seconds. It captures the screen and puts a
+/// still of it over the real windows, so the caller can write the real frames
+/// right after without anything moving on screen. MimiAnimationStart then
+/// moves pictures of the windows over the still. An animation already
+/// running is replaced, and its windows start from where they are on screen.
+///
+/// Returns the number of windows that will animate, 0 when nothing could be
+/// captured, or -1 when Screen Recording is not granted. It never prompts.
+int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double duration, int easing);
+
+/// Start the animation MimiAnimationBegin prepared, leaving out the windows
+/// whose frames did not land. Without a prepared animation it does nothing.
+void MimiAnimationStart(const uint32_t *dropped, int count);
+
+/// Report whether the process may capture the screen, without prompting.
+int MimiScreenCaptureGranted(void);
+
+#endif  // MIMI_ANIMATE_H

--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -1,0 +1,582 @@
+#import "animate.h"
+
+#import "mimi_log.h"
+#import "workspace.h"
+
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
+#import <pthread.h>
+#import <unistd.h>
+
+// The animation never touches the real windows beyond the one frame write the
+// caller makes: the window server refuses alpha, transform and ordering on
+// another process's windows from an ordinary connection. It is drawn with
+// windows of our own instead. A backdrop per display, a still of everything
+// on screen but the moving windows, covers the real windows while they jump
+// to their new frames. Over it, one proxy per window carries a picture of that
+// window, and the compositor moves it with a transform, so no application
+// does any work while the animation runs. One transaction removes everything
+// when it ends.
+
+#pragma mark - SkyLight External Declarations
+
+extern int SLSMainConnectionID(void);
+extern CGError SLSNewWindow(int cid, int type, float x, float y, CFTypeRef region, uint32_t *wid);
+extern CGError SLSReleaseWindow(int cid, uint32_t wid);
+extern CGError SLSSetWindowOpacity(int cid, uint32_t wid, bool opaque);
+extern CGError SLSSetWindowLevel(int cid, uint32_t wid, int level);
+extern CGError SLSSetWindowTags(int cid, uint32_t wid, uint64_t *tags, int size);
+extern CGError SLSSetWindowResolution(int cid, uint32_t wid, double res);
+extern CGError SLSGetWindowBounds(int cid, uint32_t wid, CGRect *out);
+extern CGContextRef SLWindowContextCreate(int cid, uint32_t wid, CFDictionaryRef options);
+extern CGError CGSNewRegionWithRect(CGRect *rect, CFTypeRef *region);
+extern CFTypeRef SLSTransactionCreate(int cid);
+extern CGError SLSTransactionCommit(CFTypeRef transaction, int synchronous);
+extern CGError SLSTransactionOrderWindow(CFTypeRef transaction, uint32_t wid, int mode, uint32_t relative);
+extern CGError SLSTransactionSetWindowTransform(
+    CFTypeRef transaction, uint32_t wid, int unused1, int unused2, CGAffineTransform transform);
+
+// The window server's backing store type for SLSNewWindow, and the window
+// tags and level the proxies carry: ignore-for-events plus no-shadow, at the
+// floating level so they sit over every ordinary window and under the Dock
+// and menu bar.
+static const int kMimiProxyBackingBuffered = 2;
+static const uint64_t kMimiProxyTags = (1ULL << 1) | (1ULL << 9);
+static const int kMimiProxyLevel = 3;
+// Window layers at and above the Dock's are never covered, so they are left
+// out of the backdrop.
+static const int kMimiDockLayer = 20;
+static const int kMimiOrderAbove = 1;
+static const int kMimiOrderOut = 0;
+
+typedef struct {
+	uint32_t number;
+	uint32_t proxy;
+	CGRect from;
+	CGRect to;
+	// alone is whether no other animating window overlaps this one where it
+	// starts, so its picture can be cropped from a composite; picture and
+	// scale hold the capture between the two phases of MimiAnimationBegin.
+	BOOL alone;
+	CGImageRef picture;
+	double scale;
+} MimiProxy;
+
+static struct {
+	pthread_mutex_t lock;
+	BOOL running;
+	MimiProxy *proxies;
+	int proxyCount;
+	uint32_t *backdrops;
+	int backdropCount;
+	double start;
+	double duration;
+	int easing;
+} gAnim = {.lock = PTHREAD_MUTEX_INITIALIZER};
+
+#pragma mark - Helpers
+
+static double mimiEase(int easing, double t) {
+	switch (easing) {
+	case MimiEasingEaseIn:
+		return t * t * t;
+	case MimiEasingEaseOut: {
+		double u = 1 - t;
+		return 1 - u * u * u;
+	}
+	case MimiEasingEaseInOut:
+		if (t < 0.5) {
+			return 4 * t * t * t;
+		} else {
+			double u = -2 * t + 2;
+			return 1 - u * u * u / 2;
+		}
+	default:
+		return t;
+	}
+}
+
+// A window is on the display that has its centre.
+static BOOL mimiOnDisplay(CGRect frame, CGRect display) {
+	return CGRectContainsPoint(display, CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame)));
+}
+
+static CGRect mimiLerp(CGRect from, CGRect to, double p) {
+	return CGRectMake(
+	    from.origin.x + (to.origin.x - from.origin.x) * p, from.origin.y + (to.origin.y - from.origin.y) * p,
+	    from.size.width + (to.size.width - from.size.width) * p,
+	    from.size.height + (to.size.height - from.size.height) * p);
+}
+
+// The transform that shows a proxy drawn at the origin with size `drawn` at
+// `at`: the window server maps screen to window, so the translation is
+// negated and the scale inverted.
+static CGAffineTransform mimiPlacement(CGSize drawn, CGRect at) {
+	CGAffineTransform move = CGAffineTransformMakeTranslation(-at.origin.x, -at.origin.y);
+	CGAffineTransform scale = CGAffineTransformMakeScale(drawn.width / at.size.width, drawn.height / at.size.height);
+	return CGAffineTransformConcat(move, scale);
+}
+
+// Where the proxies are at this instant of the running animation, for the
+// windows a new animation starts from. The caller holds the lock.
+static double mimiProgressLocked(void) {
+	if (gAnim.duration <= 0) {
+		return 1;
+	}
+	double t = (CACurrentMediaTime() - gAnim.start) / gAnim.duration;
+	return mimiEase(gAnim.easing, t < 0 ? 0 : (t > 1 ? 1 : t));
+}
+
+static BOOL mimiInFlightLocked(uint32_t number, CGRect *out) {
+	if (!gAnim.running) {
+		return NO;
+	}
+	double p = mimiProgressLocked();
+	for (int i = 0; i < gAnim.proxyCount; i++) {
+		if (gAnim.proxies[i].number == number) {
+			*out = mimiLerp(gAnim.proxies[i].from, gAnim.proxies[i].to, p);
+			return YES;
+		}
+	}
+	return NO;
+}
+
+// Create a proxy window of the given size at the origin, to be painted with
+// mimiPaint and placed with a transform in the caller's transaction. Returns
+// 0 when the window server refuses.
+static uint32_t mimiNewProxy(int cid, CGSize size, double scale) {
+	CGRect local = CGRectMake(0, 0, size.width, size.height);
+	CFTypeRef region = NULL;
+	if (CGSNewRegionWithRect(&local, &region) != kCGErrorSuccess || !region) {
+		return 0;
+	}
+
+	uint32_t wid = 0;
+	CGError err = SLSNewWindow(cid, kMimiProxyBackingBuffered, 0, 0, region, &wid);
+	CFRelease(region);
+	if (err != kCGErrorSuccess || wid == 0) {
+		MIMI_LOG("SLSNewWindow failed with error %d", (int)err);
+		return 0;
+	}
+
+	uint64_t tags = kMimiProxyTags;
+	SLSSetWindowResolution(cid, wid, scale);
+	SLSSetWindowTags(cid, wid, &tags, 64);
+	SLSSetWindowOpacity(cid, wid, false);
+	SLSSetWindowLevel(cid, wid, kMimiProxyLevel);
+
+	return wid;
+}
+
+// Draw picture into the proxy window and release it. A captured image is
+// materialised the first time it is read, which is most of a proxy's cost.
+static void mimiPaint(int cid, uint32_t wid, CGSize size, CGImageRef picture) {
+	CGContextRef context = SLWindowContextCreate(cid, wid, NULL);
+	if (context) {
+		// Copying the pixels in, alpha included, rather than compositing
+		// them over a cleared backing: the picture covers the window.
+		CGContextSetBlendMode(context, kCGBlendModeCopy);
+		CGContextDrawImage(context, CGRectMake(0, 0, size.width, size.height), picture);
+		CGContextFlush(context);
+		CGContextRelease(context);
+	}
+	CGImageRelease(picture);
+}
+
+static void mimiReleaseAllLocked(int cid, CFTypeRef transaction) {
+	for (int i = 0; i < gAnim.proxyCount; i++) {
+		SLSTransactionOrderWindow(transaction, gAnim.proxies[i].proxy, kMimiOrderOut, 0);
+	}
+	for (int i = 0; i < gAnim.backdropCount; i++) {
+		SLSTransactionOrderWindow(transaction, gAnim.backdrops[i], kMimiOrderOut, 0);
+	}
+	SLSTransactionCommit(transaction, 1);
+
+	for (int i = 0; i < gAnim.proxyCount; i++) {
+		SLSReleaseWindow(cid, gAnim.proxies[i].proxy);
+	}
+	for (int i = 0; i < gAnim.backdropCount; i++) {
+		SLSReleaseWindow(cid, gAnim.backdrops[i]);
+	}
+	free(gAnim.proxies);
+	free(gAnim.backdrops);
+	gAnim.proxies = NULL;
+	gAnim.backdrops = NULL;
+	gAnim.proxyCount = 0;
+	gAnim.backdropCount = 0;
+	gAnim.running = NO;
+}
+
+#pragma mark - Display link
+
+// The link runs on the daemon's bridge run loop, the thread the workspace
+// observer already lives on, and is made and invalidated there.
+static CADisplayLink *gLink;
+
+@interface MimiAnimationTicker : NSObject
+- (void)tick:(CADisplayLink *)link;
+@end
+
+@implementation MimiAnimationTicker
+
+- (void)tick:(CADisplayLink *)link {
+	pthread_mutex_lock(&gAnim.lock);
+	if (!gAnim.running) {
+		pthread_mutex_unlock(&gAnim.lock);
+		return;
+	}
+
+	int cid = SLSMainConnectionID();
+	double t = (CACurrentMediaTime() - gAnim.start) / gAnim.duration;
+	BOOL done = t >= 1;
+	double p = mimiEase(gAnim.easing, done ? 1 : t);
+
+	CFTypeRef transaction = SLSTransactionCreate(cid);
+	if (done) {
+		mimiReleaseAllLocked(cid, transaction);
+	} else {
+		for (int i = 0; i < gAnim.proxyCount; i++) {
+			MimiProxy *proxy = &gAnim.proxies[i];
+			SLSTransactionSetWindowTransform(
+			    transaction, proxy->proxy, 0, 0, mimiPlacement(proxy->from.size, mimiLerp(proxy->from, proxy->to, p)));
+		}
+		SLSTransactionCommit(transaction, 0);
+	}
+	CFRelease(transaction);
+
+	// Only this animation's link is ended: a new animation may have made
+	// its own since.
+	if (done && gLink == link) {
+		[link invalidate];
+		gLink = nil;
+	}
+	pthread_mutex_unlock(&gAnim.lock);
+}
+
+@end
+
+static MimiAnimationTicker *gTicker;
+
+// The screen the animation is on, for its refresh rate: the one under the
+// first window's destination, or the main screen.
+static NSScreen *mimiScreenLocked(void) {
+	if (gAnim.proxyCount > 0) {
+		CGRect to = gAnim.proxies[0].to;
+		double primaryHeight = [NSScreen screens].firstObject.frame.size.height;
+		// NSScreen frames are y-up from the primary display's bottom-left.
+		NSPoint centre = NSMakePoint(CGRectGetMidX(to), primaryHeight - CGRectGetMidY(to));
+		for (NSScreen *screen in [NSScreen screens]) {
+			if (NSPointInRect(centre, screen.frame)) {
+				return screen;
+			}
+		}
+	}
+	return [NSScreen mainScreen];
+}
+
+// Start a link on the bridge run loop. The caller holds the lock; the link
+// is made under it again on that thread, so a Start and a tick never race.
+static void mimiStartLinkLocked(void) {
+	CFRunLoopRef runLoop = GetRunLoop();
+	if (!runLoop) {
+		return;
+	}
+	if (!gTicker) {
+		gTicker = [MimiAnimationTicker new];
+	}
+	NSScreen *screen = mimiScreenLocked();
+	CFRunLoopPerformBlock(runLoop, kCFRunLoopCommonModes, ^{
+		pthread_mutex_lock(&gAnim.lock);
+		if (gLink) {
+			[gLink invalidate];
+		}
+		gLink = [screen displayLinkWithTarget:gTicker selector:@selector(tick:)];
+		[gLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+		pthread_mutex_unlock(&gAnim.lock);
+	});
+	CFRunLoopWakeUp(runLoop);
+}
+
+#pragma mark - API
+
+int MimiScreenCaptureGranted(void) { return CGPreflightScreenCaptureAccess() ? 1 : 0; }
+
+int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double duration, int easing) {
+	if (!targets || count <= 0) {
+		return 0;
+	}
+	if (!CGPreflightScreenCaptureAccess()) {
+		return -1;
+	}
+
+	@autoreleasepool {
+		int cid = SLSMainConnectionID();
+		pthread_mutex_lock(&gAnim.lock);
+
+		// Where each window starts: its current animated frame if it is animating, else
+		// where the window server has it.
+		MimiProxy *next = calloc((size_t)count, sizeof(MimiProxy));
+		int nextCount = 0;
+		for (int i = 0; i < count; i++) {
+			CGRect from;
+			if (!mimiInFlightLocked(targets[i].number, &from)) {
+				if (SLSGetWindowBounds(cid, targets[i].number, &from) != kCGErrorSuccess) {
+					continue;
+				}
+			}
+			if (from.size.width <= 0 || from.size.height <= 0 || targets[i].w <= 0 || targets[i].h <= 0) {
+				continue;
+			}
+			// A window already at its frame is skipped. Most passes move few
+			// windows, or none, and cost nothing here.
+			CGRect to = CGRectMake(targets[i].x, targets[i].y, targets[i].w, targets[i].h);
+			if (fabs(from.origin.x - to.origin.x) < 0.5 && fabs(from.origin.y - to.origin.y) < 0.5 &&
+			    fabs(from.size.width - to.size.width) < 0.5 && fabs(from.size.height - to.size.height) < 0.5) {
+				continue;
+			}
+			next[nextCount].number = targets[i].number;
+			next[nextCount].from = from;
+			next[nextCount].to = to;
+			nextCount++;
+		}
+
+		// Everything on screen but the animating windows and our own, a
+		// previous animation's proxies. CGWindowListCreateImageFromArray
+		// reads the ids as raw values, not as numbers.
+		CFMutableArrayRef others = CFArrayCreateMutable(NULL, 0, NULL);
+		pid_t self = getpid();
+		CFArrayRef onScreen = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+		for (NSDictionary *info in (__bridge NSArray *)onScreen) {
+			if ([info[(id)kCGWindowOwnerPID] intValue] == self ||
+			    [info[(id)kCGWindowLayer] intValue] >= kMimiDockLayer) {
+				continue;
+			}
+			uint32_t number = [info[(id)kCGWindowNumber] unsignedIntValue];
+			BOOL inFlight = NO;
+			for (int i = 0; i < nextCount && !inFlight; i++) {
+				inFlight = next[i].number == number;
+			}
+			if (!inFlight) {
+				CFArrayAppendValue(others, (const void *)(uintptr_t)number);
+			}
+		}
+		if (onScreen) {
+			CFRelease(onScreen);
+		}
+
+		uint32_t *backdrops = calloc(16, sizeof(uint32_t));
+		CGRect *backdropBounds = calloc(16, sizeof(CGRect));
+		CGImageRef *backdropStills = calloc(16, sizeof(CGImageRef));
+		double *backdropScales = calloc(16, sizeof(double));
+		int backdropCount = 0;
+		CGDirectDisplayID displays[16];
+		uint32_t displayCount = 0;
+		CGGetActiveDisplayList(16, displays, &displayCount);
+
+		// Every capture is taken before any window is made: a capture that
+		// follows the creation of a window not yet drawn waits half a second
+		// on it.
+		for (uint32_t d = 0; d < displayCount; d++) {
+			CGRect bounds = CGDisplayBounds(displays[d]);
+			BOOL any = NO;
+			for (int i = 0; i < nextCount; i++) {
+				if (next[i].picture == NULL && mimiOnDisplay(next[i].from, bounds)) {
+					any = YES;
+					break;
+				}
+			}
+			if (!any) {
+				continue;
+			}
+
+			// Deprecated for ScreenCaptureKit, whose screenshot is asynchronous
+			// and far slower to start; this composes the display in a few
+			// milliseconds, which an animation that starts on the same frame
+			// as the event needs.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+			// The windows that overlap another animating window, as under a monocle
+			// layout, are captured one by one: a composite of the set shows
+			// only the top one. The rest are cropped from one composite, one
+			// call for all of them, since a capture costs the same however
+			// small the window.
+			CFMutableArrayRef apart = CFArrayCreateMutable(NULL, 0, NULL);
+			for (int i = 0; i < nextCount; i++) {
+				if (next[i].picture != NULL || !mimiOnDisplay(next[i].from, bounds)) {
+					continue;
+				}
+				BOOL overlaps = NO;
+				for (int j = 0; j < nextCount && !overlaps; j++) {
+					if (j != i && next[j].picture == NULL && mimiOnDisplay(next[j].from, bounds)) {
+						overlaps = !CGRectIsEmpty(CGRectIntersection(next[i].from, next[j].from));
+					}
+				}
+				next[i].alone = !overlaps;
+				if (!overlaps) {
+					CFArrayAppendValue(apart, (const void *)(uintptr_t)next[i].number);
+				}
+			}
+
+			CGImageRef still = CGWindowListCreateImageFromArray(bounds, others, kCGWindowImageBestResolution);
+			CGImageRef flight = CFArrayGetCount(apart) > 0
+			                        ? CGWindowListCreateImageFromArray(bounds, apart, kCGWindowImageBestResolution)
+			                        : NULL;
+			CFRelease(apart);
+			double scale = still ? (double)CGImageGetWidth(still) / bounds.size.width
+			                     : (flight ? (double)CGImageGetWidth(flight) / bounds.size.width : 1);
+
+			// A display with nothing else on it needs no backdrop.
+			if (still && backdropCount < 16) {
+				backdropBounds[backdropCount] = bounds;
+				backdropStills[backdropCount] = still;
+				backdropScales[backdropCount] = scale;
+				backdropCount++;
+			}
+
+			for (int i = 0; i < nextCount; i++) {
+				MimiProxy *proxy = &next[i];
+				if (proxy->picture != NULL || !mimiOnDisplay(proxy->from, bounds)) {
+					continue;
+				}
+				if (proxy->alone && flight) {
+					CGRect crop = CGRectMake(
+					    (proxy->from.origin.x - bounds.origin.x) * scale,
+					    (proxy->from.origin.y - bounds.origin.y) * scale, proxy->from.size.width * scale,
+					    proxy->from.size.height * scale);
+					proxy->picture = CGImageCreateWithImageInRect(flight, crop);
+				} else if (!proxy->alone) {
+					proxy->picture = CGWindowListCreateImage(
+					    proxy->from, kCGWindowListOptionIncludingWindow, proxy->number, kCGWindowImageBestResolution);
+				}
+				proxy->scale = scale;
+				if (!proxy->picture) {
+					MIMI_LOG("animation: capturing window %u failed", proxy->number);
+				}
+			}
+#pragma clang diagnostic pop
+
+			if (flight) {
+				CGImageRelease(flight);
+			}
+		}
+		CFRelease(others);
+
+		// Then the windows, each painted the moment it exists: the window
+		// server stalls for half a second on a request that arrives while
+		// windows it made are still waiting for their first pixels.
+		int kept = 0;
+		for (int i = 0; i < backdropCount; i++) {
+			uint32_t backdrop = mimiNewProxy(cid, backdropBounds[i].size, backdropScales[i]);
+			if (backdrop) {
+				mimiPaint(cid, backdrop, backdropBounds[i].size, backdropStills[i]);
+				backdrops[kept] = backdrop;
+				backdropBounds[kept] = backdropBounds[i];
+				kept++;
+			} else {
+				CGImageRelease(backdropStills[i]);
+			}
+		}
+		backdropCount = kept;
+
+		for (int i = 0; i < nextCount; i++) {
+			if (next[i].picture) {
+				next[i].proxy = mimiNewProxy(cid, next[i].from.size, next[i].scale);
+				if (next[i].proxy) {
+					mimiPaint(cid, next[i].proxy, next[i].from.size, next[i].picture);
+				} else {
+					CGImageRelease(next[i].picture);
+				}
+				next[i].picture = NULL;
+			}
+		}
+		free(backdropStills);
+		free(backdropScales);
+
+		// Keep the proxies that were made, in order.
+		kept = 0;
+		for (int i = 0; i < nextCount; i++) {
+			if (next[i].proxy != 0) {
+				next[kept++] = next[i];
+			}
+		}
+
+		// One commit: the new backdrops come in under the new proxies, and
+		// the previous animation, if any, goes out.
+		CFTypeRef transaction = SLSTransactionCreate(cid);
+		for (int i = 0; i < backdropCount; i++) {
+			SLSTransactionSetWindowTransform(
+			    transaction, backdrops[i], 0, 0, mimiPlacement(backdropBounds[i].size, backdropBounds[i]));
+			SLSTransactionOrderWindow(transaction, backdrops[i], kMimiOrderAbove, 0);
+		}
+		for (int i = 0; i < kept; i++) {
+			SLSTransactionSetWindowTransform(
+			    transaction, next[i].proxy, 0, 0, mimiPlacement(next[i].from.size, next[i].from));
+			SLSTransactionOrderWindow(transaction, next[i].proxy, kMimiOrderAbove, 0);
+		}
+		mimiReleaseAllLocked(cid, transaction);
+		CFRelease(transaction);
+		free(backdropBounds);
+
+		gAnim.proxies = next;
+		gAnim.proxyCount = kept;
+		gAnim.backdrops = backdrops;
+		gAnim.backdropCount = backdropCount;
+		gAnim.duration = duration;
+		gAnim.easing = easing;
+		gAnim.running = NO;
+
+		pthread_mutex_unlock(&gAnim.lock);
+		return kept;
+	}
+}
+
+void MimiAnimationStart(const uint32_t *dropped, int count) {
+	int cid = SLSMainConnectionID();
+	pthread_mutex_lock(&gAnim.lock);
+	if (gAnim.running || (gAnim.proxyCount == 0 && gAnim.backdropCount == 0)) {
+		pthread_mutex_unlock(&gAnim.lock);
+		return;
+	}
+
+	CFTypeRef transaction = SLSTransactionCreate(cid);
+	int kept = 0;
+	for (int i = 0; i < gAnim.proxyCount; i++) {
+		BOOL drop = NO;
+		for (int j = 0; j < count; j++) {
+			if (dropped[j] == gAnim.proxies[i].number) {
+				drop = YES;
+				break;
+			}
+		}
+		if (drop) {
+			SLSTransactionOrderWindow(transaction, gAnim.proxies[i].proxy, kMimiOrderOut, 0);
+			SLSReleaseWindow(cid, gAnim.proxies[i].proxy);
+		} else {
+			gAnim.proxies[kept++] = gAnim.proxies[i];
+		}
+	}
+	gAnim.proxyCount = kept;
+
+	if (kept == 0) {
+		mimiReleaseAllLocked(cid, transaction);
+		CFRelease(transaction);
+		pthread_mutex_unlock(&gAnim.lock);
+		return;
+	}
+	SLSTransactionCommit(transaction, 1);
+	CFRelease(transaction);
+
+	if (!GetRunLoop()) {
+		// No run loop to tick on, as in the CLI, so the proxies are removed
+		// at once.
+		CFTypeRef teardown = SLSTransactionCreate(cid);
+		mimiReleaseAllLocked(cid, teardown);
+		CFRelease(teardown);
+		pthread_mutex_unlock(&gAnim.lock);
+		return;
+	}
+	gAnim.start = CACurrentMediaTime();
+	gAnim.running = YES;
+	mimiStartLinkLocked();
+	pthread_mutex_unlock(&gAnim.lock);
+}

--- a/internal/native/link.go
+++ b/internal/native/link.go
@@ -2,6 +2,6 @@ package native
 
 /*
 #cgo CFLAGS: -x objective-c -fobjc-arc
-#cgo LDFLAGS: -framework Foundation -framework AppKit -framework Carbon -framework CoreGraphics -framework ApplicationServices -framework Cocoa -F/System/Library/PrivateFrameworks -framework SkyLight
+#cgo LDFLAGS: -framework Foundation -framework AppKit -framework Carbon -framework CoreGraphics -framework ApplicationServices -framework Cocoa -framework QuartzCore -F/System/Library/PrivateFrameworks -framework SkyLight
 */
 import "C"

--- a/internal/permissions/check.go
+++ b/internal/permissions/check.go
@@ -64,6 +64,13 @@ func RequestAccessibility() bool {
 	return C.MimiRequestAccessibilityPermissions() != 0
 }
 
+// RequestScreenCapture asks macOS for Screen Recording permission, which
+// animating tiling frames needs. macOS prompts the first time and remembers
+// the answer; a grant takes effect when mimi next starts.
+func RequestScreenCapture() bool {
+	return C.MimiRequestScreenCapturePermission() != 0
+}
+
 // ShowConfigOnboardingAlert displays startup guidance for creating the first config file.
 func ShowConfigOnboardingAlert(configPath string) ConfigOnboardingChoice {
 	cPath := C.CString(configPath)

--- a/internal/permissions/permissions.h
+++ b/internal/permissions/permissions.h
@@ -4,3 +4,6 @@ int MimiCheckAccessibilityPermissions(void);
 int MimiRequestAccessibilityPermissions(void);
 int MimiShowAccessibilityPermissionStartupAlert(void);
 int MimiShowConfigOnboardingAlert(const char *configPath);
+/// Ask macOS for Screen Recording permission, which prompts the first time
+/// and otherwise reports the standing decision.
+int MimiRequestScreenCapturePermission(void);

--- a/internal/permissions/permissions.m
+++ b/internal/permissions/permissions.m
@@ -62,6 +62,8 @@ int MimiRequestAccessibilityPermissions(void) {
 	}
 }
 
+int MimiRequestScreenCapturePermission(void) { return CGRequestScreenCaptureAccess() ? 1 : 0; }
+
 int MimiShowAccessibilityPermissionStartupAlert(void) {
 	return MimiRunOnMainThreadSync(^int {
 		@autoreleasepool {

--- a/internal/tiling/desktop.go
+++ b/internal/tiling/desktop.go
@@ -21,12 +21,15 @@ func (LiveDesktop) Margins() (action.MarginsInfo, error) { return action.QueryMa
 // Focus gives keyboard focus to a window by number.
 func (LiveDesktop) Focus(number uint32) error { return action.FocusWindowNumber(number) }
 
-// Apply writes the frames the way apply_frames does.
-func (LiveDesktop) Apply(frames []action.WindowFrame) error {
+// Apply writes the frames the way apply_frames does, animated when
+// animation is set.
+func (LiveDesktop) Apply(frames []action.WindowFrame, animation *action.Animation) error {
 	cmd, err := action.NewApplyFramesCommand(frames)
 	if err != nil {
 		return err
 	}
+
+	cmd.ApplyFrames.Animation = animation
 
 	return action.ExecuteCommand(cmd)
 }

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -24,7 +25,7 @@ type Desktop interface {
 	Displays() ([]action.DisplayEntry, error)
 	ActiveSpaces() (map[uint32]int, error)
 	Margins() (action.MarginsInfo, error)
-	Apply(frames []action.WindowFrame) error
+	Apply(frames []action.WindowFrame, animation *action.Animation) error
 	Focus(number uint32) error
 }
 
@@ -46,6 +47,8 @@ type Engine struct {
 	command string
 	// gap is tiling.gap when set; nil follows the macOS margin.
 	gap *int
+	// animation is how the frames move, or nil to move them at once.
+	animation *action.Animation
 	// configured reports whether Update has run at all, which is what tells
 	// the startup pass from a reload's.
 	configured bool
@@ -120,6 +123,15 @@ func (e *Engine) Update(cfg config.TilingConfig, shell string) {
 	e.enabled = cfg.Enabled
 	e.command = cfg.Layout
 	e.gap = cfg.Gap
+
+	e.animation = nil
+	if cfg.Animation.Enabled {
+		e.animation = &action.Animation{
+			DurationMS: cfg.Animation.DurationMS,
+			Easing:     cfg.Animation.Easing,
+		}
+	}
+
 	e.configured = true
 	e.onDrag = cfg.RelayoutOnDrag
 	e.settle = time.Duration(cfg.DebounceMS) * time.Millisecond
@@ -317,12 +329,22 @@ func (e *Engine) Pass(ctx context.Context, event Event) error {
 		return nil
 	}
 
+	// A window the user just dragged is placed where the layout puts it at
+	// once rather than animated there.
+	if e.animation != nil {
+		for index := range frames {
+			if slices.Contains(event.Windows, frames[index].Number) {
+				frames[index].Animate = new(bool)
+			}
+		}
+	}
+
 	err = e.run(func() error {
 		if len(frames) == 0 {
 			return nil
 		}
 
-		return e.desktop.Apply(frames)
+		return e.desktop.Apply(frames, e.animation)
 	})
 
 	if focus != 0 {

--- a/internal/tiling/engine_test.go
+++ b/internal/tiling/engine_test.go
@@ -32,8 +32,10 @@ type fakeDesktop struct {
 	displays []action.DisplayEntry
 	spaces   map[uint32]int
 	applied  [][]action.WindowFrame
-	applyErr error
-	focused  []uint32
+	// animations is the animation each Apply was asked for, nil for none.
+	animations []*action.Animation
+	applyErr   error
+	focused    []uint32
 }
 
 func (d *fakeDesktop) Focus(number uint32) error {
@@ -64,7 +66,7 @@ func (d *fakeDesktop) Margins() (action.MarginsInfo, error) {
 	return action.MarginsInfo{Enabled: true, Size: 8}, nil
 }
 
-func (d *fakeDesktop) Apply(frames []action.WindowFrame) error {
+func (d *fakeDesktop) Apply(frames []action.WindowFrame, animation *action.Animation) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -73,6 +75,7 @@ func (d *fakeDesktop) Apply(frames []action.WindowFrame) error {
 	}
 
 	d.applied = append(d.applied, frames)
+	d.animations = append(d.animations, animation)
 
 	return nil
 }
@@ -626,5 +629,69 @@ func TestEngine_Pass_FocusesTheWindowTheLayoutAsksFor(t *testing.T) {
 			len(desktop.applied),
 			desktop.focused,
 		)
+	}
+}
+
+// TestEngine_Pass_AnimatesTheFramesButNotADraggedWindow pins how the
+// [tiling.animation] section reaches apply_frames: as the animation every
+// pass asks for, with the window the user just dragged left out of it.
+func TestEngine_Pass_AnimatesTheFramesButNotADraggedWindow(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	cfg := enabled(echoLayout)
+	cfg.Animation = config.AnimationConfig{Enabled: true, DurationMS: 120, Easing: "ease-in-out"}
+	engine.Update(cfg, shell)
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v, want nil", err)
+	}
+
+	err = engine.Pass(context.Background(), tiling.Event{Kind: "window_move", Windows: []uint32{1}})
+	if err != nil {
+		t.Fatalf("Pass(window_move) error = %v, want nil", err)
+	}
+
+	want := action.Animation{DurationMS: 120, Easing: "ease-in-out"}
+	for index, got := range desktop.animations {
+		if got == nil || *got != want {
+			t.Fatalf("animations[%d] = %+v, want %+v", index, got, want)
+		}
+	}
+
+	if len(desktop.animations) != 2 {
+		t.Fatalf("len(animations) = %d, want 2", len(desktop.animations))
+	}
+
+	if desktop.applied[0][0].Animate != nil {
+		t.Fatal("a window nobody dragged was left out of the animation")
+	}
+
+	if dragged := desktop.applied[1][0].Animate; dragged == nil || *dragged {
+		t.Fatal("the window the user dragged was animated")
+	}
+
+	cfg.Animation.Enabled = false
+	engine.Update(cfg, shell)
+
+	err = engine.Pass(context.Background(), tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v, want nil", err)
+	}
+
+	if desktop.animations[2] != nil {
+		t.Fatal("animation off in the config still animated")
+	}
+
+	// Off, a drag is not marked either: the frames go out untouched.
+	err = engine.Pass(context.Background(), tiling.Event{Kind: "window_move", Windows: []uint32{1}})
+	if err != nil {
+		t.Fatalf("Pass(window_move) error = %v, want nil", err)
+	}
+
+	if desktop.applied[3][0].Animate != nil {
+		t.Fatal("animation off in the config still marked the dragged window")
 	}
 }

--- a/internal/tiling/resize_test.go
+++ b/internal/tiling/resize_test.go
@@ -46,7 +46,7 @@ func (d *snappingDesktop) Margins() (action.MarginsInfo, error) { return action.
 
 func (d *snappingDesktop) Focus(uint32) error { return nil }
 
-func (d *snappingDesktop) Apply(frames []action.WindowFrame) error {
+func (d *snappingDesktop) Apply(frames []action.WindowFrame, _ *action.Animation) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 


### PR DESCRIPTION
## Description

This PR adds an optional animation to tiling: with it on, windows move to the frames a layout returns over a short, eased duration instead of jumping. A pass that arrives while an animation is running continues from where the windows are on screen. A window the user has just dragged is placed at once, and a layout can exclude a window from the animation.

The window server draws the animation from pictures of the windows, so the applications do no more work than for an instant move. A still of each display covers the real windows while their frames are written, and a picture of each moving window is moved over it by the compositor. Everything is removed in one step when the animation ends.

The animation is off by default. Taking the pictures needs the Screen Recording permission, which the daemon asks for only when the animation is on. With it off, nothing is captured and nothing is asked for.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config changes

New optional section. Existing configs keep working unchanged.

```toml
[tiling.animation]
enabled = false       # default; move the frames into place over time instead of at once
duration_ms = 150     # default; 1 to 1000
easing = "ease-out"   # default; linear, ease-in, ease-out or ease-in-out
```

The section reloads with the rest of `[tiling]`. A layout's output gains an optional per-frame field, `"animate": false`, which places that one window at once while the rest animate.

## Additional Context

The window server refuses alpha, transform, and ordering changes on another process's windows from an ordinary connection, which is why the real windows are covered rather than hidden or moved. The proxies use private SkyLight window and transaction calls, the same tier as the space-move code, and the deprecated CoreGraphics window capture. ScreenCaptureKit was measured as the replacement and rejected: 800ms on the first screenshot, then 22 to 30ms per capture plus 27ms to enumerate windows, against 6 to 9ms for the CoreGraphics call. The display link is CADisplayLink, scheduled on the run loop the workspace observer already owns.

Measured on macOS 26.6 with three windows moving: 70 to 90ms of setup on a 1x display and 75 to 140ms on a 2x display before the first animated frame, then compositor work only. A pass that moves no window costs under 1ms. Physical footprint settles at 18MB idle after 24 animations, with a transient peak of 125MB during a 2x animation while the captures are alive. Two orderings that stalled the window server for half a second were found and avoided: capturing after creating an unpainted window, and painting proxies from several threads. The comments in the native file record both.

Screenshots taken mid-animation on the 2x display render at full resolution.
