### PR TITLE
perf(tiling): write frames per app at once and draw translucent proxies as seen

### DIFF
--- a/internal/action/apply_frames.go
+++ b/internal/action/apply_frames.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
@@ -217,31 +218,7 @@ func (e *Executor) ApplyFrames(args ApplyFramesArgs) error {
 		animating = beginErr == nil && count > 0
 	}
 
-	var (
-		failures []string
-		dropped  []uint32
-	)
-
-	for _, entry := range args.Frames {
-		windowID, ok := byNumber[entry.Number]
-		if !ok {
-			failures = append(
-				failures,
-				fmt.Sprintf("window %d is not on the active space", entry.Number),
-			)
-
-			continue
-		}
-
-		setErr := e.desktop.SetWindowFrame(windowID, rectOfFrame(entry.Frame))
-		if setErr != nil {
-			dropped = append(dropped, entry.Number)
-			failures = append(
-				failures,
-				fmt.Sprintf("window %d: %s", entry.Number, derrors.Message(setErr)),
-			)
-		}
-	}
+	failures, dropped := e.writeFrames(args.Frames, windows)
 
 	if animating {
 		animator.StartFrameAnimation(dropped)
@@ -258,4 +235,80 @@ func (e *Executor) ApplyFrames(args ApplyFramesArgs) error {
 	}
 
 	return nil
+}
+
+// writeFrames writes every frame, one goroutine per owning application. A
+// write is a synchronous round trip into the application, some ten
+// milliseconds for a heavy one, and writes to different applications do not
+// wait on each other, so a layout takes as long as its slowest application
+// rather than the sum. Writes to one application stay in payload order, on
+// one goroutine, since an application may apply concurrent requests out of
+// order.
+// The failures come back in payload order, and the dropped windows are the
+// ones whose frame did not land.
+func (e *Executor) writeFrames(frames []WindowFrame, windows []Window) ([]string, []uint32) {
+	byNumber := make(map[uint32]Window, len(windows))
+	for _, win := range windows {
+		byNumber[win.Number] = win
+	}
+
+	// messages holds each frame's failure in payload order, empty for one
+	// that landed. errs is what the writers report, one slot each, so they
+	// share nothing.
+	messages := make([]string, len(frames))
+	errs := make([]error, len(frames))
+	groups := make(map[int][]int)
+
+	for index, entry := range frames {
+		win, ok := byNumber[entry.Number]
+		if !ok {
+			messages[index] = fmt.Sprintf("window %d is not on the active space", entry.Number)
+
+			continue
+		}
+
+		groups[win.PID] = append(groups[win.PID], index)
+	}
+
+	var writers sync.WaitGroup
+
+	for _, indexes := range groups {
+		writers.Add(1)
+
+		go func(indexes []int) {
+			defer writers.Done()
+
+			for _, index := range indexes {
+				entry := frames[index]
+				errs[index] = e.desktop.SetWindowFrame(
+					byNumber[entry.Number].ID,
+					rectOfFrame(entry.Frame),
+				)
+			}
+		}(indexes)
+	}
+
+	writers.Wait()
+
+	var (
+		failures []string
+		dropped  []uint32
+	)
+
+	for index, entry := range frames {
+		if errs[index] != nil {
+			dropped = append(dropped, entry.Number)
+			messages[index] = fmt.Sprintf(
+				"window %d: %s",
+				entry.Number,
+				derrors.Message(errs[index]),
+			)
+		}
+
+		if messages[index] != "" {
+			failures = append(failures, messages[index])
+		}
+	}
+
+	return failures, dropped
 }

--- a/internal/action/apply_frames_test.go
+++ b/internal/action/apply_frames_test.go
@@ -440,3 +440,47 @@ func TestExecutor_ApplyFrames_WithoutAnAnimationNeverTouchesTheAnimator(t *testi
 		t.Fatalf("window 4242 frame = %v, want %v", got, want)
 	}
 }
+
+// TestExecutor_ApplyFrames_WritesOneApplicationsFramesInPayloadOrder pins
+// that the frames of one application land in the order the payload lists
+// them, whatever the other applications' frames are doing at the time.
+func TestExecutor_ApplyFrames_WritesOneApplicationsFramesInPayloadOrder(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithWindows(4, 1)
+	for index := range desktop.windows {
+		desktop.windows[index].pid = 100 + index%2
+		desktop.windows[index].number = uint32(5000 + index)
+	}
+
+	frames := make([]action.WindowFrame, 0, 4)
+	for _, number := range []uint32{5003, 5000, 5001, 5002} {
+		frames = append(frames, action.WindowFrame{
+			Number: number,
+			Frame:  action.Frame{X: 0, Y: 0, Width: 100, Height: 100},
+		})
+	}
+
+	err := action.NewExecutor(desktop).ExecuteCommand(applyFramesCommandFor(t, frames...))
+	if err != nil {
+		t.Fatalf("ExecuteCommand(apply_frames) error = %v, want nil", err)
+	}
+
+	var even, odd []action.WindowID
+
+	for _, id := range desktop.frameWrites {
+		if desktop.windows[id-1].pid == 100 {
+			even = append(even, id)
+		} else {
+			odd = append(odd, id)
+		}
+	}
+
+	if want := []action.WindowID{1, 3}; !slices.Equal(even, want) {
+		t.Fatalf("pid 100 writes = %v, want %v", even, want)
+	}
+
+	if want := []action.WindowID{4, 2}; !slices.Equal(odd, want) {
+		t.Fatalf("pid 101 writes = %v, want %v", odd, want)
+	}
+}

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -2,6 +2,7 @@ package action_test
 
 import (
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/y3owk1n/mimi/internal/action"
@@ -33,6 +34,10 @@ type fakeWindow struct {
 // back in these fields, so a test asserts what the desktop looks like
 // afterwards rather than which methods ran.
 type fakeDesktop struct {
+	mu sync.Mutex
+	// frameWrites is every window written by SetWindowFrame, in order.
+	frameWrites []action.WindowID
+
 	accessibilityErr error
 
 	windows      []fakeWindow
@@ -241,6 +246,12 @@ func (d *fakeDesktop) ReopenApplication(pid int) error {
 }
 
 func (d *fakeDesktop) SetWindowFrame(windowID action.WindowID, frame geometry.Rect) error {
+	// apply_frames writes to different applications at once.
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.frameWrites = append(d.frameWrites, windowID)
+
 	index, err := d.indexOf(windowID)
 	if err != nil {
 		return err

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -20,7 +20,10 @@ import (
 // previous generation is released — so no action above this seam ever holds,
 // or has to release, a native reference.
 type nativeDesktop struct {
-	mu      sync.Mutex
+	// mu is held for writing while the window set is replaced, and for
+	// reading around every use of a window in it, so frames can be written to
+	// several windows at once.
+	mu      sync.RWMutex
 	lastID  WindowID
 	windows map[WindowID]*native.Element
 }
@@ -334,8 +337,8 @@ func (d *nativeDesktop) withWindow(
 	windowID WindowID,
 	apply func(*native.Element) error,
 ) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 
 	element, ok := d.windows[windowID]
 	if !ok || element == nil {

--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -57,11 +57,17 @@ typedef struct {
 	CGRect from;
 	CGRect to;
 	// alone is whether no other animating window overlaps this one where it
-	// starts, so its picture can be cropped from a composite; picture and
-	// scale hold the capture between the two phases of MimiAnimationBegin.
+	// starts, so its picture can be cropped from a composite; picture, mask
+	// and scale hold the capture between the phases of MimiAnimationBegin.
+	// mask, when there is one, is the window's own capture, whose alpha
+	// clips the picture to the window's shape.
 	BOOL alone;
 	CGImageRef picture;
+	CGImageRef mask;
 	double scale;
+	// depth is the window's place in the on-screen list, front first, so
+	// the proxies stack as the windows do.
+	int depth;
 } MimiProxy;
 
 static struct {
@@ -183,6 +189,38 @@ static void mimiPaint(int cid, uint32_t wid, CGSize size, CGImageRef picture) {
 		CGContextRelease(context);
 	}
 	CGImageRelease(picture);
+}
+
+// Render picture, clipped to mask's alpha when there is one, into memory
+// the paint can copy from. A captured image is materialised the first time
+// it is read, which is most of a proxy's cost, and this is that read. Done
+// here, off the thread that makes the windows, several run at once. Both
+// inputs are released.
+static CGImageRef mimiRender(CGImageRef picture, CGImageRef mask) {
+	size_t width = CGImageGetWidth(picture);
+	size_t height = CGImageGetHeight(picture);
+	CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
+	CGContextRef context = CGBitmapContextCreate(
+	    NULL, width, height, 8, 0, space, kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
+	CGColorSpaceRelease(space);
+	if (!context) {
+		if (mask) {
+			CGImageRelease(mask);
+		}
+		return picture;
+	}
+	CGRect whole = CGRectMake(0, 0, width, height);
+	CGContextSetBlendMode(context, kCGBlendModeCopy);
+	CGContextDrawImage(context, whole, picture);
+	if (mask) {
+		CGContextSetBlendMode(context, kCGBlendModeDestinationIn);
+		CGContextDrawImage(context, whole, mask);
+		CGImageRelease(mask);
+	}
+	CGImageRelease(picture);
+	CGImageRef rendered = CGBitmapContextCreateImage(context);
+	CGContextRelease(context);
+	return rendered;
 }
 
 static void mimiReleaseAllLocked(int cid, CFTypeRef transaction) {
@@ -307,7 +345,13 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 	if (!targets || count <= 0) {
 		return 0;
 	}
-	if (!CGPreflightScreenCaptureAccess()) {
+	// The check is a round trip that was measured at 8 ms, and a grant only
+	// takes effect when the process restarts, so a yes is kept.
+	static BOOL granted = NO;
+	if (!granted) {
+		granted = CGPreflightScreenCaptureAccess();
+	}
+	if (!granted) {
 		return -1;
 	}
 
@@ -349,10 +393,16 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 		// drawn over the proxies. The rest goes under them.
 		// CGWindowListCreateImageFromArray reads the ids as raw values, not
 		// as numbers.
+		// CGWindowListCreateImageFromArray composites the list in the order
+		// given, first on top, so every list keeps the on-screen order. under
+		// is the scene from the first animating window down, moving windows
+		// included, that the apart windows' pictures are cropped from.
 		CFMutableArrayRef others = CFArrayCreateMutable(NULL, 0, NULL);
 		CFMutableArrayRef front = CFArrayCreateMutable(NULL, 0, NULL);
+		CFMutableArrayRef under = CFArrayCreateMutable(NULL, 0, NULL);
 		pid_t self = getpid();
 		BOOL passed = NO;
+		int depth = 0;
 		CFArrayRef onScreen = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
 		for (NSDictionary *info in (__bridge NSArray *)onScreen) {
 			if ([info[(id)kCGWindowOwnerPID] intValue] == self ||
@@ -363,11 +413,18 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 			BOOL inFlight = NO;
 			for (int i = 0; i < nextCount && !inFlight; i++) {
 				inFlight = next[i].number == number;
+				if (inFlight) {
+					next[i].depth = depth;
+				}
 			}
+			depth++;
 			if (inFlight) {
 				passed = YES;
 			} else {
 				CFArrayAppendValue(passed ? others : front, (const void *)(uintptr_t)number);
+			}
+			if (passed) {
+				CFArrayAppendValue(under, (const void *)(uintptr_t)number);
 			}
 		}
 		if (onScreen) {
@@ -405,7 +462,12 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 			// Deprecated for ScreenCaptureKit, whose screenshot is asynchronous
 			// and far slower to start; this composes the display in a few
 			// milliseconds, which an animation that starts on the same frame
-			// as the event needs.
+			// as the event needs. SLSHWCaptureWindowList, the hardware
+			// capture yabai uses, was measured on macOS 26 at 6 to 10 ms per
+			// window, the cost of one of these composites of a whole display,
+			// and returns one clipped image for a list, so it captures
+			// nothing faster here. The window server serialises captures, so
+			// issuing them concurrently was measured to gain nothing.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			// The windows that overlap another animating window, as under a monocle
@@ -437,6 +499,14 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 			CGImageRef flight = CFArrayGetCount(apart) > 0
 			                        ? CGWindowListCreateImageFromArray(bounds, apart, kCGWindowImageBestResolution)
 			                        : NULL;
+			// A window captured on its own comes out opaque, with its
+			// translucent parts a flat tint, since the window server has
+			// nothing behind it to blend with. Composited with what is under
+			// it, it looks as it does on screen, so the apart windows take
+			// their picture from that scene, cropped, and their own capture
+			// only clips it to the window's shape.
+			CGImageRef scene =
+			    flight ? CGWindowListCreateImageFromArray(bounds, under, kCGWindowImageBestResolution) : NULL;
 			CFRelease(apart);
 			CGImageRef measure = still ? still : (cover ? cover : flight);
 			double scale = measure ? (double)CGImageGetWidth(measure) / bounds.size.width : 1;
@@ -463,7 +533,10 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 					    (proxy->from.origin.x - bounds.origin.x) * scale,
 					    (proxy->from.origin.y - bounds.origin.y) * scale, proxy->from.size.width * scale,
 					    proxy->from.size.height * scale);
-					proxy->picture = CGImageCreateWithImageInRect(flight, crop);
+					proxy->picture = CGImageCreateWithImageInRect(scene ? scene : flight, crop);
+					if (scene && proxy->picture) {
+						proxy->mask = CGImageCreateWithImageInRect(flight, crop);
+					}
 				} else if (!proxy->alone) {
 					proxy->picture = CGWindowListCreateImage(
 					    proxy->from, kCGWindowListOptionIncludingWindow, proxy->number, kCGWindowImageBestResolution);
@@ -478,9 +551,51 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 			if (flight) {
 				CGImageRelease(flight);
 			}
+			if (scene) {
+				CGImageRelease(scene);
+			}
 		}
 		CFRelease(others);
 		CFRelease(front);
+		CFRelease(under);
+
+		// Every picture is rendered before any window is made, at once on
+		// as many threads as there are pictures. The rendering is the bulk of
+		// a paint, so the paints below only copy.
+		int renderCount = backdropCount;
+		for (int i = 0; i < nextCount; i++) {
+			if (next[i].picture) {
+				renderCount++;
+			}
+		}
+		CGImageRef *pictures = calloc((size_t)renderCount, sizeof(CGImageRef));
+		CGImageRef *masks = calloc((size_t)renderCount, sizeof(CGImageRef));
+		int r = 0;
+		for (int i = 0; i < backdropCount; i++) {
+			pictures[r++] = backdropStills[i];
+		}
+		for (int i = 0; i < nextCount; i++) {
+			if (next[i].picture) {
+				pictures[r] = next[i].picture;
+				masks[r] = next[i].mask;
+				r++;
+			}
+		}
+		dispatch_apply((size_t)renderCount, dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^(size_t k) {
+			pictures[k] = mimiRender(pictures[k], masks[k]);
+		});
+		r = 0;
+		for (int i = 0; i < backdropCount; i++) {
+			backdropStills[i] = pictures[r++];
+		}
+		for (int i = 0; i < nextCount; i++) {
+			if (next[i].picture) {
+				next[i].picture = pictures[r++];
+				next[i].mask = NULL;
+			}
+		}
+		free(pictures);
+		free(masks);
 
 		// Then the windows, each painted the moment it exists: the window
 		// server stalls for half a second on a request that arrives while
@@ -533,10 +648,19 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 				SLSTransactionOrderWindow(transaction, backdrops[i], kMimiOrderAbove, 0);
 			}
 		}
+		// The proxies go in back to front, each above everything, so they
+		// stack as their windows do on screen.
 		for (int i = 0; i < kept; i++) {
+			int back = 0;
+			for (int j = 1; j < kept; j++) {
+				if (next[j].depth > next[back].depth) {
+					back = j;
+				}
+			}
 			SLSTransactionSetWindowTransform(
-			    transaction, next[i].proxy, 0, 0, mimiPlacement(next[i].from.size, next[i].from));
-			SLSTransactionOrderWindow(transaction, next[i].proxy, kMimiOrderAbove, 0);
+			    transaction, next[back].proxy, 0, 0, mimiPlacement(next[back].from.size, next[back].from));
+			SLSTransactionOrderWindow(transaction, next[back].proxy, kMimiOrderAbove, 0);
+			next[back].depth = -1;
 		}
 		for (int i = 0; i < backdropCount; i++) {
 			if (backdropOver[i]) {


### PR DESCRIPTION
## Description

This PR cuts the delay between a tiling pass and the first animated frame, and makes translucent windows look as they do on screen while they move.

Frame writes now go out on one goroutine per application. Each write is a synchronous round trip into the application, 4 ms for Ghostty and 11 ms for Safari on a MacBook Air, so a layout of several heavy applications waited for the sum. It now waits for the slowest one. Writes to one application keep their payload order.

Proxy pictures are cropped from a composite of the window and everything under it, clipped to the window's shape by its own capture. A window captured alone comes out opaque with its translucent parts a flat tint, so sidebars and other vibrancy views used to look wrong for the length of the animation.

Also in the animation:

- Pictures are rendered in memory on several threads before any proxy window is made, so each paint only copies.
- The Screen Recording preflight, 8 ms per call, is checked once instead of on every pass.
- Proxies stack in their windows' on-screen order. They followed payload order, which drew a still window's proxy over one growing to cover it.

Measured on a 1x display with two windows, the animation prepare went from 75 ms to 70 ms with the extra composite included. No config or CLI change.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

How to test: enable `[tiling.animation]` with a long `duration_ms`, run `mimi tiling cmd togglemax` with a Notes or Finder window on the space, and screenshot mid-animation. The window's sidebar should match its on-screen colour, and the growing window's proxy should draw over the still ones.

Two things worth knowing from the work behind this:

- `CGWindowListCreateImageFromArray` composites the array in the order given, first on top, not by real depth. Every list the animation builds keeps the on-screen order for that reason.
- `SLSHWCaptureWindowList`, the hardware capture yabai uses, was measured at 6 to 10 ms per window on macOS 26 and returns one clipped image for a list, so it is no faster than the composite captures and was not adopted. Captures are serialised by the window server, so issuing them concurrently gains nothing either.

Verified on a 1x display only. The crop and scale maths at 2x is unchanged in kind but not checked by eye.
