### PR TITLE
feat(tiling): keep the layout running between passes and drop queued repeats

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -70,6 +70,10 @@ show_workspace_number = true
 enabled = false
 # A command line, run through hook_shell above. Required when enabled.
 # layout = "~/.config/mimi/tiling/bsp.py"
+# How the layout runs. "oneshot" starts a process per pass and reads it to
+# exit. "resident" keeps one running and sends an input line per pass, so
+# the layout skips its own startup. The shipped layouts work either way.
+layout_mode = "oneshot"
 # Settle a burst of window events into one run.
 debounce_ms = 100
 # Kill the layout past this.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -211,6 +211,7 @@ show_workspace_number = true   # show active space number in menu bar — restar
 [tiling]
 enabled = true
 layout = "~/.config/mimi/tiling/columns.py"
+layout_mode = "oneshot"   # or "resident", one process kept running between passes
 debounce_ms = 100     # settle a burst of window events into one pass
 timeout_secs = 5      # kill the layout past this
 relayout_on_drag = false     # a window the user moves or resizes runs a pass too
@@ -228,6 +229,25 @@ the frames to apply as JSON on stdout. The daemon runs it whenever a window is
 created, closed or focused, an application hides, unhides or quits, or the
 space changes, waiting `debounce_ms` for the burst to settle so one pass covers
 it.
+
+`layout_mode` is how the daemon runs it. With `oneshot`, the default, every
+pass starts a new process, writes the input, and reads until it exits. With
+`resident`, the daemon starts the process once and keeps it running. Each
+pass writes the input as one line on its stdin and reads one line of output
+from its stdout, so a layout in an interpreted language skips its startup on
+every pass after the first. That is what lets a held scroll key keep up.
+A resident layout must flush its output after every line, and must exit when
+stdin closes. The daemon stops it on a reload that changes the command, when
+tiling is disabled, and when it quits. A layout that exits between passes is
+started again on the next pass. One that fails a pass is started again after
+a wait that doubles with each failure in a row, up to five seconds. The
+layouts in `examples/tiling/` work in both modes.
+
+A command sent with `mimi tiling cmd` runs one pass. While that pass runs,
+one more command of the same name may wait, and further copies are dropped.
+A held key repeats faster than passes run, and dropping the extra copies is
+what keeps the screen in step with the key and stops the scrolling when the
+key is released.
 
 Moves and resizes are opt-in, with `relayout_on_drag = true`, because every
 frame the engine writes is one and a layout that ran on its own writes would

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -126,6 +126,10 @@ The `[tiling]` keys are `enabled`, `layout`, `debounce_ms`, `timeout_secs`,
 ## The contract
 
 Your program reads one JSON document on stdin and prints one on stdout.
+With `layout_mode = "resident"` in the config, it keeps going. It reads one
+document per line on stdin for as long as stdin stays open, and prints one
+line of output per document, flushed after each. The shipped layouts do
+both, through `serve()` in `rules.py`.
 
 ### Input
 
@@ -261,7 +265,9 @@ Anything that reads stdin, speaks JSON, and writes stdout will do: Go, Rust,
 Swift, Ruby, Lua, a shell script. Two things matter more than the language.
 Startup time, since the program runs once per display on every window event
 and a compiled binary starts in a few milliseconds where Node takes tens.
-And a JSON codec, since `state` is how a layout remembers anything. The
+`layout_mode = "resident"` takes startup out of every pass but the first for
+a program that reads a line at a time and flushes its answers. And a JSON
+codec, since `state` is how a layout remembers anything. The
 examples are Python because it ships with the Xcode Command Line Tools and
 needs no library. A whole layout in shell and jq, one column per window:
 

--- a/examples/tiling/README.md
+++ b/examples/tiling/README.md
@@ -16,7 +16,10 @@ do when nothing happens, is the
 
 All in Python with the standard library only, so `python3` from the Xcode
 Command Line Tools is enough. Each reads stdin, prints stdout, and imports
-`rules.py` from its own directory, so copy the directory as a whole.
+`rules.py` from its own directory, so copy the directory as a whole. They
+run in both of mimi's layout modes: one process per pass, or, with
+`layout_mode = "resident"`, one process kept running that answers a line
+per pass.
 
 | File | What it does |
 | --- | --- |
@@ -25,7 +28,7 @@ Command Line Tools is enough. Each reads stdin, prints stdout, and imports
 | `master-stack.py [ratio]` | One master on the left, the rest stacked on the right. Remembers the master and ratio in `state`, answers `swap` and `ratio +0.05`, reads a drag of the split from either side, and makes a stack window dropped on the master the master. |
 | `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. Answers `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction|prev|+d|-d]`, `center`, `scroll <dir> [fraction]`, `togglefloat`, `togglemax`; a dragged edge sets a column's width and a window dropped on a column joins it. `PRIORITY` fixes where listed apps open. |
 | `bsp.py` | Dwindle BSP, as Hyprland tiles by default: a new window splits the focused one, closing hands the area back, any dragged edge resizes its split, a window dropped on another swaps with it. Answers `swap <dir>`, `togglesplit`, `ratio <delta>`, `togglefloat`. |
-| `rules.py` | What the others share: the float rules (edit the bundle ids and title patterns here), the area to fill, reading the input and writing the output, and the temporary maximise every layout answers as `togglemax`. |
+| `rules.py` | What the others share: the float rules (edit the bundle ids and title patterns here), the area to fill, `serve()`, which reads the input and runs the layout in either mode, `write_output`, and the temporary maximise every layout answers as `togglemax`. |
 
 Run any of them with nothing on stdin and it lays the desktop out once by
 itself: the inputs the daemon would build, one run per display, frames

--- a/examples/tiling/bsp.py
+++ b/examples/tiling/bsp.py
@@ -31,7 +31,7 @@ Usage: bsp.py     (the gap is tiling.gap, else the macOS tiled-window margin)
 import sys
 
 from rules import clamp as clamp_to
-from rules import area, command, gap, maximised, read_input, write_output
+from rules import area, command, gap, maximised, serve, write_output
 
 # The gap, set from the input once it is read. The tree functions below read
 # it as a global.
@@ -225,10 +225,9 @@ def neighbour(rects, number, direction):
 # --- one pass -------------------------------------------------------------
 
 
-def main():
+def main(inp):
     global GAP
 
-    inp = read_input()
     GAP = gap(inp)
     state = inp.get("state") or {}
     box = area(inp, GAP)
@@ -313,4 +312,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    serve(main)

--- a/examples/tiling/columns.py
+++ b/examples/tiling/columns.py
@@ -11,11 +11,10 @@ stdout. Copy, edit, own. Standard library only.
 Usage: columns.py     (the gap is tiling.gap, else the macOS tiled-window margin)
 """
 
-from rules import area, gap, maximised, read_input, write_output
+from rules import area, gap, maximised, serve, write_output
 
 
-def main():
-    inp = read_input()
+def main(inp):
     GAP = gap(inp)
     state = inp.get("state") or {}
     windows = inp["windows"]
@@ -42,4 +41,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    serve(main)

--- a/examples/tiling/master-stack.py
+++ b/examples/tiling/master-stack.py
@@ -24,13 +24,12 @@ Usage: master-stack.py [ratio]     (the gap is tiling.gap, else the macOS tiled-
 
 import sys
 
-from rules import area, clamp, command, gap, maximised, read_input, write_output
+from rules import area, clamp, command, gap, maximised, serve, write_output
 
 RATIO = float(sys.argv[1]) if len(sys.argv) > 1 else 0.6
 
 
-def main():
-    inp = read_input()
+def main(inp):
     GAP = gap(inp)
     state = inp.get("state") or {}
     windows = inp["windows"]
@@ -104,4 +103,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    serve(main)

--- a/examples/tiling/monocle.py
+++ b/examples/tiling/monocle.py
@@ -11,14 +11,13 @@ stdout. Copy, edit, own. Standard library only.
 Usage: monocle.py     (the gap is tiling.gap, else the macOS tiled-window margin)
 """
 
-from rules import area, gap, read_input, write_output
+from rules import area, gap, serve, write_output
 
 
-def main():
-    inp = read_input()
+def main(inp):
     box = area(inp, gap(inp))
     write_output([(w["number"], box) for w in inp["windows"]], None)
 
 
 if __name__ == "__main__":
-    main()
+    serve(main)

--- a/examples/tiling/rules.py
+++ b/examples/tiling/rules.py
@@ -1,8 +1,9 @@
 """Shared pieces the layout programs import: which windows to leave alone,
 and which display to fill. Copy, edit, own.
 
-Every layout here reads one JSON document on stdin and prints one on
-stdout; see README.md for the shapes. mimi runs a layout once per display,
+Every layout here reads a JSON document per line on stdin and prints one
+per line on stdout, once or for as long as stdin stays open. See README.md
+for the shapes. mimi runs a layout once per display,
 with that display's windows and a state of that display's own, so a layout
 only ever thinks about one display. This file is the one place to add a
 bundle identifier or a title pattern that should never be tiled.
@@ -33,9 +34,14 @@ def floating(win):
     )
 
 
-def read_input():
-    """The layout input from stdin, with `windows` narrowed to the tileable
-    ones and `focused` re-pointed at the same window, or -1 if it went.
+def serve(layout):
+    """Run `layout(inp)` for every input the daemon sends, in either mode
+    mimi runs a layout: once, for one document on stdin (`layout_mode =
+    "oneshot"`, the default), or once per line for as long as stdin stays
+    open (`layout_mode = "resident"`), which skips the interpreter's startup
+    on every pass after the first. Each input's `windows` is narrowed to
+    the tileable ones and `focused` re-pointed at the same window, or -1 if
+    it went.
 
     Run with nothing on stdin, from a terminal or a hotkey, a layout drives
     itself instead: it builds the inputs the daemon would, runs itself once
@@ -43,9 +49,17 @@ def read_input():
     used as a one-shot command with tiling off and no daemon running."""
     if sys.stdin.isatty():
         run_once()
-        sys.exit(0)
+        return
 
-    inp = json.load(sys.stdin)
+    for line in sys.stdin:
+        if line.strip():
+            layout(narrow(json.loads(line)))
+            sys.stdout.flush()
+
+
+def narrow(inp):
+    """The input with `windows` narrowed to the tileable ones and `focused`
+    re-pointed at the same window, or -1 if it went."""
     focused_number = (
         inp["windows"][inp["focused"]]["number"] if inp["focused"] >= 0 else None
     )
@@ -134,6 +148,7 @@ def write_output(frames, state, focus=None):
     if focus is not None:
         out["focus"] = focus
     json.dump(out, sys.stdout)
+    sys.stdout.write("\n")
 
 
 def maximised(inp, state, frames, area):

--- a/examples/tiling/strip.py
+++ b/examples/tiling/strip.py
@@ -47,7 +47,7 @@ A layout program: reads the tiling input on stdin, prints the output on
 stdout. Copy, edit, own. Standard library only.
 """
 
-from rules import area, clamp, command, gap, maximised, read_input, write_output
+from rules import area, clamp, command, gap, maximised, serve, write_output
 
 PRESETS = [1 / 3, 1 / 2, 2 / 3]
 DEFAULT = 1 / 2
@@ -198,8 +198,7 @@ def column_at(columns, box, gap, offset, x):
 # --- one run ------------------------------------------------------------------
 
 
-def main():
-    inp = read_input()
+def main(inp):
     state = inp.get("state") or {}
     columns = state.get("columns") or []
     offset = float(state.get("offset") or 0)
@@ -340,4 +339,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    serve(main)

--- a/internal/config/animation_test.go
+++ b/internal/config/animation_test.go
@@ -65,3 +65,39 @@ func TestLoad_RejectsATilingAnimationItCannotRun(t *testing.T) {
 		})
 	}
 }
+
+func TestLoad_TilingLayoutMode(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(writeConfig(t, "[tiling]\nenabled = true\nlayout = \"cat\"\n"))
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	if cfg.Tiling.LayoutMode != LayoutModeOneshot {
+		t.Fatalf(
+			"tiling.layout_mode = %q, want %q by default",
+			cfg.Tiling.LayoutMode,
+			LayoutModeOneshot,
+		)
+	}
+
+	cfg, err = Load(
+		writeConfig(t, "[tiling]\nenabled = true\nlayout = \"cat\"\nlayout_mode = \"resident\"\n"),
+	)
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	if cfg.Tiling.LayoutMode != LayoutModeResident {
+		t.Fatalf("tiling.layout_mode = %q, want %q", cfg.Tiling.LayoutMode, LayoutModeResident)
+	}
+
+	_, err = Load(
+		writeConfig(t, "[tiling]\nenabled = true\nlayout = \"cat\"\nlayout_mode = \"daemon\"\n"),
+	)
+	if err == nil ||
+		!strings.Contains(err.Error(), "tiling.layout_mode must be oneshot or resident") {
+		t.Fatalf("Load() error = %v, want the layout_mode message", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,12 @@ type SystrayConfig struct {
 	ShowWorkspaceNumber bool `json:"showWorkspaceNumber" reload:"restart-only" toml:"show_workspace_number"`
 }
 
+// The values tiling.layout_mode takes.
+const (
+	LayoutModeOneshot  = "oneshot"
+	LayoutModeResident = "resident"
+)
+
 // TilingConfig holds the [tiling] section of the config: whether the daemon
 // runs a layout at all, and the program that is the layout.
 //
@@ -74,8 +80,13 @@ type SystrayConfig struct {
 // examples/tiling/). The whole section is reloadable: the engine re-reads it
 // on every reload, and enabling it at runtime is how a layout is tried out.
 type TilingConfig struct {
-	Enabled        bool   `json:"enabled"        toml:"enabled"`
-	Layout         string `json:"layout"         toml:"layout"`
+	Enabled bool   `json:"enabled" toml:"enabled"`
+	Layout  string `json:"layout"  toml:"layout"`
+	// LayoutMode is how the layout runs: LayoutModeOneshot, a process per
+	// pass given the input on stdin and read to exit, or
+	// LayoutModeResident, one process kept running that reads an input
+	// line and prints an output line per pass.
+	LayoutMode     string `json:"layoutMode"     toml:"layout_mode"`
 	DebounceMS     int    `json:"debounceMs"     toml:"debounce_ms"`
 	TimeoutSecs    int    `json:"timeoutSecs"    toml:"timeout_secs"`
 	RelayoutOnDrag bool   `json:"relayoutOnDrag" toml:"relayout_on_drag"`

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -189,6 +189,10 @@ func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 		cfg.Tiling.TimeoutSecs = defaultTilingTimeoutSecs
 	}
 
+	if cfg.Tiling.LayoutMode == "" {
+		cfg.Tiling.LayoutMode = LayoutModeOneshot
+	}
+
 	if cfg.Tiling.Animation.DurationMS == 0 {
 		cfg.Tiling.Animation.DurationMS = defaultTilingAnimationMS
 	}
@@ -242,6 +246,10 @@ func validate(cfg *Config) error {
 
 	if cfg.Tiling.TimeoutSecs < 1 {
 		errs = append(errs, "tiling.timeout_secs must be >= 1")
+	}
+
+	if cfg.Tiling.LayoutMode != LayoutModeOneshot && cfg.Tiling.LayoutMode != LayoutModeResident {
+		errs = append(errs, "tiling.layout_mode must be oneshot or resident")
 	}
 
 	animationMS := cfg.Tiling.Animation.DurationMS

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -53,7 +53,16 @@ type Engine struct {
 	// the startup pass from a reload's.
 	configured bool
 	layout     Layout
-	settle     time.Duration
+	// resident is the layout when it is kept running between passes, so
+	// a reload or shutdown can stop it; nil otherwise.
+	resident *Resident
+	// pending is each command a pass is waiting to run for, by name. A
+	// command that arrives while one of its name already waits is dropped:
+	// a held key sends them faster than passes run, and without this they
+	// queue up and keep scrolling after the key is released.
+	pendingMu sync.Mutex
+	pending   map[string]bool
+	settle    time.Duration
 	// states is what the layout returned last time, keyed by display and
 	// the space in front on it (stateKey), so a space switched on one
 	// display never touches what the other remembers.
@@ -90,6 +99,7 @@ func New(desktop Desktop, serialize Serializer, logger *zap.SugaredLogger) *Engi
 		serialize:   serialize,
 		logger:      logger,
 		states:      map[string]json.RawMessage{},
+		pending:     map[string]bool{},
 		applied:     map[uint32]action.Frame{},
 		resizeGrace: defaultResizeGrace,
 		wake:        make(chan Event, 1),
@@ -135,10 +145,26 @@ func (e *Engine) Update(cfg config.TilingConfig, shell string) {
 	e.configured = true
 	e.onDrag = cfg.RelayoutOnDrag
 	e.settle = time.Duration(cfg.DebounceMS) * time.Millisecond
-	e.layout = Program{
-		Shell:   shell,
-		Command: cfg.Layout,
-		Timeout: time.Duration(cfg.TimeoutSecs) * time.Second,
+
+	// A resident layout survives a reload that leaves it as it was: what it
+	// runs, and how. Anything else stops it, and the next pass starts what
+	// the config names now.
+	timeout := time.Duration(cfg.TimeoutSecs) * time.Second
+	resident := cfg.Enabled && cfg.LayoutMode == config.LayoutModeResident
+
+	keep := e.resident != nil && resident && e.resident.Shell == shell &&
+		e.resident.Command == cfg.Layout && e.resident.Timeout == timeout
+	if !keep {
+		e.stopResidentLocked()
+	}
+
+	switch {
+	case keep:
+	case resident:
+		e.resident = NewResident(shell, cfg.Layout, timeout, e.logger)
+		e.layout = e.resident
+	default:
+		e.layout = Program{Shell: shell, Command: cfg.Layout, Timeout: timeout}
 	}
 
 	if !cfg.Enabled || (wasEnabled && hadCommand == cfg.Layout) {
@@ -240,6 +266,8 @@ func (e *Engine) Run(ctx context.Context, sub events.Subscriber) {
 				timer.Stop()
 			}
 
+			e.Close()
+
 			return
 		case evt, ok := <-sub:
 			if !ok {
@@ -285,6 +313,88 @@ func (e *Engine) Pass(ctx context.Context, event Event) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	return e.passLocked(ctx, event)
+}
+
+// Command is a Pass a user asked for, by hotkey or by hand: unlike an event
+// from the bus, it is refused rather than dropped while the engine is
+// disabled, so the user learns why nothing moved. Commands of one name are
+// run one at a time with at most one more waiting; the rest are dropped, so
+// a key held down scrolls in step with the screen and stops when released.
+func (e *Engine) Command(ctx context.Context, event Event) error {
+	key := event.Kind + " " + event.Name
+
+	e.pendingMu.Lock()
+	if e.pending[key] {
+		e.pendingMu.Unlock()
+
+		return nil
+	}
+
+	e.pending[key] = true
+	e.pendingMu.Unlock()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.pendingMu.Lock()
+	delete(e.pending, key)
+	e.pendingMu.Unlock()
+
+	if !e.enabled {
+		return derrors.New(
+			derrors.CodeActionFailed,
+			"tiling is disabled (set tiling.enabled = true, and grant Accessibility)",
+		)
+	}
+
+	return e.passLocked(ctx, event)
+}
+
+// Close stops a resident layout. The engine is not used after it.
+func (e *Engine) Close() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.stopResidentLocked()
+}
+
+// Preview runs the layout the way Pass would, once per display, and returns
+// what each run was given and what it would apply instead of applying it.
+// It runs whether or not the engine is enabled, so a layout can be tried
+// before it is switched on, and it keeps no state.
+func (e *Engine) Preview(ctx context.Context, event Event) ([]Input, []Output, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	inputs, err := e.inputsLocked(event)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if e.layout == nil {
+		return inputs, nil, derrors.New(
+			derrors.CodeInvalidConfig,
+			"no tiling layout configured",
+		)
+	}
+
+	outputs := make([]Output, 0, len(inputs))
+
+	for _, input := range inputs {
+		out, reduceErr := e.layout.Reduce(ctx, input)
+		if reduceErr != nil {
+			return inputs, outputs, reduceErr
+		}
+
+		outputs = append(outputs, out)
+	}
+
+	return inputs, outputs, nil
+}
+
+// passLocked is Pass under the lock.
+func (e *Engine) passLocked(ctx context.Context, event Event) error {
 	if !e.enabled {
 		return nil
 	}
@@ -381,52 +491,16 @@ func (e *Engine) Pass(ctx context.Context, event Event) error {
 	return nil
 }
 
-// Command is a Pass a user asked for, by hotkey or by hand: unlike an event
-// from the bus, it is refused rather than dropped while the engine is
-// disabled, so the user learns why nothing moved.
-func (e *Engine) Command(ctx context.Context, event Event) error {
-	if !e.Enabled() {
-		return derrors.New(
-			derrors.CodeActionFailed,
-			"tiling is disabled (set tiling.enabled = true, and grant Accessibility)",
-		)
+// stopResidentLocked ends the resident layout, if there is one. The caller
+// holds the lock.
+func (e *Engine) stopResidentLocked() {
+	if e.resident == nil {
+		return
 	}
 
-	return e.Pass(ctx, event)
-}
-
-// Preview runs the layout the way Pass would, once per display, and returns
-// what each run was given and what it would apply instead of applying it.
-// It runs whether or not the engine is enabled, so a layout can be tried
-// before it is switched on, and it keeps no state.
-func (e *Engine) Preview(ctx context.Context, event Event) ([]Input, []Output, error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	inputs, err := e.inputsLocked(event)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if e.layout == nil {
-		return inputs, nil, derrors.New(
-			derrors.CodeInvalidConfig,
-			"no tiling layout configured",
-		)
-	}
-
-	outputs := make([]Output, 0, len(inputs))
-
-	for _, input := range inputs {
-		out, reduceErr := e.layout.Reduce(ctx, input)
-		if reduceErr != nil {
-			return inputs, outputs, reduceErr
-		}
-
-		outputs = append(outputs, out)
-	}
-
-	return inputs, outputs, nil
+	e.resident.Stop()
+	e.resident = nil
+	e.layout = nil
 }
 
 // stateKey names the state for one display and the space in front on it.

--- a/internal/tiling/engine_test.go
+++ b/internal/tiling/engine_test.go
@@ -695,3 +695,76 @@ func TestEngine_Pass_AnimatesTheFramesButNotADraggedWindow(t *testing.T) {
 		t.Fatal("animation off in the config still marked the dragged window")
 	}
 }
+
+// TestEngine_Command_DropsRepeatsWhileOneWaits pins the key-repeat rule: with
+// a pass running and one command of the same name already waiting, further
+// copies are dropped rather than queued, so a held key never scrolls on
+// after it is released.
+func TestEngine_Command_DropsRepeatsWhileOneWaits(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled("sleep 0.3; "+echoLayout), shell)
+
+	scroll := tiling.Event{Kind: tiling.EventCommand, Name: "scroll", Args: []string{"right"}}
+
+	var commands sync.WaitGroup
+
+	commands.Go(func() {
+		_ = engine.Command(context.Background(), scroll)
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	for range 4 {
+		commands.Go(func() {
+			_ = engine.Command(context.Background(), scroll)
+		})
+	}
+
+	commands.Wait()
+
+	if got := desktop.appliedCount(); got != 2 {
+		t.Fatalf("passes applied = %d, want 2: the running one and one waiting", got)
+	}
+}
+
+// TestEngine_Update_KeepsAResidentLayoutUnlessItChanges pins what a reload
+// does to a resident layout: the same command keeps its process, a
+// different one gets a fresh one.
+func TestEngine_Update_KeepsAResidentLayoutUnlessItChanges(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+
+	engine := tiling.New(desktop, nil, nil)
+	defer engine.Close()
+
+	cfg := enabled(countingLayout)
+	cfg.LayoutMode = config.LayoutModeResident
+	engine.Update(cfg, shell)
+
+	pass := func(want int) {
+		t.Helper()
+
+		_, outs, err := engine.Preview(context.Background(), tiling.Event{Kind: created})
+		if err != nil {
+			t.Fatalf("Preview() error = %v, want nil", err)
+		}
+
+		if got := stateOf(t, outs[0]); got != want {
+			t.Fatalf("state = %d, want %d", got, want)
+		}
+	}
+
+	pass(1)
+	pass(2)
+
+	engine.Update(cfg, shell)
+	pass(3)
+
+	cfg.Layout = "true; " + countingLayout
+	engine.Update(cfg, shell)
+	pass(1)
+}

--- a/internal/tiling/resident.go
+++ b/internal/tiling/resident.go
@@ -1,0 +1,336 @@
+package tiling
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// The backoff after a resident layout fails: doubled per failure in a row,
+// from the first up to the last.
+const (
+	residentBackoffFirst = 100 * time.Millisecond
+	residentBackoffLast  = 5 * time.Second
+	// maxLayoutLineBytes bounds one output line, so a layout that prints
+	// without end cannot grow the daemon's memory.
+	maxLayoutLineBytes = 8 << 20
+)
+
+// Resident is the Layout the config names with layout_mode = "resident": the
+// same command line as Program, started once and kept running. Each pass
+// writes the Input as one line on its stdin and reads the Output as one line
+// from its stdout, so a layout skips its own startup on every pass after
+// the first. A layout that exits, prints something that is not an Output,
+// or takes longer than Timeout is stopped. The next pass starts it again,
+// after a backoff that grows while it keeps failing.
+type Resident struct {
+	// Shell, Command and Timeout are as Program's. Timeout bounds one
+	// pass, not the process.
+	Shell   string
+	Command string
+	Timeout time.Duration
+
+	logger *zap.SugaredLogger
+
+	mu       sync.Mutex
+	proc     *residentProcess
+	failures int
+	failedAt time.Time
+}
+
+// NewResident returns a Resident that starts its program on the first
+// Reduce. A nil logger logs nothing.
+func NewResident(
+	shell, command string,
+	timeout time.Duration,
+	logger *zap.SugaredLogger,
+) *Resident {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
+	return &Resident{Shell: shell, Command: command, Timeout: timeout, logger: logger}
+}
+
+// residentProcess is one run of the program: its pipes, and the lines it
+// prints, read by a goroutine of its own so a read can be given up on.
+type residentProcess struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stderr *limitedBuffer
+	lines  chan residentLine
+	served int
+}
+
+type residentLine struct {
+	data []byte
+	err  error
+}
+
+// Reduce hands the input to the running program, starting it if it is not,
+// and reads its answer. A program that exited between passes is started
+// again and given the input once more, so that costs nothing. A failure
+// while answering fails the pass.
+func (r *Resident) Reduce(ctx context.Context, input Input) (Output, error) {
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return Output{}, derrors.Wrapf(
+			err,
+			derrors.CodeSerializationFailed,
+			"encoding layout input",
+		)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for attempt := range 2 {
+		proc, startErr := r.ensureLocked()
+		if startErr != nil {
+			return Output{}, startErr
+		}
+
+		served := proc.served
+
+		out, reduceErr := r.exchangeLocked(ctx, proc, payload)
+		if reduceErr == nil {
+			r.failures = 0
+
+			return out, nil
+		}
+
+		r.stopLocked()
+
+		// A program that had answered before and now gave end of file
+		// exited between passes. It is started once more before the pass
+		// is given up on.
+		if attempt == 0 && served > 0 && errors.Is(reduceErr, errResidentGone) {
+			r.logger.Debugw("resident layout exited; restarting")
+
+			continue
+		}
+
+		r.failures++
+		r.failedAt = time.Now()
+
+		return Output{}, reduceErr
+	}
+
+	return Output{}, derrors.New(derrors.CodeActionFailed, "layout failed")
+}
+
+// Stop ends the program, if it runs. The next Reduce starts it again.
+func (r *Resident) Stop() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.stopLocked()
+}
+
+// errResidentGone is a program that gave end of file where an answer was
+// due: it exited, or was killed. errLineTooLong is an output line past
+// maxLayoutLineBytes.
+var (
+	errResidentGone = errors.New("layout exited")
+	errLineTooLong  = errors.New("layout output line too long")
+)
+
+// ensureLocked is the running program, started if need be, or the reason
+// it cannot be. The caller holds the lock.
+func (r *Resident) ensureLocked() (*residentProcess, error) {
+	if r.proc != nil {
+		return r.proc, nil
+	}
+
+	if r.failures > 0 {
+		backoff := min(residentBackoffFirst<<(r.failures-1), residentBackoffLast)
+		if wait := time.Until(r.failedAt.Add(backoff)); wait > 0 {
+			return nil, derrors.Newf(
+				derrors.CodeActionFailed,
+				"layout failed %d times in a row; restarting in %s",
+				r.failures,
+				wait.Round(time.Millisecond),
+			)
+		}
+	}
+
+	// The process outlives any one pass, so no pass's context bounds it.
+	// stopLocked ends it.
+	cmd := exec.CommandContext(context.Background(), r.Shell, "-c", r.Command)
+	stderr := &limitedBuffer{buf: &bytes.Buffer{}, limit: maxLayoutOutputBytes}
+	cmd.Stderr = stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, derrors.Wrapf(err, derrors.CodeActionFailed, "starting layout")
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, derrors.Wrapf(err, derrors.CodeActionFailed, "starting layout")
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		r.failures++
+		r.failedAt = time.Now()
+
+		return nil, derrors.Wrapf(err, derrors.CodeActionFailed, "starting layout")
+	}
+
+	proc := &residentProcess{cmd: cmd, stdin: stdin, stderr: stderr, lines: make(chan residentLine)}
+	go readLines(stdout, proc.lines)
+
+	r.proc = proc
+	r.logger.Debugw("resident layout started", "pid", cmd.Process.Pid)
+
+	return proc, nil
+}
+
+// readLines hands each line stdout prints to lines, then the error that
+// ended it, and closes lines.
+func readLines(stdout io.Reader, lines chan<- residentLine) {
+	defer close(lines)
+
+	reader := bufio.NewReaderSize(stdout, 64<<10) //nolint:mnd
+
+	for {
+		data, err := readLine(reader)
+		if len(data) > 0 {
+			lines <- residentLine{data: data}
+		}
+
+		if err != nil {
+			lines <- residentLine{err: err}
+
+			return
+		}
+	}
+}
+
+// readLine reads one line without its newline, failing past
+// maxLayoutLineBytes.
+func readLine(reader *bufio.Reader) ([]byte, error) {
+	var line []byte
+
+	for {
+		chunk, err := reader.ReadSlice('\n')
+		line = append(line, chunk...)
+
+		if err == nil {
+			return bytes.TrimRight(line, "\r\n"), nil
+		}
+
+		if !errors.Is(err, bufio.ErrBufferFull) {
+			return line, err
+		}
+
+		if len(line) > maxLayoutLineBytes {
+			return nil, errLineTooLong
+		}
+	}
+}
+
+// exchangeLocked writes one input line and reads one output line, within
+// Timeout. The caller holds the lock.
+func (r *Resident) exchangeLocked(
+	ctx context.Context,
+	proc *residentProcess,
+	payload []byte,
+) (Output, error) {
+	_, err := proc.stdin.Write(append(payload, '\n'))
+	if err != nil {
+		return Output{}, errResidentGone
+	}
+
+	var timeout <-chan time.Time
+	if r.Timeout > 0 {
+		timer := time.NewTimer(r.Timeout)
+		defer timer.Stop()
+
+		timeout = timer.C
+	}
+
+	select {
+	case line, open := <-proc.lines:
+		if open && line.err != nil && !errors.Is(line.err, io.EOF) {
+			return Output{}, derrors.Wrapf(
+				line.err,
+				derrors.CodeActionFailed,
+				"reading layout output",
+			)
+		}
+
+		if !open || line.err != nil {
+			if proc.served > 0 {
+				return Output{}, errResidentGone
+			}
+
+			return Output{}, derrors.Newf(
+				derrors.CodeActionFailed,
+				"layout exited without answering%s",
+				stderrSuffix(proc.stderr.buf.String()),
+			)
+		}
+
+		proc.served++
+
+		out, decodeErr := decodeOutput(line.data)
+		if decodeErr != nil {
+			return Output{}, decodeErr
+		}
+
+		return out, nil
+	case <-timeout:
+		return Output{}, derrors.Newf(
+			derrors.CodeActionFailed,
+			"layout timed out after %s",
+			r.Timeout,
+		)
+	case <-ctx.Done():
+		return Output{}, derrors.Wrapf(ctx.Err(), derrors.CodeActionFailed, "layout pass canceled")
+	}
+}
+
+// stopLocked ends the program and forgets it. The caller holds the lock.
+func (r *Resident) stopLocked() {
+	proc := r.proc
+	if proc == nil {
+		return
+	}
+
+	r.proc = nil
+
+	_ = proc.stdin.Close()
+
+	// Closing stdin ends a well-behaved program at once. One that is stuck
+	// is killed after a grace period.
+	done := make(chan struct{})
+	go func() {
+		_ = proc.cmd.Wait()
+
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(residentBackoffFirst):
+		_ = proc.cmd.Process.Kill()
+
+		<-done
+	}
+
+	// Drain the reader so it can end.
+	for range proc.lines {
+	}
+}

--- a/internal/tiling/resident.go
+++ b/internal/tiling/resident.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os/exec"
 	"sync"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
@@ -109,7 +110,7 @@ func (r *Resident) Reduce(ctx context.Context, input Input) (Output, error) {
 			return out, nil
 		}
 
-		r.stopLocked()
+		stderr := r.stopLocked()
 
 		// A program that had answered before and now gave end of file
 		// exited between passes. It is started once more before the pass
@@ -122,6 +123,16 @@ func (r *Resident) Reduce(ctx context.Context, input Input) (Output, error) {
 
 		r.failures++
 		r.failedAt = time.Now()
+
+		// What it wrote to stderr is read once it has exited, and is what
+		// a program that answered nothing has to say for itself.
+		if errors.Is(reduceErr, errNoAnswer) {
+			return Output{}, derrors.Newf(
+				derrors.CodeActionFailed,
+				"layout exited without answering%s",
+				stderrSuffix(stderr),
+			)
+		}
 
 		return Output{}, reduceErr
 	}
@@ -142,6 +153,7 @@ func (r *Resident) Stop() {
 // maxLayoutLineBytes.
 var (
 	errResidentGone = errors.New("layout exited")
+	errNoAnswer     = errors.New("layout exited without answering")
 	errLineTooLong  = errors.New("layout output line too long")
 )
 
@@ -169,6 +181,9 @@ func (r *Resident) ensureLocked() (*residentProcess, error) {
 	cmd := exec.CommandContext(context.Background(), r.Shell, "-c", r.Command)
 	stderr := &limitedBuffer{buf: &bytes.Buffer{}, limit: maxLayoutOutputBytes}
 	cmd.Stderr = stderr
+	// Its own process group, so that killing it takes what it started
+	// with it, which is what holds the pipes open otherwise.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -276,11 +291,7 @@ func (r *Resident) exchangeLocked(
 				return Output{}, errResidentGone
 			}
 
-			return Output{}, derrors.Newf(
-				derrors.CodeActionFailed,
-				"layout exited without answering%s",
-				stderrSuffix(proc.stderr.buf.String()),
-			)
+			return Output{}, errNoAnswer
 		}
 
 		proc.served++
@@ -302,11 +313,12 @@ func (r *Resident) exchangeLocked(
 	}
 }
 
-// stopLocked ends the program and forgets it. The caller holds the lock.
-func (r *Resident) stopLocked() {
+// stopLocked ends the program and forgets it, returning what it wrote to
+// stderr. The caller holds the lock.
+func (r *Resident) stopLocked() string {
 	proc := r.proc
 	if proc == nil {
-		return
+		return ""
 	}
 
 	r.proc = nil
@@ -314,7 +326,7 @@ func (r *Resident) stopLocked() {
 	_ = proc.stdin.Close()
 
 	// Closing stdin ends a well-behaved program at once. One that is stuck
-	// is killed after a grace period.
+	// is killed after a grace period, with everything it started.
 	done := make(chan struct{})
 	go func() {
 		_ = proc.cmd.Wait()
@@ -325,7 +337,7 @@ func (r *Resident) stopLocked() {
 	select {
 	case <-done:
 	case <-time.After(residentBackoffFirst):
-		_ = proc.cmd.Process.Kill()
+		_ = syscall.Kill(-proc.cmd.Process.Pid, syscall.SIGKILL)
 
 		<-done
 	}
@@ -333,4 +345,6 @@ func (r *Resident) stopLocked() {
 	// Drain the reader so it can end.
 	for range proc.lines {
 	}
+
+	return proc.stderr.buf.String()
 }

--- a/internal/tiling/resident_test.go
+++ b/internal/tiling/resident_test.go
@@ -1,0 +1,123 @@
+package tiling_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/tiling"
+)
+
+// countingLayout answers every line with the number of lines it has read,
+// so a test can tell one process from a restarted one.
+const countingLayout = `n=0; while IFS= read -r line; do n=$((n+1)); echo "{\"frames\":[],\"state\":$n}"; done`
+
+func stateOf(t *testing.T, out tiling.Output) int {
+	t.Helper()
+
+	var state int
+
+	err := json.Unmarshal(out.State, &state)
+	if err != nil {
+		t.Fatalf("state %q is not a number: %v", out.State, err)
+	}
+
+	return state
+}
+
+func TestResident_KeepsOneProcessAcrossPasses(t *testing.T) {
+	t.Parallel()
+
+	layout := tiling.NewResident(shell, countingLayout, time.Second, nil)
+	defer layout.Stop()
+
+	for want := 1; want <= 3; want++ {
+		out, err := layout.Reduce(context.Background(), tiling.Input{})
+		if err != nil {
+			t.Fatalf("Reduce() #%d error = %v, want nil", want, err)
+		}
+
+		if got := stateOf(t, out); got != want {
+			t.Fatalf("Reduce() #%d state = %d, want %d (a new process per pass)", want, got, want)
+		}
+	}
+
+	layout.Stop()
+
+	out, err := layout.Reduce(context.Background(), tiling.Input{})
+	if err != nil {
+		t.Fatalf("Reduce() after Stop error = %v, want nil", err)
+	}
+
+	if got := stateOf(t, out); got != 1 {
+		t.Fatalf("Reduce() after Stop state = %d, want 1 (a fresh process)", got)
+	}
+}
+
+func TestResident_RestartsALayoutThatExitedBetweenPasses(t *testing.T) {
+	t.Parallel()
+
+	// Answers once, then exits.
+	layout := tiling.NewResident(
+		shell,
+		`IFS= read -r line; echo '{"frames":[],"state":1}'`,
+		time.Second,
+		nil,
+	)
+	defer layout.Stop()
+
+	for pass := 1; pass <= 3; pass++ {
+		out, err := layout.Reduce(context.Background(), tiling.Input{})
+		if err != nil {
+			t.Fatalf("Reduce() #%d error = %v, want nil", pass, err)
+		}
+
+		if got := stateOf(t, out); got != 1 {
+			t.Fatalf("Reduce() #%d state = %d, want 1", pass, got)
+		}
+	}
+}
+
+func TestResident_FailuresAreReportedAndBackedOff(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		command  string
+		fragment string
+	}{
+		"exits without answering": {`echo nope >&2; exit 3`, "nope"},
+		"prints something else": {
+			`while IFS= read -r line; do echo not json; done`,
+			"decoding layout output",
+		},
+		"never answers": {`while IFS= read -r line; do sleep 5; done`, "timed out"},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			layout := tiling.NewResident(shell, testCase.command, 200*time.Millisecond, nil)
+			defer layout.Stop()
+
+			_, err := layout.Reduce(context.Background(), tiling.Input{})
+			if !derrors.IsCode(err, derrors.CodeActionFailed) &&
+				!derrors.IsCode(err, derrors.CodeSerializationFailed) {
+				t.Fatalf("Reduce() error = %v, want a failure", err)
+			}
+
+			if !strings.Contains(err.Error(), testCase.fragment) {
+				t.Fatalf("error %q does not mention %q", err.Error(), testCase.fragment)
+			}
+
+			// Right after a failure the layout is not started again.
+			_, err = layout.Reduce(context.Background(), tiling.Input{})
+			if err == nil || !strings.Contains(err.Error(), "restarting in") {
+				t.Fatalf("Reduce() right after a failure error = %v, want a backoff", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a held scroll key on the strip layout falling behind the screen and scrolling on after release. Each key repeat sent a command, each command started the layout program again, and passes took 60 to 90ms against a 30ms repeat, so commands queued and drained after the key was up.

Two changes address it. A layout can now be kept running between passes, so an interpreted layout skips its startup on every pass after the first. And commands of one name now run one at a time with at most one more waiting; further copies are dropped, so a held key scrolls in step with the screen and stops when released, whichever way the layout runs.

The shipped example layouts work both ways. A kept-running layout that exits between passes is started again on the next; one that fails a pass is started again after a wait that doubles per failure in a row, up to five seconds.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Config changes

One new key. Existing configs keep working unchanged, and the default is the previous behaviour.

```toml
[tiling]
layout_mode = "oneshot"   # default; or "resident"
```

With `resident`, the daemon starts the layout once and keeps it running. Each pass writes the input as one line on stdin and reads one line of output. A resident layout must flush after every line and exit when stdin closes. It is stopped on a reload that changes the command, when tiling is disabled, and when the daemon quits. The key reloads with the rest of `[tiling]`.

Layout scripts based on `rules.py` change from calling `read_input()` in `main()` to defining `main(inp)` and ending with `serve(main)`, which handles both modes. The five shipped layouts are updated. A layout written against the old one-shot contract keeps working in the default mode.

## Additional Context

Measured on the strip layout with three windows. One scroll command end to end went from 60 to 90ms to 30 to 45ms in resident mode, the rest being the client process and the frame writes. Twenty key repeats 30ms apart previously finished 130ms after the last key; with the coalescing they finish within a frame of it, in both modes, because the daemon never holds more than one waiting command per name.
