### PR TITLE
perf(tiling): make animated navigation immediate

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -235,8 +235,11 @@ shape, and applies nothing.
 
 With `[tiling.animation]` enabled, windows move to their frames over
 `duration_ms` along the `easing` curve. A pass that lands mid-animation
-continues from where the windows are. A window the user just dragged moves at
-once, and a layout can opt a window out with `animate: false` on its frame.
+continues from where the windows are, and one that asks for the frames
+already in flight leaves the animation to finish. A window arriving from off
+screen slides in. A window the user just dragged moves at once, and a layout
+can opt a window out with `animate: false` on its frame. The focus a layout
+asks for lands before its frames move.
 
 **Animation requires Screen Recording permission.** macOS lets a process
 move another application's window, but not fade, transform or reorder it.

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -189,7 +189,7 @@ both, through `serve()` in `rules.py`.
 | --- | --- |
 | `frames` | The windows to place. Leave a window out to leave it where it is. Print nothing, or an empty list, to change nothing. With `[tiling.animation]` on, a frame may carry `"animate": false` to move that one window at once while the rest animate, for a window with no sensible starting position. |
 | `state` | Any JSON. Handed back next run. Omit the key and the previous state is kept. Print `null` to clear it. |
-| `focus` | Optional. A window number to give keyboard focus once the frames land. For moving focus along a layout's own structure where spatial `focus_window` cannot, such as a strip's parked columns. |
+| `focus` | Optional. A window number to give keyboard focus, before the frames move. For moving focus along a layout's own structure where spatial `focus_window` cannot, such as a strip's parked columns. |
 
 ### Coordinates
 

--- a/internal/action/apply_frames.go
+++ b/internal/action/apply_frames.go
@@ -150,9 +150,9 @@ func (e *Executor) FocusWindowNumber(number uint32) error {
 		return err
 	}
 
-	windows, _, err := e.desktop.FocusableWindows()
+	windows, err := e.windowsNamed([]uint32{number})
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get focusable windows")
+		return err
 	}
 
 	for _, win := range windows {
@@ -181,9 +181,14 @@ func (e *Executor) ApplyFrames(args ApplyFramesArgs) error {
 		return err
 	}
 
-	windows, _, err := e.desktop.FocusableWindows()
+	numbers := make([]uint32, 0, len(args.Frames))
+	for _, entry := range args.Frames {
+		numbers = append(numbers, entry.Number)
+	}
+
+	windows, err := e.windowsNamed(numbers)
 	if err != nil {
-		return derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get focusable windows")
+		return err
 	}
 
 	byNumber := make(map[uint32]WindowID, len(windows))
@@ -235,6 +240,38 @@ func (e *Executor) ApplyFrames(args ApplyFramesArgs) error {
 	}
 
 	return nil
+}
+
+// windowsNamed is the focusable windows, from the desktop's recent
+// enumeration when it has every number asked for, else enumerated afresh.
+func (e *Executor) windowsNamed(numbers []uint32) ([]Window, error) {
+	known := e.desktop.KnownWindows()
+	if len(known) > 0 {
+		seen := make(map[uint32]bool, len(known))
+		for _, win := range known {
+			seen[win.Number] = true
+		}
+
+		complete := true
+		for _, number := range numbers {
+			if !seen[number] {
+				complete = false
+
+				break
+			}
+		}
+
+		if complete {
+			return known, nil
+		}
+	}
+
+	windows, _, err := e.desktop.FocusableWindows()
+	if err != nil {
+		return nil, derrors.Wrapf(err, derrors.CodeActionFailed, "failed to get focusable windows")
+	}
+
+	return windows, nil
 }
 
 // writeFrames writes every frame, one goroutine per owning application. A

--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -72,6 +72,13 @@ type Desktop interface {
 	// focused window — or -1 when no window in the list holds focus.
 	FocusableWindows() ([]Window, int, error)
 
+	// KnownWindows is what the last FocusableWindows call reported, in the
+	// same order, when it was recent enough to still trust, else nil. An
+	// action that names its windows by number can find them here without
+	// asking every application again: an enumeration is a round trip into
+	// each one, and an application just activated answers late.
+	KnownWindows() []Window
+
 	// WindowFrame reads one window's frame, in window coordinates. It is its
 	// own call rather than part of the enumeration because reading a frame
 	// costs a round trip to the owning application, and the cycling path never

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -107,6 +107,15 @@ func (d *fakeDesktop) FocusableWindows() ([]action.Window, int, error) {
 	return windows, d.focused, nil
 }
 
+func (d *fakeDesktop) KnownWindows() []action.Window {
+	windows, _, err := d.FocusableWindows()
+	if err != nil {
+		return nil
+	}
+
+	return windows
+}
+
 func (d *fakeDesktop) WindowFrame(windowID action.WindowID) (geometry.Rect, error) {
 	index, err := d.indexOf(windowID)
 	if err != nil {

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"cmp"
 	"math"
 	"slices"
 	"sync"
@@ -16,17 +17,25 @@ import (
 // nativeDesktop is the Desktop macOS itself: the adapter between the actions'
 // values and internal/native's handles.
 //
-// It owns every window reference behind the ids it hands out. A generation of
-// references lives until the next lookup replaces it, at which point the whole
-// previous generation is released — so no action above this seam ever holds,
-// or has to release, a native reference.
+// It owns every window reference behind the ids it hands out, by window
+// number, for as long as the window server has the window. An application
+// is asked for its windows only when the server lists a number the desktop
+// has not seen: a round trip into an application waits on its main thread,
+// and the one just activated is busy, so a pass that asks every application
+// waits on the slowest one. No action above this seam ever holds, or has to
+// release, a native reference.
 type nativeDesktop struct {
-	// mu is held for writing while the window set is replaced, and for
-	// reading around every use of a window in it, so frames can be written to
+	// mu is held for writing while the window set changes, and for reading
+	// around every use of a window in it, so frames can be written to
 	// several windows at once.
 	mu      sync.RWMutex
 	lastID  WindowID
 	windows map[WindowID]*native.Element
+	// entries is what the desktop knows of each window by number.
+	entries map[uint32]*windowEntry
+	// missing is when an application last failed to list a number the
+	// window server has for it, so it is not asked again at once.
+	missing map[uint32]time.Time
 	// known is the last enumeration, and knownAt when it was taken.
 	known   []Window
 	knownAt time.Time
@@ -40,7 +49,17 @@ type nativeDesktop struct {
 	// enumeration and again after a write, since a write moves the
 	// windows. It answers frames, and titles when the server names them,
 	// without a round trip into the application.
-	listed map[uint32]native.OnScreenWindow
+	listed map[uint32]native.ListedWindow
+}
+
+// windowEntry is one window the desktop holds a reference to.
+type windowEntry struct {
+	id      WindowID
+	element *native.Element
+	pid     int
+	// isWindow is whether Accessibility calls it a window, rather than a
+	// sheet, a popover or the like, which never changes.
+	isWindow bool
 }
 
 // knownWindowsFor is how long an enumeration is trusted by number. Within
@@ -48,10 +67,16 @@ type nativeDesktop struct {
 // space unnoticed.
 const knownWindowsFor = time.Second
 
+// missingFor is how long an application is left alone after it did not
+// list a window the window server has for it.
+const missingFor = 2 * time.Second
+
 // newNativeDesktop returns the Desktop backed by macOS.
 func newNativeDesktop() *nativeDesktop {
 	return &nativeDesktop{
 		windows: map[WindowID]*native.Element{},
+		entries: map[uint32]*windowEntry{},
+		missing: map[uint32]time.Time{},
 		frames:  map[WindowID]geometry.Rect{},
 	}
 }
@@ -61,44 +86,111 @@ func (d *nativeDesktop) EnsureAccessible() error {
 	return permissions.FriendlyError(permissions.Check())
 }
 
-// FocusableWindows enumerates the focusable windows on the active space.
+// FocusableWindows enumerates the focusable windows on the active space:
+// the window server's on-screen windows at the ordinary layer owned by a
+// regular, visible application, that Accessibility calls windows. They are
+// ordered top to bottom, then left to right, then by application, and the
+// focused one is the frontmost of them: the window server orders its list
+// front to back, and the window with keyboard focus is in front of every
+// other application's. Asking the Accessibility server instead was measured
+// to wait on the application just activated.
 func (d *nativeDesktop) FocusableWindows() ([]Window, int, error) {
-	elements, focused, err := native.AllFocusableOnActiveSpaceWithFocused()
-	if err != nil {
-		return nil, -1, err
-	}
+	onScreen := native.WindowList(true)
+	all := native.WindowList(false)
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.releaseLocked()
+	d.evictLocked(all)
 
-	windows := make([]Window, 0, len(elements))
+	// The numbers the desktop has not seen, by application, each asked
+	// once for every window it has, at the same time as the others.
+	unknown := map[int]bool{}
 
-	for _, element := range elements {
-		if element == nil {
+	for _, window := range onScreen {
+		if window.Layer != 0 || !window.Regular {
 			continue
 		}
 
-		// A window whose owning process cannot be read still cycles; the pid
-		// is what tells applications apart, not what makes a window valid.
-		pid, pidErr := element.PID()
-		if pidErr != nil {
-			pid = 0
+		if _, ok := d.entries[window.Number]; ok {
+			continue
 		}
 
-		windows = append(windows, Window{
-			ID:     d.registerLocked(element),
-			PID:    pid,
-			Number: element.Number(),
-		})
+		if asked, ok := d.missing[window.Number]; ok && time.Since(asked) < missingFor {
+			continue
+		}
+
+		unknown[window.PID] = true
+	}
+
+	d.learnLocked(unknown)
+
+	windows := make([]Window, 0, len(onScreen))
+	focused := uint32(0)
+
+	for _, window := range onScreen {
+		if window.Layer != 0 || !window.Regular {
+			continue
+		}
+
+		entry, ok := d.entries[window.Number]
+		if !ok {
+			d.missing[window.Number] = time.Now()
+
+			continue
+		}
+
+		if !entry.isWindow {
+			continue
+		}
+
+		if focused == 0 {
+			focused = window.Number
+		}
+
+		windows = append(windows, Window{ID: entry.id, PID: entry.pid, Number: window.Number})
+	}
+
+	frames := map[uint32]native.Frame{}
+	for _, window := range onScreen {
+		frames[window.Number] = window.Frame
+	}
+
+	slices.SortStableFunc(windows, func(left, right Window) int {
+		leftFrame, rightFrame := frames[left.Number], frames[right.Number]
+		if leftFrame.Y != rightFrame.Y {
+			return cmp.Compare(leftFrame.Y, rightFrame.Y)
+		}
+
+		if leftFrame.X != rightFrame.X {
+			return cmp.Compare(leftFrame.X, rightFrame.X)
+		}
+
+		return cmp.Compare(left.PID, right.PID)
+	})
+
+	focusedIndex := -1
+	for index, window := range windows {
+		if window.Number == focused {
+			focusedIndex = index
+		}
 	}
 
 	d.known = windows
 	d.knownAt = time.Now()
-	d.relist()
+	d.listed = listing(onScreen)
 
-	return windows, focused, nil
+	return windows, focusedIndex, nil
+}
+
+// listing indexes a window list by number.
+func listing(windows []native.ListedWindow) map[uint32]native.ListedWindow {
+	listed := make(map[uint32]native.ListedWindow, len(windows))
+	for _, window := range windows {
+		listed[window.Number] = window
+	}
+
+	return listed
 }
 
 // KnownWindows is the last enumeration, when it is recent.
@@ -161,12 +253,24 @@ func (d *nativeDesktop) FrontmostWindow() (Window, error) {
 		pid = 0
 	}
 
+	number := element.Number()
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.releaseLocked()
+	// The window in front is kept like any other, by number; one without a
+	// number is held until the next enumeration evicts it.
+	if entry, ok := d.entries[number]; ok && number != 0 {
+		element.Release()
 
-	return Window{ID: d.registerLocked(element), PID: pid, Number: element.Number()}, nil
+		return Window{ID: entry.id, PID: pid, Number: number}, nil
+	}
+
+	d.lastID++
+	d.windows[d.lastID] = element
+	d.entries[number] = &windowEntry{id: d.lastID, element: element, pid: pid, isWindow: true}
+
+	return Window{ID: d.lastID, PID: pid, Number: number}, nil
 }
 
 // WindowFrame reads one window's frame.
@@ -176,7 +280,7 @@ func (d *nativeDesktop) WindowFrame(windowID WindowID) (geometry.Rect, error) {
 	err := d.withWindow(windowID, func(element *native.Element) error {
 		// The window server's answer is where the window is on screen,
 		// and costs no round trip into the application.
-		if listed, ok := d.listing(element); ok {
+		if listed, ok := d.listedWindow(element); ok {
 			frame = geometry.Rect{
 				X: listed.Frame.X,
 				Y: listed.Frame.Y,
@@ -209,7 +313,7 @@ func (d *nativeDesktop) WindowTitle(id WindowID) (string, error) {
 	err := d.withWindow(id, func(element *native.Element) error {
 		// The window server names windows only with Screen Recording
 		// granted; otherwise the application is asked.
-		if listed, ok := d.listing(element); ok && listed.Named {
+		if listed, ok := d.listedWindow(element); ok && listed.Named {
 			title = listed.Title
 
 			return nil
@@ -443,29 +547,6 @@ func (d *nativeDesktop) withWindow(
 	return apply(element)
 }
 
-// registerLocked takes ownership of one native reference and returns the id
-// standing for it. The caller must hold the lock.
-func (d *nativeDesktop) registerLocked(element *native.Element) WindowID {
-	d.lastID++
-	d.windows[d.lastID] = element
-
-	return d.lastID
-}
-
-// releaseLocked releases every reference the desktop holds. The caller must
-// hold the lock.
-func (d *nativeDesktop) releaseLocked() {
-	for id, element := range d.windows {
-		element.Release()
-		delete(d.windows, id)
-	}
-
-	d.framesMu.Lock()
-	defer d.framesMu.Unlock()
-
-	clear(d.frames)
-}
-
 func (d *nativeDesktop) rememberFrame(id WindowID, frame geometry.Rect) {
 	d.framesMu.Lock()
 	defer d.framesMu.Unlock()
@@ -486,10 +567,7 @@ func (d *nativeDesktop) rememberedSize(id WindowID) (geometry.Rect, bool) {
 
 // relist takes the window server's list afresh.
 func (d *nativeDesktop) relist() {
-	listed := map[uint32]native.OnScreenWindow{}
-	for _, window := range native.OnScreenWindows() {
-		listed[window.Number] = window
-	}
+	listed := listing(native.WindowList(true))
 
 	d.framesMu.Lock()
 	defer d.framesMu.Unlock()
@@ -498,10 +576,10 @@ func (d *nativeDesktop) relist() {
 }
 
 // listing is the window server's entry for a window, when it has one.
-func (d *nativeDesktop) listing(element *native.Element) (native.OnScreenWindow, bool) {
+func (d *nativeDesktop) listedWindow(element *native.Element) (native.ListedWindow, bool) {
 	number := element.Number()
 	if number == 0 {
-		return native.OnScreenWindow{}, false
+		return native.ListedWindow{}, false
 	}
 
 	d.framesMu.Lock()
@@ -510,4 +588,74 @@ func (d *nativeDesktop) listing(element *native.Element) (native.OnScreenWindow,
 	window, ok := d.listed[number]
 
 	return window, ok
+}
+
+// learnLocked asks each given application for its windows, at once, and
+// keeps a reference to every one that has a number. The caller holds mu.
+func (d *nativeDesktop) learnLocked(pids map[int]bool) {
+	if len(pids) == 0 {
+		return
+	}
+
+	results := make(chan []native.ApplicationWindow, len(pids))
+
+	for pid := range pids {
+		go func(pid int) {
+			results <- native.ApplicationWindowElements(pid)
+		}(pid)
+	}
+
+	for range pids {
+		for _, window := range <-results {
+			if _, ok := d.entries[window.Number]; ok {
+				window.Element.Release()
+
+				continue
+			}
+
+			pid, err := window.Element.PID()
+			if err != nil {
+				pid = 0
+			}
+
+			d.lastID++
+			d.windows[d.lastID] = window.Element
+			d.entries[window.Number] = &windowEntry{
+				id:       d.lastID,
+				element:  window.Element,
+				pid:      pid,
+				isWindow: window.IsWindow,
+			}
+			delete(d.missing, window.Number)
+		}
+	}
+}
+
+// evictLocked releases the windows the window server no longer has. The
+// caller holds mu.
+func (d *nativeDesktop) evictLocked(all []native.ListedWindow) {
+	alive := make(map[uint32]bool, len(all))
+	for _, window := range all {
+		alive[window.Number] = true
+	}
+
+	for number, entry := range d.entries {
+		if alive[number] {
+			continue
+		}
+
+		entry.element.Release()
+		delete(d.windows, entry.id)
+		delete(d.entries, number)
+
+		d.framesMu.Lock()
+		delete(d.frames, entry.id)
+		d.framesMu.Unlock()
+	}
+
+	for number := range d.missing {
+		if !alive[number] {
+			delete(d.missing, number)
+		}
+	}
 }

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -36,6 +36,11 @@ type nativeDesktop struct {
 	// windows at once under mu's read lock.
 	framesMu sync.Mutex
 	frames   map[WindowID]geometry.Rect
+	// listed is the window server's list by number, taken with the last
+	// enumeration and again after a write, since a write moves the
+	// windows. It answers frames, and titles when the server names them,
+	// without a round trip into the application.
+	listed map[uint32]native.OnScreenWindow
 }
 
 // knownWindowsFor is how long an enumeration is trusted by number. Within
@@ -91,6 +96,7 @@ func (d *nativeDesktop) FocusableWindows() ([]Window, int, error) {
 
 	d.known = windows
 	d.knownAt = time.Now()
+	d.relist()
 
 	return windows, focused, nil
 }
@@ -168,6 +174,20 @@ func (d *nativeDesktop) WindowFrame(windowID WindowID) (geometry.Rect, error) {
 	var frame geometry.Rect
 
 	err := d.withWindow(windowID, func(element *native.Element) error {
+		// The window server's answer is where the window is on screen,
+		// and costs no round trip into the application.
+		if listed, ok := d.listing(element); ok {
+			frame = geometry.Rect{
+				X: listed.Frame.X,
+				Y: listed.Frame.Y,
+				W: listed.Frame.W,
+				H: listed.Frame.H,
+			}
+			d.rememberFrame(windowID, frame)
+
+			return nil
+		}
+
 		posX, posY, width, height, err := element.GetFrame()
 		if err != nil {
 			return err
@@ -187,6 +207,14 @@ func (d *nativeDesktop) WindowTitle(id WindowID) (string, error) {
 	var title string
 
 	err := d.withWindow(id, func(element *native.Element) error {
+		// The window server names windows only with Screen Recording
+		// granted; otherwise the application is asked.
+		if listed, ok := d.listing(element); ok && listed.Named {
+			title = listed.Title
+
+			return nil
+		}
+
 		title = element.Title()
 
 		return nil
@@ -226,6 +254,7 @@ func (d *nativeDesktop) SetWindowFrame(windowID WindowID, frame geometry.Rect) e
 		}
 
 		d.rememberFrame(windowID, frame)
+		d.relist()
 
 		return nil
 	})
@@ -453,4 +482,32 @@ func (d *nativeDesktop) rememberedSize(id WindowID) (geometry.Rect, bool) {
 	frame, ok := d.frames[id]
 
 	return frame, ok
+}
+
+// relist takes the window server's list afresh.
+func (d *nativeDesktop) relist() {
+	listed := map[uint32]native.OnScreenWindow{}
+	for _, window := range native.OnScreenWindows() {
+		listed[window.Number] = window
+	}
+
+	d.framesMu.Lock()
+	defer d.framesMu.Unlock()
+
+	d.listed = listed
+}
+
+// listing is the window server's entry for a window, when it has one.
+func (d *nativeDesktop) listing(element *native.Element) (native.OnScreenWindow, bool) {
+	number := element.Number()
+	if number == 0 {
+		return native.OnScreenWindow{}, false
+	}
+
+	d.framesMu.Lock()
+	defer d.framesMu.Unlock()
+
+	window, ok := d.listed[number]
+
+	return window, ok
 }

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"math"
 	"slices"
 	"sync"
 	"time"
@@ -26,11 +27,28 @@ type nativeDesktop struct {
 	mu      sync.RWMutex
 	lastID  WindowID
 	windows map[WindowID]*native.Element
+	// known is the last enumeration, and knownAt when it was taken.
+	known   []Window
+	knownAt time.Time
+	// frames is the frame each window was last read at or written to,
+	// as the application reported it, for the windows of the last
+	// enumeration. framesMu covers it: frames are written to several
+	// windows at once under mu's read lock.
+	framesMu sync.Mutex
+	frames   map[WindowID]geometry.Rect
 }
+
+// knownWindowsFor is how long an enumeration is trusted by number. Within
+// it a window may close, and its write fails, but it does not leave the
+// space unnoticed.
+const knownWindowsFor = time.Second
 
 // newNativeDesktop returns the Desktop backed by macOS.
 func newNativeDesktop() *nativeDesktop {
-	return &nativeDesktop{windows: map[WindowID]*native.Element{}}
+	return &nativeDesktop{
+		windows: map[WindowID]*native.Element{},
+		frames:  map[WindowID]geometry.Rect{},
+	}
 }
 
 // EnsureAccessible reports whether macOS still lets mimi drive the desktop.
@@ -71,7 +89,22 @@ func (d *nativeDesktop) FocusableWindows() ([]Window, int, error) {
 		})
 	}
 
+	d.known = windows
+	d.knownAt = time.Now()
+
 	return windows, focused, nil
+}
+
+// KnownWindows is the last enumeration, when it is recent.
+func (d *nativeDesktop) KnownWindows() []Window {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if time.Since(d.knownAt) > knownWindowsFor {
+		return nil
+	}
+
+	return d.known
 }
 
 // FindApplication resolves a bundle identifier or a name to a running pid.
@@ -131,16 +164,17 @@ func (d *nativeDesktop) FrontmostWindow() (Window, error) {
 }
 
 // WindowFrame reads one window's frame.
-func (d *nativeDesktop) WindowFrame(id WindowID) (geometry.Rect, error) {
+func (d *nativeDesktop) WindowFrame(windowID WindowID) (geometry.Rect, error) {
 	var frame geometry.Rect
 
-	err := d.withWindow(id, func(element *native.Element) error {
+	err := d.withWindow(windowID, func(element *native.Element) error {
 		posX, posY, width, height, err := element.GetFrame()
 		if err != nil {
 			return err
 		}
 
 		frame = geometry.Rect{X: posX, Y: posY, W: width, H: height}
+		d.rememberFrame(windowID, frame)
 
 		return nil
 	})
@@ -171,11 +205,39 @@ func (d *nativeDesktop) ApplicationInfo(pid int) (AppInfo, error) {
 	return AppInfo{Name: info.Name, BundleID: info.BundleID}, nil
 }
 
-// SetWindowFrame moves and resizes one window.
-func (d *nativeDesktop) SetWindowFrame(id WindowID, frame geometry.Rect) error {
-	return d.withWindow(id, func(element *native.Element) error {
-		return element.SetFrame(frame.X, frame.Y, frame.W, frame.H)
+// SetWindowFrame moves and resizes one window. A window the application
+// last reported at the size asked for is only moved: each write is a round
+// trip into the application, some ten milliseconds for a heavy one, and a
+// move is the common case, as a layout that scrolls or swaps two windows
+// of a size makes.
+func (d *nativeDesktop) SetWindowFrame(windowID WindowID, frame geometry.Rect) error {
+	return d.withWindow(windowID, func(element *native.Element) error {
+		last, known := d.rememberedSize(windowID)
+		if known && sameLength(last.W, frame.W) && sameLength(last.H, frame.H) {
+			err := element.SetPosition(frame.X, frame.Y)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := element.SetFrame(frame.X, frame.Y, frame.W, frame.H)
+			if err != nil {
+				return err
+			}
+		}
+
+		d.rememberFrame(windowID, frame)
+
+		return nil
 	})
+}
+
+// samePoint is how far two lengths may differ and still be the same as
+// macOS stores them, in whole points.
+const samePoint = 0.5
+
+// sameLength is whether two lengths agree in whole points.
+func sameLength(a, b float64) bool {
+	return math.Abs(a-b) < samePoint
 }
 
 // BeginFrameAnimation prepares to fly the given windows to their frames.
@@ -368,4 +430,27 @@ func (d *nativeDesktop) releaseLocked() {
 		element.Release()
 		delete(d.windows, id)
 	}
+
+	d.framesMu.Lock()
+	defer d.framesMu.Unlock()
+
+	clear(d.frames)
+}
+
+func (d *nativeDesktop) rememberFrame(id WindowID, frame geometry.Rect) {
+	d.framesMu.Lock()
+	defer d.framesMu.Unlock()
+
+	d.frames[id] = frame
+}
+
+// rememberedSize is the size the window was last read at or written to,
+// when it was.
+func (d *nativeDesktop) rememberedSize(id WindowID) (geometry.Rect, bool) {
+	d.framesMu.Lock()
+	defer d.framesMu.Unlock()
+
+	frame, ok := d.frames[id]
+
+	return frame, ok
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -551,6 +551,10 @@ func tilingConfigFor(
 		}
 	}
 
+	if tilingCfg.Enabled && tilingCfg.Animation.Enabled {
+		native.WarmFrameAnimation()
+	}
+
 	return tilingCfg
 }
 

--- a/internal/native/animate.go
+++ b/internal/native/animate.go
@@ -95,6 +95,12 @@ func StartFrameAnimation(dropped []uint32) {
 	C.MimiAnimationStart((*C.uint32_t)(unsafe.Pointer(&dropped[0])), C.int(len(dropped)))
 }
 
+// WarmFrameAnimation makes the windows the first frame animation would
+// otherwise make during its setup, where a new window costs half a second.
+func WarmFrameAnimation() {
+	C.MimiAnimationWarm()
+}
+
 // ScreenCaptureGranted reports whether macOS lets mimi capture the screen,
 // which animating frames needs. It never prompts.
 func ScreenCaptureGranted() bool {

--- a/internal/native/animate.go
+++ b/internal/native/animate.go
@@ -95,8 +95,8 @@ func StartFrameAnimation(dropped []uint32) {
 	C.MimiAnimationStart((*C.uint32_t)(unsafe.Pointer(&dropped[0])), C.int(len(dropped)))
 }
 
-// WarmFrameAnimation makes the windows the first frame animation would
-// otherwise make during its setup, where a new window costs half a second.
+// WarmFrameAnimation makes the window per display the frame animation
+// draws in, ahead of the first animation.
 func WarmFrameAnimation() {
 	C.MimiAnimationWarm()
 }

--- a/internal/native/animate.h
+++ b/internal/native/animate.h
@@ -36,6 +36,10 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 /// whose frames did not land. Without a prepared animation it does nothing.
 void MimiAnimationStart(const uint32_t *dropped, int count);
 
+/// Make the windows the first animation would otherwise make, ahead of it:
+/// a window made during an animation's setup costs it half a second.
+void MimiAnimationWarm(void);
+
 /// Report whether the process may capture the screen, without prompting.
 int MimiScreenCaptureGranted(void);
 

--- a/internal/native/animate.h
+++ b/internal/native/animate.h
@@ -36,8 +36,8 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 /// whose frames did not land. Without a prepared animation it does nothing.
 void MimiAnimationStart(const uint32_t *dropped, int count);
 
-/// Make the windows the first animation would otherwise make, ahead of it:
-/// a window made during an animation's setup costs it half a second.
+/// Make the window per display the animation draws in, ahead of the first
+/// animation.
 void MimiAnimationWarm(void);
 
 /// Report whether the process may capture the screen, without prompting.

--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -27,9 +27,10 @@
 // here. Every layer and window lives on the main thread, where the daemon
 // runs its application loop, and the calls below go there.
 
-// Window layers at and above the Dock's are never covered, so they are left
-// out of the backdrop.
-static const int kMimiDockLayer = 20;
+// Window layers above the floating level, where the host window sits, show
+// through it on their own: a picture-in-picture player, the Dock, the menu
+// bar. They are left out of the backdrop, and need no still of their own.
+static const int kMimiHostLayer = 3;
 
 // How many window masks are remembered.
 enum {
@@ -160,6 +161,57 @@ typedef struct {
 static MimiMask gMasks[kMimiMaskCacheSize];
 static int gMaskCount;
 static int gMaskNext;
+
+// The pictures of the windows an animation parked off every display, by
+// number, kept while they stay there: nothing draws a window the user
+// cannot see, so the picture it left with is the picture it comes back
+// with, and its capture, a round trip of its own, is saved.
+@interface MimiParked : NSObject
+@property(nonatomic) CGSize size;
+@property(nonatomic) double scale;
+@property(nonatomic) CGImageRef picture;
+@end
+
+@implementation MimiParked
+
+- (void)dealloc {
+	if (_picture) {
+		CGImageRelease(_picture);
+	}
+}
+
+@end
+
+static NSMutableDictionary<NSNumber *, MimiParked *> *gParked;
+
+enum {
+	kMimiParkedLimit = 16,
+};
+
+// The last still taken under the proxies of each display, with what it
+// showed and when: taken again within a second for the same windows at the
+// same places it would show the same, but for what those windows drew
+// since, which a still on screen for the length of an animation hides.
+@interface MimiStill : NSObject
+@property(nonatomic) MimiEntry *shows;
+@property(nonatomic) int showsCount;
+@property(nonatomic) double taken;
+@property(nonatomic) CGImageRef picture;
+@end
+
+@implementation MimiStill
+
+- (void)dealloc {
+	free(_shows);
+	if (_picture) {
+		CGImageRelease(_picture);
+	}
+}
+
+@end
+
+static NSMutableDictionary<NSNumber *, MimiStill *> *gStills;
+static const double kMimiStillFor = 1.0;
 
 #pragma mark - Helpers
 
@@ -473,6 +525,73 @@ static MimiBackdrop *mimiReusable(CGDirectDisplayID display, BOOL over, const Mi
 	return nil;
 }
 
+// The still last taken under this display's proxies, retained, when it
+// showed these very windows where they are now and is recent.
+static CGImageRef mimiRecentStill(CGDirectDisplayID display, const MimiEntry *shows, int showsCount) {
+	MimiStill *still = gStills[@(display)];
+	if (!still || CACurrentMediaTime() - still.taken > kMimiStillFor ||
+	    !mimiSameEntries(still.shows, still.showsCount, shows, showsCount)) {
+		return NULL;
+	}
+	return CGImageRetain(still.picture);
+}
+
+static void mimiRememberStill(CGDirectDisplayID display, const MimiEntry *shows, int showsCount, CGImageRef picture) {
+	if (!gStills) {
+		gStills = [NSMutableDictionary new];
+	}
+	MimiStill *still = [MimiStill new];
+	still.shows = calloc((size_t)showsCount + 1, sizeof(MimiEntry));
+	memcpy(still.shows, shows, (size_t)showsCount * sizeof(MimiEntry));
+	still.showsCount = showsCount;
+	still.taken = CACurrentMediaTime();
+	still.picture = CGImageRetain(picture);
+	gStills[@(display)] = still;
+}
+
+// The picture a window was parked off screen with, retained, when it is
+// still the size it left at.
+static CGImageRef mimiParkedPicture(uint32_t number, CGSize size, double scale) {
+	MimiParked *parked = gParked[@(number)];
+	if (!parked || !mimiSameSize(parked.size, size) || parked.scale != scale) {
+		return NULL;
+	}
+	return CGImageRetain(parked.picture);
+}
+
+static BOOL mimiOffEveryDisplay(CGRect frame) {
+	CGDirectDisplayID displays[16];
+	uint32_t count = 0;
+	CGGetDisplaysWithPoint(CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame)), 16, displays, &count);
+	return count == 0;
+}
+
+// Keep the pictures of the proxies parking off screen, and forget those of
+// the windows on screen now, which may draw before they park again.
+static void mimiRememberParked(NSArray<MimiProxy *> *proxies) {
+	if (!gParked) {
+		gParked = [NSMutableDictionary new];
+	}
+	for (MimiProxy *proxy in proxies) {
+		if (!mimiOffEveryDisplay(proxy.from)) {
+			[gParked removeObjectForKey:@(proxy.number)];
+		}
+	}
+	for (MimiProxy *proxy in proxies) {
+		if (!proxy.picture || !mimiOffEveryDisplay(proxy.to)) {
+			continue;
+		}
+		if (gParked.count >= kMimiParkedLimit && !gParked[@(proxy.number)]) {
+			[gParked removeObjectForKey:gParked.allKeys.firstObject];
+		}
+		MimiParked *parked = [MimiParked new];
+		parked.size = proxy.to.size;
+		parked.scale = proxy.scale;
+		parked.picture = CGImageRetain(proxy.picture);
+		gParked[@(proxy.number)] = parked;
+	}
+}
+
 static MimiBackdrop *mimiNewBackdrop(
     CGDirectDisplayID display, CGRect bounds, BOOL over, const MimiEntry *shows, int showsCount, CGImageRef still,
     MimiBackdrop *reused) {
@@ -596,7 +715,7 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 	BOOL passed = NO;
 	int depth = 0;
 	for (NSDictionary *info in (__bridge NSArray *)onScreen) {
-		if ([info[(id)kCGWindowOwnerPID] intValue] == self || [info[(id)kCGWindowLayer] intValue] >= kMimiDockLayer) {
+		if ([info[(id)kCGWindowOwnerPID] intValue] == self || [info[(id)kCGWindowLayer] intValue] > kMimiHostLayer) {
 			continue;
 		}
 		MimiEntry entry = {.number = [info[(id)kCGWindowNumber] unsignedIntValue]};
@@ -697,9 +816,15 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 		if (keptUnder) {
 			[backdrops addObject:mimiNewBackdrop(displays[d], bounds, NO, others, othersCount, NULL, keptUnder)];
 		} else if (othersCount > 0) {
-			CFArrayRef list = mimiNumbers(others, othersCount);
-			CGImageRef still = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
-			CFRelease(list);
+			CGImageRef still = mimiRecentStill(displays[d], others, othersCount);
+			if (!still) {
+				CFArrayRef list = mimiNumbers(others, othersCount);
+				still = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+				CFRelease(list);
+				if (still) {
+					mimiRememberStill(displays[d], others, othersCount, still);
+				}
+			}
 			if (still) {
 				[backdrops addObject:mimiNewBackdrop(displays[d], bounds, NO, others, othersCount, still, nil)];
 			}
@@ -761,13 +886,20 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 				proxy.picture = CGWindowListCreateImage(
 				    proxy.from, kCGWindowListOptionIncludingWindow, proxy.number, kCGWindowImageBestResolution);
 			} else {
-				// Off the display, a window has pixels only when asked for
-				// by its own bounds: a rectangle there comes back empty. Its
-				// picture is opaque, a flat tint where the window is
-				// translucent, since nothing is under it to blend with.
-				proxy.picture = CGWindowListCreateImage(
-				    CGRectNull, kCGWindowListOptionIncludingWindow, proxy.number,
-				    kCGWindowImageBoundsIgnoreFraming | kCGWindowImageBestResolution);
+				// A window parked by an earlier animation comes back with
+				// the picture it left with. Otherwise, off the display, a
+				// window has pixels only when asked for by its own bounds: a
+				// rectangle there comes back empty. That picture is opaque,
+				// a flat tint where the window is translucent, since nothing
+				// is under it to blend with.
+				proxy.picture = mimiParkedPicture(proxy.number, proxy.from.size, scale);
+				if (proxy.picture) {
+					proxy.mask = mimiCachedMask(proxy.number, proxy.from.size, scale);
+				} else {
+					proxy.picture = CGWindowListCreateImage(
+					    CGRectNull, kCGWindowListOptionIncludingWindow, proxy.number,
+					    kCGWindowImageBoundsIgnoreFraming | kCGWindowImageBestResolution);
+				}
 			}
 			proxy.scale = scale;
 			if (!proxy.picture) {
@@ -807,6 +939,7 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 		backdrop.still = NULL;
 		[mimiHost(backdrop.display, backdrop.bounds).root addSublayer:backdrop.layer];
 	}
+	mimiRememberParked(next);
 	NSMutableArray<MimiProxy *> *made = [NSMutableArray array];
 	for (MimiProxy *proxy in next) {
 		if (proxy.carried || proxy.picture) {

--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -19,6 +19,12 @@
 // window, a floating one say, get a still of their own over the proxies, so
 // the stacking order is kept. One transaction removes everything when it
 // ends.
+//
+// What the setup costs is what the user waits before anything moves, so the
+// windows are pooled rather than made and released each time, the mask that
+// clips a window's picture to its shape is kept between animations, every
+// paint runs at once on its own thread, and an animation that starts while
+// one runs keeps the backdrops whose windows have not changed.
 
 #pragma mark - SkyLight External Declarations
 
@@ -51,6 +57,22 @@ static const int kMimiDockLayer = 20;
 static const int kMimiOrderAbove = 1;
 static const int kMimiOrderOut = 0;
 
+// How many windows the pool keeps between animations, and how many window
+// masks are remembered. A pooled backdrop holds a display's worth of pixels.
+enum {
+	kMimiPoolSize = 8,
+	kMimiMaskCacheSize = 32,
+	kMimiMaxBackdrops = 32,
+};
+
+// One on-screen window, as the window list reports it. A backdrop remembers
+// the entries it shows, so a later animation can tell whether it still
+// shows the screen.
+typedef struct {
+	uint32_t number;
+	CGRect bounds;
+} MimiEntry;
+
 typedef struct {
 	uint32_t number;
 	uint32_t proxy;
@@ -68,19 +90,77 @@ typedef struct {
 	// depth is the window's place in the on-screen list, front first, so
 	// the proxies stack as the windows do.
 	int depth;
+	// carried is a proxy taken over from the running animation, already
+	// painted and on screen, since its window was on its way to the same
+	// frame. taken marks the running animation's entry it came from, which
+	// its teardown then leaves alone.
+	BOOL carried;
+	BOOL taken;
+	// listed is whether the window is in the on-screen list: one entirely
+	// off the display is not, and is captured on its own.
+	BOOL listed;
+	// drawn is the size the proxy was painted at, the window's size when
+	// it was captured, which the placement scales from.
+	CGSize drawn;
 } MimiProxy;
+
+typedef struct {
+	uint32_t window;
+	CGRect bounds;
+	double scale;
+	// over is whether the backdrop sits over the proxies, showing the
+	// windows in front of every moving one, rather than under them.
+	BOOL over;
+	// shows is what the backdrop is a still of, front to back.
+	MimiEntry *shows;
+	int showsCount;
+	// still is the capture waiting to be painted, between the phases of
+	// MimiAnimationBegin. reused is a backdrop kept from the animation
+	// before, already painted and on screen.
+	CGImageRef still;
+	BOOL reused;
+} MimiBackdrop;
 
 static struct {
 	pthread_mutex_t lock;
 	BOOL running;
 	MimiProxy *proxies;
 	int proxyCount;
-	uint32_t *backdrops;
+	MimiBackdrop *backdrops;
 	int backdropCount;
 	double start;
 	double duration;
 	int easing;
 } gAnim = {.lock = PTHREAD_MUTEX_INITIALIZER};
+
+// The pool of windows not on screen, each made for a size and scale, ready
+// to be painted and ordered in again. Making a window is a round trip, and
+// a request that reaches the window server while a window it just made
+// waits for its first pixels stalls for half a second, so the same windows
+// serve every animation. The lock covers it.
+typedef struct {
+	uint32_t window;
+	CGSize size;
+	double scale;
+} MimiPooled;
+
+static MimiPooled gPool[kMimiPoolSize];
+static int gPoolCount;
+
+// The masks remembered by window number, each for the size the window had
+// and the scale of the display it was on. A window's shape only changes
+// with its size, and taking the mask is a capture, the cost of a whole
+// display's composite.
+typedef struct {
+	uint32_t number;
+	CGSize size;
+	double scale;
+	CGImageRef mask;
+} MimiMask;
+
+static MimiMask gMasks[kMimiMaskCacheSize];
+static int gMaskCount;
+static int gMaskNext;
 
 #pragma mark - Helpers
 
@@ -109,6 +189,19 @@ static BOOL mimiOnDisplay(CGRect frame, CGRect display) {
 	return CGRectContainsPoint(display, CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame)));
 }
 
+// A window animates on the display it starts on, or, starting off every
+// display, as a strip's parked column does, on the one it arrives on.
+static BOOL mimiAnimatesOn(const MimiProxy *proxy, CGRect display, CGDirectDisplayID display_id) {
+	if (mimiOnDisplay(proxy->from, display)) {
+		return YES;
+	}
+	CGDirectDisplayID starts[16];
+	uint32_t startCount = 0;
+	CGGetDisplaysWithPoint(
+	    CGPointMake(CGRectGetMidX(proxy->from), CGRectGetMidY(proxy->from)), 16, starts, &startCount);
+	return startCount == 0 && mimiOnDisplay(proxy->to, display);
+}
+
 static CGRect mimiLerp(CGRect from, CGRect to, double p) {
 	return CGRectMake(
 	    from.origin.x + (to.origin.x - from.origin.x) * p, from.origin.y + (to.origin.y - from.origin.y) * p,
@@ -125,6 +218,36 @@ static CGAffineTransform mimiPlacement(CGSize drawn, CGRect at) {
 	return CGAffineTransformConcat(move, scale);
 }
 
+static BOOL mimiSameSize(CGSize a, CGSize b) {
+	return fabs(a.width - b.width) < 0.5 && fabs(a.height - b.height) < 0.5;
+}
+
+static BOOL mimiSameRect(CGRect a, CGRect b) {
+	return fabs(a.origin.x - b.origin.x) < 0.5 && fabs(a.origin.y - b.origin.y) < 0.5 && mimiSameSize(a.size, b.size);
+}
+
+static BOOL mimiSameEntries(const MimiEntry *a, int aCount, const MimiEntry *b, int bCount) {
+	if (aCount != bCount) {
+		return NO;
+	}
+	for (int i = 0; i < aCount; i++) {
+		if (a[i].number != b[i].number || !mimiSameRect(a[i].bounds, b[i].bounds)) {
+			return NO;
+		}
+	}
+	return YES;
+}
+
+// The window numbers of entries, as CGWindowListCreateImageFromArray reads
+// them: raw values, not CFNumbers.
+static CFArrayRef mimiNumbers(const MimiEntry *entries, int count) {
+	CFMutableArrayRef numbers = CFArrayCreateMutable(NULL, count, NULL);
+	for (int i = 0; i < count; i++) {
+		CFArrayAppendValue(numbers, (const void *)(uintptr_t)entries[i].number);
+	}
+	return numbers;
+}
+
 // Where the proxies are at this instant of the running animation, for the
 // windows a new animation starts from. The caller holds the lock.
 static double mimiProgressLocked(void) {
@@ -135,7 +258,9 @@ static double mimiProgressLocked(void) {
 	return mimiEase(gAnim.easing, t < 0 ? 0 : (t > 1 ? 1 : t));
 }
 
-static BOOL mimiInFlightLocked(uint32_t number, CGRect *out) {
+// Whether the window is in flight, and if so where it is now and which
+// proxy carries it.
+static BOOL mimiInFlightLocked(uint32_t number, CGRect *out, int *index) {
 	if (!gAnim.running) {
 		return NO;
 	}
@@ -143,16 +268,19 @@ static BOOL mimiInFlightLocked(uint32_t number, CGRect *out) {
 	for (int i = 0; i < gAnim.proxyCount; i++) {
 		if (gAnim.proxies[i].number == number) {
 			*out = mimiLerp(gAnim.proxies[i].from, gAnim.proxies[i].to, p);
+			*index = i;
 			return YES;
 		}
 	}
 	return NO;
 }
 
-// Create a proxy window of the given size at the origin, to be painted with
+#pragma mark - Windows
+
+// Create a window of the given size at the origin, to be painted with
 // mimiPaint and placed with a transform in the caller's transaction. Returns
 // 0 when the window server refuses.
-static uint32_t mimiNewProxy(int cid, CGSize size, double scale) {
+static uint32_t mimiNewWindow(int cid, CGSize size, double scale) {
 	CGRect local = CGRectMake(0, 0, size.width, size.height);
 	CFTypeRef region = NULL;
 	if (CGSNewRegionWithRect(&local, &region) != kCGErrorSuccess || !region) {
@@ -176,67 +304,167 @@ static uint32_t mimiNewProxy(int cid, CGSize size, double scale) {
 	return wid;
 }
 
-// Draw picture into the proxy window and release it. A captured image is
-// materialised the first time it is read, which is most of a proxy's cost.
-static void mimiPaint(int cid, uint32_t wid, CGSize size, CGImageRef picture) {
+// A window of the given size and scale from the pool, or 0 when it has
+// none. The caller holds the lock.
+static uint32_t mimiPooledLocked(CGSize size, double scale) {
+	for (int i = 0; i < gPoolCount; i++) {
+		if (mimiSameSize(gPool[i].size, size) && gPool[i].scale == scale) {
+			uint32_t wid = gPool[i].window;
+			gPool[i] = gPool[--gPoolCount];
+			return wid;
+		}
+	}
+	return 0;
+}
+
+// Keep an ordered-out window for the next animation, or release it when the
+// pool is full. The caller holds the lock.
+static void mimiRecycleLocked(int cid, uint32_t wid, CGSize size, double scale) {
+	if (gPoolCount < kMimiPoolSize) {
+		gPool[gPoolCount++] = (MimiPooled){.window = wid, .size = size, .scale = scale};
+		return;
+	}
+	SLSReleaseWindow(cid, wid);
+}
+
+// Draw picture into the window, clipped to mask's alpha when there is one,
+// and release both. A captured image is materialised the first time it is
+// read, which is most of a proxy's cost, and this is that read: the paints
+// of one animation run at once, each on its own thread.
+static void mimiPaint(int cid, uint32_t wid, CGSize size, CGImageRef picture, CGImageRef mask) {
 	CGContextRef context = SLWindowContextCreate(cid, wid, NULL);
 	if (context) {
+		CGRect whole = CGRectMake(0, 0, size.width, size.height);
 		// Copying the pixels in, alpha included, rather than compositing
-		// them over a cleared backing: the picture covers the window.
+		// them over whatever the window showed last: the picture covers
+		// the window.
 		CGContextSetBlendMode(context, kCGBlendModeCopy);
-		CGContextDrawImage(context, CGRectMake(0, 0, size.width, size.height), picture);
+		CGContextDrawImage(context, whole, picture);
+		if (mask) {
+			CGContextSetBlendMode(context, kCGBlendModeDestinationIn);
+			CGContextDrawImage(context, whole, mask);
+		}
 		CGContextFlush(context);
 		CGContextRelease(context);
 	}
 	CGImageRelease(picture);
+	if (mask) {
+		CGImageRelease(mask);
+	}
 }
 
-// Render picture, clipped to mask's alpha when there is one, into memory
-// the paint can copy from. A captured image is materialised the first time
-// it is read, which is most of a proxy's cost, and this is that read. Done
-// here, off the thread that makes the windows, several run at once. Both
-// inputs are released.
-static CGImageRef mimiRender(CGImageRef picture, CGImageRef mask) {
-	size_t width = CGImageGetWidth(picture);
-	size_t height = CGImageGetHeight(picture);
+// Paint picture into a pooled window, when the pool has one of the size,
+// on the group's queue, and hand the window back in *window with *picture
+// and *mask taken. With no pooled window the picture stays for the caller
+// to make one for. The caller holds the lock.
+static void mimiPaintPooledLocked(
+    uint32_t *window, CGSize size, double scale, CGImageRef *picture, CGImageRef *mask, dispatch_group_t group,
+    dispatch_queue_t queue, int cid) {
+	uint32_t wid = mimiPooledLocked(size, scale);
+	if (!wid) {
+		return;
+	}
+	*window = wid;
+	CGImageRef image = *picture;
+	CGImageRef clip = mask ? *mask : NULL;
+	*picture = NULL;
+	if (mask) {
+		*mask = NULL;
+	}
+	dispatch_group_async(group, queue, ^{
+		mimiPaint(cid, wid, size, image, clip);
+	});
+}
+
+#pragma mark - Masks
+
+// The remembered mask for a window of this size, retained, or NULL. The
+// caller holds the lock.
+static CGImageRef mimiCachedMaskLocked(uint32_t number, CGSize size, double scale) {
+	for (int i = 0; i < gMaskCount; i++) {
+		if (gMasks[i].number == number && mimiSameSize(gMasks[i].size, size) && gMasks[i].scale == scale) {
+			return CGImageRetain(gMasks[i].mask);
+		}
+	}
+	return NULL;
+}
+
+// Remember a mask, copied into memory of its own so the capture it was
+// cropped from can go. The window's older mask, if any, is replaced;
+// otherwise the oldest entry is. The caller holds the lock.
+static void mimiRememberMaskLocked(uint32_t number, CGSize size, double scale, CGImageRef mask) {
+	size_t width = CGImageGetWidth(mask);
+	size_t height = CGImageGetHeight(mask);
 	CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
 	CGContextRef context = CGBitmapContextCreate(
 	    NULL, width, height, 8, 0, space, kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
 	CGColorSpaceRelease(space);
 	if (!context) {
-		if (mask) {
-			CGImageRelease(mask);
-		}
-		return picture;
+		return;
 	}
-	CGRect whole = CGRectMake(0, 0, width, height);
 	CGContextSetBlendMode(context, kCGBlendModeCopy);
-	CGContextDrawImage(context, whole, picture);
-	if (mask) {
-		CGContextSetBlendMode(context, kCGBlendModeDestinationIn);
-		CGContextDrawImage(context, whole, mask);
-		CGImageRelease(mask);
-	}
-	CGImageRelease(picture);
-	CGImageRef rendered = CGBitmapContextCreateImage(context);
+	CGContextDrawImage(context, CGRectMake(0, 0, width, height), mask);
+	CGImageRef copy = CGBitmapContextCreateImage(context);
 	CGContextRelease(context);
-	return rendered;
+	if (!copy) {
+		return;
+	}
+
+	int slot = -1;
+	for (int i = 0; i < gMaskCount; i++) {
+		if (gMasks[i].number == number) {
+			slot = i;
+			break;
+		}
+	}
+	if (slot < 0) {
+		if (gMaskCount < kMimiMaskCacheSize) {
+			slot = gMaskCount++;
+		} else {
+			slot = gMaskNext;
+			gMaskNext = (gMaskNext + 1) % kMimiMaskCacheSize;
+		}
+	}
+	if (gMasks[slot].mask) {
+		CGImageRelease(gMasks[slot].mask);
+	}
+	gMasks[slot] = (MimiMask){.number = number, .size = size, .scale = scale, .mask = copy};
 }
 
-static void mimiReleaseAllLocked(int cid, CFTypeRef transaction) {
+#pragma mark - Teardown
+
+static void mimiFreeBackdrop(MimiBackdrop *backdrop) {
+	free(backdrop->shows);
+	backdrop->shows = NULL;
+	backdrop->showsCount = 0;
+}
+
+// Order every window of the current animation out in the transaction,
+// commit it, and pool the windows, except the backdrops marked reused,
+// which the next animation keeps on screen. The caller holds the lock.
+static void mimiRetireLocked(int cid, CFTypeRef transaction) {
 	for (int i = 0; i < gAnim.proxyCount; i++) {
-		SLSTransactionOrderWindow(transaction, gAnim.proxies[i].proxy, kMimiOrderOut, 0);
+		if (!gAnim.proxies[i].taken) {
+			SLSTransactionOrderWindow(transaction, gAnim.proxies[i].proxy, kMimiOrderOut, 0);
+		}
 	}
 	for (int i = 0; i < gAnim.backdropCount; i++) {
-		SLSTransactionOrderWindow(transaction, gAnim.backdrops[i], kMimiOrderOut, 0);
+		if (!gAnim.backdrops[i].reused) {
+			SLSTransactionOrderWindow(transaction, gAnim.backdrops[i].window, kMimiOrderOut, 0);
+		}
 	}
 	SLSTransactionCommit(transaction, 1);
 
 	for (int i = 0; i < gAnim.proxyCount; i++) {
-		SLSReleaseWindow(cid, gAnim.proxies[i].proxy);
+		if (!gAnim.proxies[i].taken) {
+			mimiRecycleLocked(cid, gAnim.proxies[i].proxy, gAnim.proxies[i].drawn, gAnim.proxies[i].scale);
+		}
 	}
 	for (int i = 0; i < gAnim.backdropCount; i++) {
-		SLSReleaseWindow(cid, gAnim.backdrops[i]);
+		if (!gAnim.backdrops[i].reused) {
+			mimiRecycleLocked(cid, gAnim.backdrops[i].window, gAnim.backdrops[i].bounds.size, gAnim.backdrops[i].scale);
+		}
+		mimiFreeBackdrop(&gAnim.backdrops[i]);
 	}
 	free(gAnim.proxies);
 	free(gAnim.backdrops);
@@ -245,6 +473,16 @@ static void mimiReleaseAllLocked(int cid, CFTypeRef transaction) {
 	gAnim.proxyCount = 0;
 	gAnim.backdropCount = 0;
 	gAnim.running = NO;
+}
+
+static void mimiReleaseAllLocked(int cid, CFTypeRef transaction) {
+	for (int i = 0; i < gAnim.backdropCount; i++) {
+		gAnim.backdrops[i].reused = NO;
+	}
+	for (int i = 0; i < gAnim.proxyCount; i++) {
+		gAnim.proxies[i].taken = NO;
+	}
+	mimiRetireLocked(cid, transaction);
 }
 
 #pragma mark - Display link
@@ -278,7 +516,7 @@ static CADisplayLink *gLink;
 		for (int i = 0; i < gAnim.proxyCount; i++) {
 			MimiProxy *proxy = &gAnim.proxies[i];
 			SLSTransactionSetWindowTransform(
-			    transaction, proxy->proxy, 0, 0, mimiPlacement(proxy->from.size, mimiLerp(proxy->from, proxy->to, p)));
+			    transaction, proxy->proxy, 0, 0, mimiPlacement(proxy->drawn, mimiLerp(proxy->from, proxy->to, p)));
 		}
 		SLSTransactionCommit(transaction, 0);
 	}
@@ -337,9 +575,81 @@ static void mimiStartLinkLocked(void) {
 	CFRunLoopWakeUp(runLoop);
 }
 
-#pragma mark - API
+#pragma mark - Begin
+
+// A backdrop of the running animation that still shows the screen: on this
+// display, on this side of the proxies, and a still of these very windows
+// where they are now. Its picture is at most one animation old. The caller
+// holds the lock.
+static MimiBackdrop *mimiReusableLocked(CGRect bounds, BOOL over, const MimiEntry *shows, int showsCount) {
+	if (!gAnim.running) {
+		return NULL;
+	}
+	for (int i = 0; i < gAnim.backdropCount; i++) {
+		MimiBackdrop *backdrop = &gAnim.backdrops[i];
+		if (backdrop->over == over && mimiSameRect(backdrop->bounds, bounds) &&
+		    mimiSameEntries(backdrop->shows, backdrop->showsCount, shows, showsCount)) {
+			return backdrop;
+		}
+	}
+	return NULL;
+}
+
+// Note a backdrop to make from a still of the given entries, or, when the
+// running animation has one that still shows them, to keep from it.
+static void mimiAddBackdrop(
+    MimiBackdrop *backdrops, int *count, CGRect bounds, double scale, BOOL over, const MimiEntry *shows, int showsCount,
+    CGImageRef still, MimiBackdrop *reused) {
+	if (*count >= kMimiMaxBackdrops) {
+		if (still) {
+			CGImageRelease(still);
+		}
+		return;
+	}
+	MimiBackdrop *backdrop = &backdrops[(*count)++];
+	*backdrop = (MimiBackdrop){.bounds = bounds, .scale = scale, .over = over, .still = still};
+	backdrop->shows = calloc((size_t)showsCount + 1, sizeof(MimiEntry));
+	memcpy(backdrop->shows, shows, (size_t)showsCount * sizeof(MimiEntry));
+	backdrop->showsCount = showsCount;
+	if (reused) {
+		backdrop->window = reused->window;
+		backdrop->reused = YES;
+		reused->reused = YES;
+	}
+}
 
 int MimiScreenCaptureGranted(void) { return CGPreflightScreenCaptureAccess() ? 1 : 0; }
+
+void MimiAnimationWarm(void) {
+	@autoreleasepool {
+		int cid = SLSMainConnectionID();
+		CGDirectDisplayID displays[16];
+		uint32_t displayCount = 0;
+		CGGetActiveDisplayList(16, displays, &displayCount);
+
+		pthread_mutex_lock(&gAnim.lock);
+		for (uint32_t d = 0; d < displayCount; d++) {
+			CGRect bounds = CGDisplayBounds(displays[d]);
+			double scale = bounds.size.width > 0 ? CGDisplayPixelsWide(displays[d]) / bounds.size.width : 1;
+			// Two per display: the backdrop under the proxies and the one
+			// over them.
+			for (int k = 0; k < 2 && gPoolCount < kMimiPoolSize; k++) {
+				uint32_t wid = mimiNewWindow(cid, bounds.size, scale);
+				if (!wid) {
+					break;
+				}
+				CGContextRef context = SLWindowContextCreate(cid, wid, NULL);
+				if (context) {
+					CGContextClearRect(context, CGRectMake(0, 0, bounds.size.width, bounds.size.height));
+					CGContextFlush(context);
+					CGContextRelease(context);
+				}
+				mimiRecycleLocked(cid, wid, bounds.size, scale);
+			}
+		}
+		pthread_mutex_unlock(&gAnim.lock);
+	}
+}
 
 int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double duration, int easing) {
 	if (!targets || count <= 0) {
@@ -359,13 +669,19 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 		int cid = SLSMainConnectionID();
 		pthread_mutex_lock(&gAnim.lock);
 
-		// Where each window starts: its current animated frame if it is animating, else
-		// where the window server has it.
+		// Where each window starts: its current animated frame if it is
+		// animating, else where the window server has it. A window in
+		// flight to the very frame asked for again, as when the pass that
+		// follows a focus change repeats the one that made it, keeps the
+		// proxy it has, and when no window does more than that the
+		// running animation is left to finish.
 		MimiProxy *next = calloc((size_t)count, sizeof(MimiProxy));
 		int nextCount = 0;
+		int carriedCount = 0;
 		for (int i = 0; i < count; i++) {
 			CGRect from;
-			if (!mimiInFlightLocked(targets[i].number, &from)) {
+			int flight = -1;
+			if (!mimiInFlightLocked(targets[i].number, &from, &flight)) {
 				if (SLSGetWindowBounds(cid, targets[i].number, &from) != kCGErrorSuccess) {
 					continue;
 				}
@@ -376,55 +692,79 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 			// A window already at its frame is skipped. Most passes move few
 			// windows, or none, and cost nothing here.
 			CGRect to = CGRectMake(targets[i].x, targets[i].y, targets[i].w, targets[i].h);
-			if (fabs(from.origin.x - to.origin.x) < 0.5 && fabs(from.origin.y - to.origin.y) < 0.5 &&
-			    fabs(from.size.width - to.size.width) < 0.5 && fabs(from.size.height - to.size.height) < 0.5) {
+			if (mimiSameRect(from, to)) {
 				continue;
 			}
 			next[nextCount].number = targets[i].number;
 			next[nextCount].from = from;
 			next[nextCount].to = to;
+			if (flight >= 0 && mimiSameRect(gAnim.proxies[flight].to, to)) {
+				next[nextCount].carried = YES;
+				next[nextCount].proxy = gAnim.proxies[flight].proxy;
+				next[nextCount].scale = gAnim.proxies[flight].scale;
+				next[nextCount].drawn = gAnim.proxies[flight].drawn;
+				carriedCount++;
+			}
 			nextCount++;
+		}
+		if (nextCount == carriedCount) {
+			free(next);
+			pthread_mutex_unlock(&gAnim.lock);
+			return 0;
+		}
+		for (int i = 0; i < nextCount; i++) {
+			if (next[i].carried) {
+				for (int j = 0; j < gAnim.proxyCount; j++) {
+					if (gAnim.proxies[j].proxy == next[i].proxy) {
+						gAnim.proxies[j].taken = YES;
+					}
+				}
+			}
 		}
 
 		// Everything on screen but the animating windows and our own, a
 		// previous animation's proxies. The list runs front to back, and is
 		// split at the first animating window. Whatever comes before it is
 		// in front of every moving window, a floating window say, and is
-		// drawn over the proxies. The rest goes under them.
-		// CGWindowListCreateImageFromArray reads the ids as raw values, not
-		// as numbers.
-		// CGWindowListCreateImageFromArray composites the list in the order
-		// given, first on top, so every list keeps the on-screen order. under
-		// is the scene from the first animating window down, moving windows
+		// drawn over the proxies. The rest goes under them. under is the
+		// scene from the first animating window down, moving windows
 		// included, that the apart windows' pictures are cropped from.
-		CFMutableArrayRef others = CFArrayCreateMutable(NULL, 0, NULL);
-		CFMutableArrayRef front = CFArrayCreateMutable(NULL, 0, NULL);
-		CFMutableArrayRef under = CFArrayCreateMutable(NULL, 0, NULL);
+		// CGWindowListCreateImageFromArray composites a list in the order
+		// given, first on top, so every list keeps the on-screen order.
+		CFArrayRef onScreen = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+		CFIndex onScreenCount = onScreen ? CFArrayGetCount(onScreen) : 0;
+		MimiEntry *others = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
+		MimiEntry *front = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
+		MimiEntry *under = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
+		int othersCount = 0, frontCount = 0, underCount = 0;
 		pid_t self = getpid();
 		BOOL passed = NO;
 		int depth = 0;
-		CFArrayRef onScreen = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
 		for (NSDictionary *info in (__bridge NSArray *)onScreen) {
 			if ([info[(id)kCGWindowOwnerPID] intValue] == self ||
 			    [info[(id)kCGWindowLayer] intValue] >= kMimiDockLayer) {
 				continue;
 			}
-			uint32_t number = [info[(id)kCGWindowNumber] unsignedIntValue];
+			MimiEntry entry = {.number = [info[(id)kCGWindowNumber] unsignedIntValue]};
+			CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)info[(id)kCGWindowBounds], &entry.bounds);
 			BOOL inFlight = NO;
 			for (int i = 0; i < nextCount && !inFlight; i++) {
-				inFlight = next[i].number == number;
+				inFlight = next[i].number == entry.number;
 				if (inFlight) {
 					next[i].depth = depth;
+					next[i].listed = YES;
 				}
 			}
 			depth++;
 			if (inFlight) {
 				passed = YES;
+			} else if (passed) {
+				others[othersCount++] = entry;
 			} else {
-				CFArrayAppendValue(passed ? others : front, (const void *)(uintptr_t)number);
+				front[frontCount++] = entry;
 			}
 			if (passed) {
-				CFArrayAppendValue(under, (const void *)(uintptr_t)number);
+				under[underCount++] = entry;
 			}
 		}
 		if (onScreen) {
@@ -433,24 +773,29 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 
 		// Backdrops: at most two per display, the still of what is under
 		// the proxies and, when anything is, the still of what is over them.
-		uint32_t *backdrops = calloc(32, sizeof(uint32_t));
-		CGRect *backdropBounds = calloc(32, sizeof(CGRect));
-		CGImageRef *backdropStills = calloc(32, sizeof(CGImageRef));
-		double *backdropScales = calloc(32, sizeof(double));
-		BOOL *backdropOver = calloc(32, sizeof(BOOL));
+		MimiBackdrop *backdrops = calloc(kMimiMaxBackdrops, sizeof(MimiBackdrop));
 		int backdropCount = 0;
 		CGDirectDisplayID displays[16];
 		uint32_t displayCount = 0;
 		CGGetActiveDisplayList(16, displays, &displayCount);
 
-		// Every capture is taken before any window is made: a capture that
-		// follows the creation of a window not yet drawn waits half a second
-		// on it.
+		// A capture costs the same round trip whatever its area, so the
+		// captures are what the setup waits on. Each one's paint starts
+		// as soon as it is taken, on a thread of its own, when the pool
+		// has a window for it, and runs under the captures that follow.
+		// A window the pool lacks is made only once every capture is
+		// taken, then painted at once: a capture that follows the creation
+		// of a window not yet drawn waits half a second on it, as does a
+		// request that reaches the window server while such a window
+		// waits for its first pixels.
+		dispatch_group_t paints = dispatch_group_create();
+		dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0);
+
 		for (uint32_t d = 0; d < displayCount; d++) {
 			CGRect bounds = CGDisplayBounds(displays[d]);
 			BOOL any = NO;
 			for (int i = 0; i < nextCount; i++) {
-				if (next[i].picture == NULL && mimiOnDisplay(next[i].from, bounds)) {
+				if (!next[i].carried && next[i].picture == NULL && mimiAnimatesOn(&next[i], bounds, displays[d])) {
 					any = YES;
 					break;
 				}
@@ -458,93 +803,149 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 			if (!any) {
 				continue;
 			}
+			double scale = bounds.size.width > 0 ? CGDisplayPixelsWide(displays[d]) / bounds.size.width : 1;
+
+			// The windows that overlap another animating window, as under a
+			// monocle layout, are captured one by one: a composite of the
+			// set shows only the top one. The rest are cropped from one
+			// composite of the scene. Their masks come from one composite of
+			// those windows alone, taken only for the windows whose mask is
+			// not remembered from an earlier animation.
+			MimiEntry *apart = calloc((size_t)nextCount, sizeof(MimiEntry));
+			int apartCount = 0;
+			BOOL anyAlone = NO;
+			for (int i = 0; i < nextCount; i++) {
+				if (next[i].carried || next[i].picture != NULL || !mimiAnimatesOn(&next[i], bounds, displays[d])) {
+					continue;
+				}
+				// A window off the display is not in the scene, and one
+				// not in the list has no place in it either.
+				BOOL overlaps = !next[i].listed || !mimiOnDisplay(next[i].from, bounds);
+				for (int j = 0; j < nextCount && !overlaps; j++) {
+					if (j != i && next[j].picture == NULL && mimiAnimatesOn(&next[j], bounds, displays[d])) {
+						overlaps = !CGRectIsEmpty(CGRectIntersection(next[i].from, next[j].from));
+					}
+				}
+				next[i].alone = !overlaps;
+				if (!overlaps) {
+					anyAlone = YES;
+					next[i].mask = mimiCachedMaskLocked(next[i].number, next[i].from.size, scale);
+					if (!next[i].mask) {
+						apart[apartCount++] = (MimiEntry){.number = next[i].number, .bounds = next[i].from};
+					}
+				}
+			}
 
 			// Deprecated for ScreenCaptureKit, whose screenshot is asynchronous
-			// and far slower to start; this composes the display in a few
+			// and far slower to start; this composes the display in some ten
 			// milliseconds, which an animation that starts on the same frame
 			// as the event needs. SLSHWCaptureWindowList, the hardware
 			// capture yabai uses, was measured on macOS 26 at 6 to 10 ms per
 			// window, the cost of one of these composites of a whole display,
 			// and returns one clipped image for a list, so it captures
 			// nothing faster here. The window server serialises captures, so
-			// issuing them concurrently was measured to gain nothing.
+			// issuing them concurrently was measured to gain nothing, and a
+			// smaller area or a lower resolution was measured to cost the
+			// same.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-			// The windows that overlap another animating window, as under a monocle
-			// layout, are captured one by one: a composite of the set shows
-			// only the top one. The rest are cropped from one composite, one
-			// call for all of them, since a capture costs the same however
-			// small the window.
-			CFMutableArrayRef apart = CFArrayCreateMutable(NULL, 0, NULL);
-			for (int i = 0; i < nextCount; i++) {
-				if (next[i].picture != NULL || !mimiOnDisplay(next[i].from, bounds)) {
-					continue;
-				}
-				BOOL overlaps = NO;
-				for (int j = 0; j < nextCount && !overlaps; j++) {
-					if (j != i && next[j].picture == NULL && mimiOnDisplay(next[j].from, bounds)) {
-						overlaps = !CGRectIsEmpty(CGRectIntersection(next[i].from, next[j].from));
-					}
-				}
-				next[i].alone = !overlaps;
-				if (!overlaps) {
-					CFArrayAppendValue(apart, (const void *)(uintptr_t)next[i].number);
+			MimiBackdrop *keptUnder = mimiReusableLocked(bounds, NO, others, othersCount);
+			if (keptUnder) {
+				mimiAddBackdrop(backdrops, &backdropCount, bounds, scale, NO, others, othersCount, NULL, keptUnder);
+			} else if (othersCount > 0) {
+				CFArrayRef list = mimiNumbers(others, othersCount);
+				CGImageRef still = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+				CFRelease(list);
+				if (still) {
+					mimiAddBackdrop(backdrops, &backdropCount, bounds, scale, NO, others, othersCount, still, NULL);
+					mimiPaintPooledLocked(
+					    &backdrops[backdropCount - 1].window, bounds.size, scale, &backdrops[backdropCount - 1].still,
+					    NULL, paints, queue, cid);
 				}
 			}
-
-			CGImageRef still = CGWindowListCreateImageFromArray(bounds, others, kCGWindowImageBestResolution);
-			CGImageRef cover = CFArrayGetCount(front) > 0
-			                       ? CGWindowListCreateImageFromArray(bounds, front, kCGWindowImageBestResolution)
-			                       : NULL;
-			CGImageRef flight = CFArrayGetCount(apart) > 0
-			                        ? CGWindowListCreateImageFromArray(bounds, apart, kCGWindowImageBestResolution)
-			                        : NULL;
+			MimiBackdrop *keptOver = frontCount > 0 ? mimiReusableLocked(bounds, YES, front, frontCount) : NULL;
+			if (keptOver) {
+				mimiAddBackdrop(backdrops, &backdropCount, bounds, scale, YES, front, frontCount, NULL, keptOver);
+			} else if (frontCount > 0) {
+				CFArrayRef list = mimiNumbers(front, frontCount);
+				CGImageRef cover = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+				CFRelease(list);
+				if (cover) {
+					mimiAddBackdrop(backdrops, &backdropCount, bounds, scale, YES, front, frontCount, cover, NULL);
+					mimiPaintPooledLocked(
+					    &backdrops[backdropCount - 1].window, bounds.size, scale, &backdrops[backdropCount - 1].still,
+					    NULL, paints, queue, cid);
+				}
+			}
+			CGImageRef flight = NULL;
+			if (apartCount > 0) {
+				CFArrayRef list = mimiNumbers(apart, apartCount);
+				flight = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+				CFRelease(list);
+			}
 			// A window captured on its own comes out opaque, with its
 			// translucent parts a flat tint, since the window server has
 			// nothing behind it to blend with. Composited with what is under
 			// it, it looks as it does on screen, so the apart windows take
 			// their picture from that scene, cropped, and their own capture
 			// only clips it to the window's shape.
-			CGImageRef scene =
-			    flight ? CGWindowListCreateImageFromArray(bounds, under, kCGWindowImageBestResolution) : NULL;
-			CFRelease(apart);
-			CGImageRef measure = still ? still : (cover ? cover : flight);
-			double scale = measure ? (double)CGImageGetWidth(measure) / bounds.size.width : 1;
-
-			// A display with nothing else on it needs no backdrop.
-			CGImageRef stills[2] = {still, cover};
-			for (int k = 0; k < 2; k++) {
-				if (stills[k] && backdropCount < 32) {
-					backdropBounds[backdropCount] = bounds;
-					backdropStills[backdropCount] = stills[k];
-					backdropScales[backdropCount] = scale;
-					backdropOver[backdropCount] = k == 1;
-					backdropCount++;
-				}
+			CGImageRef scene = NULL;
+			if (anyAlone) {
+				CFArrayRef list = mimiNumbers(under, underCount);
+				scene = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+				CFRelease(list);
 			}
+			free(apart);
 
 			for (int i = 0; i < nextCount; i++) {
 				MimiProxy *proxy = &next[i];
-				if (proxy->picture != NULL || !mimiOnDisplay(proxy->from, bounds)) {
+				if (proxy->carried || proxy->picture != NULL || !mimiAnimatesOn(proxy, bounds, displays[d])) {
 					continue;
 				}
-				if (proxy->alone && flight) {
+				if (proxy->alone) {
 					CGRect crop = CGRectMake(
 					    (proxy->from.origin.x - bounds.origin.x) * scale,
 					    (proxy->from.origin.y - bounds.origin.y) * scale, proxy->from.size.width * scale,
 					    proxy->from.size.height * scale);
-					proxy->picture = CGImageCreateWithImageInRect(scene ? scene : flight, crop);
-					if (scene && proxy->picture) {
-						proxy->mask = CGImageCreateWithImageInRect(flight, crop);
+					if (scene) {
+						proxy->picture = CGImageCreateWithImageInRect(scene, crop);
 					}
-				} else if (!proxy->alone) {
+					if (!proxy->mask && flight) {
+						proxy->mask = CGImageCreateWithImageInRect(flight, crop);
+						if (proxy->mask) {
+							mimiRememberMaskLocked(proxy->number, proxy->from.size, scale, proxy->mask);
+						}
+					}
+					if (!proxy->picture && proxy->mask) {
+						// No scene: the window's own capture is the picture.
+						proxy->picture = proxy->mask;
+						proxy->mask = NULL;
+					}
+				} else if (mimiOnDisplay(proxy->from, bounds)) {
 					proxy->picture = CGWindowListCreateImage(
 					    proxy->from, kCGWindowListOptionIncludingWindow, proxy->number, kCGWindowImageBestResolution);
+				} else {
+					// Off the display, a window has pixels only when asked
+					// for by its own bounds: a rectangle there comes back
+					// empty. Its picture is opaque, a flat tint where the
+					// window is translucent, since nothing is under it to
+					// blend with.
+					proxy->picture = CGWindowListCreateImage(
+					    CGRectNull, kCGWindowListOptionIncludingWindow, proxy->number,
+					    kCGWindowImageBoundsIgnoreFraming | kCGWindowImageBestResolution);
 				}
 				proxy->scale = scale;
+				proxy->drawn = proxy->from.size;
 				if (!proxy->picture) {
 					MIMI_LOG("animation: capturing window %u failed", proxy->number);
+					if (proxy->mask) {
+						CGImageRelease(proxy->mask);
+						proxy->mask = NULL;
+					}
+					continue;
 				}
+				mimiPaintPooledLocked(
+				    &proxy->proxy, proxy->from.size, scale, &proxy->picture, &proxy->mask, paints, queue, cid);
 			}
 #pragma clang diagnostic pop
 
@@ -555,79 +956,49 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 				CGImageRelease(scene);
 			}
 		}
-		CFRelease(others);
-		CFRelease(front);
-		CFRelease(under);
+		free(others);
+		free(front);
+		free(under);
 
-		// Every picture is rendered before any window is made, at once on
-		// as many threads as there are pictures. The rendering is the bulk of
-		// a paint, so the paints below only copy.
-		int renderCount = backdropCount;
-		for (int i = 0; i < nextCount; i++) {
-			if (next[i].picture) {
-				renderCount++;
-			}
-		}
-		CGImageRef *pictures = calloc((size_t)renderCount, sizeof(CGImageRef));
-		CGImageRef *masks = calloc((size_t)renderCount, sizeof(CGImageRef));
-		int r = 0;
-		for (int i = 0; i < backdropCount; i++) {
-			pictures[r++] = backdropStills[i];
-		}
-		for (int i = 0; i < nextCount; i++) {
-			if (next[i].picture) {
-				pictures[r] = next[i].picture;
-				masks[r] = next[i].mask;
-				r++;
-			}
-		}
-		dispatch_apply((size_t)renderCount, dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^(size_t k) {
-			pictures[k] = mimiRender(pictures[k], masks[k]);
-		});
-		r = 0;
-		for (int i = 0; i < backdropCount; i++) {
-			backdropStills[i] = pictures[r++];
-		}
-		for (int i = 0; i < nextCount; i++) {
-			if (next[i].picture) {
-				next[i].picture = pictures[r++];
-				next[i].mask = NULL;
-			}
-		}
-		free(pictures);
-		free(masks);
-
-		// Then the windows, each painted the moment it exists: the window
-		// server stalls for half a second on a request that arrives while
-		// windows it made are still waiting for their first pixels.
+		// The windows the pool had none of, made now and painted the moment
+		// they exist. A picture still held here is one waiting for such a
+		// window.
 		int kept = 0;
 		for (int i = 0; i < backdropCount; i++) {
-			uint32_t backdrop = mimiNewProxy(cid, backdropBounds[i].size, backdropScales[i]);
-			if (backdrop) {
-				mimiPaint(cid, backdrop, backdropBounds[i].size, backdropStills[i]);
-				backdrops[kept] = backdrop;
-				backdropBounds[kept] = backdropBounds[i];
-				backdropOver[kept] = backdropOver[i];
-				kept++;
+			MimiBackdrop *backdrop = &backdrops[i];
+			if (backdrop->still) {
+				backdrop->window = mimiNewWindow(cid, backdrop->bounds.size, backdrop->scale);
+				if (backdrop->window) {
+					mimiPaint(cid, backdrop->window, backdrop->bounds.size, backdrop->still, NULL);
+				} else {
+					CGImageRelease(backdrop->still);
+				}
+				backdrop->still = NULL;
+			}
+			if (backdrop->window) {
+				backdrops[kept++] = *backdrop;
 			} else {
-				CGImageRelease(backdropStills[i]);
+				mimiFreeBackdrop(backdrop);
 			}
 		}
 		backdropCount = kept;
-
 		for (int i = 0; i < nextCount; i++) {
-			if (next[i].picture) {
-				next[i].proxy = mimiNewProxy(cid, next[i].from.size, next[i].scale);
-				if (next[i].proxy) {
-					mimiPaint(cid, next[i].proxy, next[i].from.size, next[i].picture);
-				} else {
-					CGImageRelease(next[i].picture);
-				}
-				next[i].picture = NULL;
+			if (!next[i].picture) {
+				continue;
 			}
+			next[i].proxy = mimiNewWindow(cid, next[i].from.size, next[i].scale);
+			if (next[i].proxy) {
+				mimiPaint(cid, next[i].proxy, next[i].from.size, next[i].picture, next[i].mask);
+			} else {
+				CGImageRelease(next[i].picture);
+				if (next[i].mask) {
+					CGImageRelease(next[i].mask);
+				}
+			}
+			next[i].picture = NULL;
+			next[i].mask = NULL;
 		}
-		free(backdropStills);
-		free(backdropScales);
+		dispatch_group_wait(paints, DISPATCH_TIME_FOREVER);
 
 		// Keep the proxies that were made, in order.
 		kept = 0;
@@ -639,13 +1010,16 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 
 		// One commit: the under backdrops come in, the new proxies over
 		// them, the over backdrops on top, and the previous animation, if
-		// any, goes out.
+		// any, goes out, but for the backdrops this one keeps.
 		CFTypeRef transaction = SLSTransactionCreate(cid);
 		for (int i = 0; i < backdropCount; i++) {
+			if (backdrops[i].reused) {
+				continue;
+			}
 			SLSTransactionSetWindowTransform(
-			    transaction, backdrops[i], 0, 0, mimiPlacement(backdropBounds[i].size, backdropBounds[i]));
-			if (!backdropOver[i]) {
-				SLSTransactionOrderWindow(transaction, backdrops[i], kMimiOrderAbove, 0);
+			    transaction, backdrops[i].window, 0, 0, mimiPlacement(backdrops[i].bounds.size, backdrops[i].bounds));
+			if (!backdrops[i].over) {
+				SLSTransactionOrderWindow(transaction, backdrops[i].window, kMimiOrderAbove, 0);
 			}
 		}
 		// The proxies go in back to front, each above everything, so they
@@ -658,19 +1032,17 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 				}
 			}
 			SLSTransactionSetWindowTransform(
-			    transaction, next[back].proxy, 0, 0, mimiPlacement(next[back].from.size, next[back].from));
+			    transaction, next[back].proxy, 0, 0, mimiPlacement(next[back].drawn, next[back].from));
 			SLSTransactionOrderWindow(transaction, next[back].proxy, kMimiOrderAbove, 0);
 			next[back].depth = -1;
 		}
 		for (int i = 0; i < backdropCount; i++) {
-			if (backdropOver[i]) {
-				SLSTransactionOrderWindow(transaction, backdrops[i], kMimiOrderAbove, 0);
+			if (backdrops[i].over) {
+				SLSTransactionOrderWindow(transaction, backdrops[i].window, kMimiOrderAbove, 0);
 			}
 		}
-		mimiReleaseAllLocked(cid, transaction);
+		mimiRetireLocked(cid, transaction);
 		CFRelease(transaction);
-		free(backdropBounds);
-		free(backdropOver);
 
 		gAnim.proxies = next;
 		gAnim.proxyCount = kept;
@@ -705,7 +1077,7 @@ void MimiAnimationStart(const uint32_t *dropped, int count) {
 		}
 		if (drop) {
 			SLSTransactionOrderWindow(transaction, gAnim.proxies[i].proxy, kMimiOrderOut, 0);
-			SLSReleaseWindow(cid, gAnim.proxies[i].proxy);
+			mimiRecycleLocked(cid, gAnim.proxies[i].proxy, gAnim.proxies[i].drawn, gAnim.proxies[i].scale);
 		} else {
 			gAnim.proxies[kept++] = gAnim.proxies[i];
 		}

--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -114,6 +114,9 @@ typedef struct {
 // in screen coordinates whatever the window's frame is.
 @interface MimiHost : NSWindow
 @property(nonatomic) CGDirectDisplayID display;
+// root holds the layers, under the content view's own layer, whose bounds
+// AppKit resets as it lays the view out.
+@property(nonatomic, strong) CALayer *root;
 @end
 
 @implementation MimiHost
@@ -278,6 +281,12 @@ static NSRect mimiCocoaRect(CGRect rect) {
 // The host for a display, made on first use, at the floating level so it
 // sits over every ordinary window and under the Dock and menu bar, passing
 // events through.
+// A host covers its display and half a display's width to either side,
+// where a strip parks the column beside the one on screen, so a proxy
+// starting there is drawn. It is never resized: moving a window that shows
+// an animation would show it shifted for a frame.
+static CGRect mimiHostFrame(CGRect bounds) { return CGRectInset(bounds, -bounds.size.width / 2, 0); }
+
 static MimiHost *mimiHost(CGDirectDisplayID display, CGRect bounds) {
 	if (!gHosts) {
 		gHosts = [NSMutableDictionary new];
@@ -286,7 +295,7 @@ static MimiHost *mimiHost(CGDirectDisplayID display, CGRect bounds) {
 	if (host) {
 		return host;
 	}
-	host = [[MimiHost alloc] initWithContentRect:mimiCocoaRect(bounds)
+	host = [[MimiHost alloc] initWithContentRect:mimiCocoaRect(mimiHostFrame(bounds))
 	                                   styleMask:NSWindowStyleMaskBorderless
 	                                     backing:NSBackingStoreBuffered
 	                                       defer:NO];
@@ -302,18 +311,37 @@ static MimiHost *mimiHost(CGDirectDisplayID display, CGRect bounds) {
 	                          NSWindowCollectionBehaviorIgnoresCycle | NSWindowCollectionBehaviorFullScreenAuxiliary;
 	NSView *view = host.contentView;
 	view.wantsLayer = YES;
-	view.layer.geometryFlipped = YES;
-	view.layer.masksToBounds = NO;
+	// The root layer fills the view, and its coordinate space is screen
+	// coordinates, y down.
+	CGRect frame = mimiHostFrame(bounds);
+	CALayer *root = [CALayer layer];
+	root.geometryFlipped = YES;
+	root.masksToBounds = NO;
+	root.anchorPoint = CGPointZero;
+	root.position = CGPointZero;
+	root.bounds = CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
+	root.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+	[view.layer addSublayer:root];
+	host.root = root;
 	gHosts[@(display)] = host;
 	return host;
 }
 
-// Place the host over `frame`, in screen coordinates, with its root layer's
-// coordinate space kept as screen coordinates.
-static void mimiPlaceHost(MimiHost *host, CGRect frame) {
-	[host setFrame:mimiCocoaRect(frame) display:NO];
-	CALayer *root = host.contentView.layer;
-	root.bounds = CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
+// Push the committed transaction to the render server and wait for the
+// display to show it. A commit made on the main thread from a dispatched
+// block is otherwise held until the run loop turns, and the caller writes
+// the real frames as soon as this returns: they must already be covered.
+static void mimiShow(void) {
+	[CATransaction flush];
+	double refresh = 60;
+	CGDisplayModeRef mode = CGDisplayCopyDisplayMode(CGMainDisplayID());
+	if (mode) {
+		if (CGDisplayModeGetRefreshRate(mode) > 0) {
+			refresh = CGDisplayModeGetRefreshRate(mode);
+		}
+		CGDisplayModeRelease(mode);
+	}
+	usleep((useconds_t)(1e6 / refresh));
 }
 
 // A layer showing image over `frame`, in screen coordinates, clipped to
@@ -411,7 +439,7 @@ static void mimiRetire(NSArray<MimiProxy *> *carried) {
 	}
 	[CATransaction commit];
 	for (MimiHost *host in gHosts.allValues) {
-		if (host.contentView.layer.sublayers.count == 0) {
+		if (host.root.sublayers.count == 0) {
 			[host orderOut:nil];
 		}
 	}
@@ -759,14 +787,7 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 			CGImageRelease(scene);
 		}
 
-		// The host covers the display and wherever a proxy starts off it.
-		CGRect reach = bounds;
-		for (MimiProxy *proxy in next) {
-			if ((proxy.picture || proxy.carried) && mimiAnimatesOn(proxy, bounds)) {
-				reach = CGRectUnion(reach, proxy.from);
-			}
-		}
-		mimiPlaceHost(mimiHost(displays[d], bounds), reach);
+		mimiHost(displays[d], bounds);
 	}
 	free(others);
 	free(front);
@@ -784,7 +805,7 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 		backdrop.layer = mimiImageLayer(backdrop.still, NULL, backdrop.bounds, 1);
 		CGImageRelease(backdrop.still);
 		backdrop.still = NULL;
-		[mimiHost(backdrop.display, backdrop.bounds).contentView.layer addSublayer:backdrop.layer];
+		[mimiHost(backdrop.display, backdrop.bounds).root addSublayer:backdrop.layer];
 	}
 	NSMutableArray<MimiProxy *> *made = [NSMutableArray array];
 	for (MimiProxy *proxy in next) {
@@ -811,7 +832,7 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 		if (!root) {
 			for (MimiHost *host in gHosts.allValues) {
 				if (mimiAnimatesOn(proxy, CGDisplayBounds(host.display))) {
-					root = host.contentView.layer;
+					root = host.root;
 					break;
 				}
 			}
@@ -829,15 +850,16 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 			backdrop.still = NULL;
 		}
 		[backdrop.layer removeFromSuperlayer];
-		[mimiHost(backdrop.display, backdrop.bounds).contentView.layer addSublayer:backdrop.layer];
+		[mimiHost(backdrop.display, backdrop.bounds).root addSublayer:backdrop.layer];
 	}
 	[CATransaction commit];
 	mimiRetire(carried);
 	for (MimiHost *host in gHosts.allValues) {
-		if (host.contentView.layer.sublayers.count > 0 && !host.visible) {
+		if (host.root.sublayers.count > 0 && !host.visible) {
 			[host orderFrontRegardless];
 		}
 	}
+	mimiShow();
 
 	gProxies = made;
 	gBackdrops = backdrops;
@@ -914,6 +936,7 @@ void MimiAnimationStart(const uint32_t *dropped, int count) {
 			[layer addAnimation:size forKey:@"bounds"];
 		}
 		[CATransaction commit];
+		[CATransaction flush];
 		gRunning = YES;
 	});
 }

--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -5,65 +5,38 @@
 
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
-#import <pthread.h>
 #import <unistd.h>
 
 // The animation never touches the real windows beyond the one frame write the
 // caller makes: the window server refuses alpha, transform and ordering on
-// another process's windows from an ordinary connection. It is drawn with
-// windows of our own instead. A backdrop per display, a still of everything
-// on screen but the moving windows, covers the real windows while they jump
-// to their new frames. Over it, one proxy per window carries a picture of that
-// window, and the compositor moves it with a transform, so no application
-// does any work while the animation runs. Windows in front of every moving
-// window, a floating one say, get a still of their own over the proxies, so
-// the stacking order is kept. One transaction removes everything when it
-// ends.
+// another process's windows from an ordinary connection. It is drawn with a
+// window of our own per display instead, a transparent layer-backed one the
+// size of the display and whatever starts off it. In it, a backdrop layer
+// per display, a still of everything on screen but the moving windows,
+// covers the real windows while they jump to their new frames. Over it, one
+// proxy layer per window carries a picture of that window, and Core
+// Animation moves it, so no application does any work while the animation
+// runs. Windows in front of every moving window, a floating one say, get a
+// still of their own over the proxies, so the stacking order is kept.
 //
-// What the setup costs is what the user waits before anything moves, so the
-// windows are pooled rather than made and released each time, the mask that
-// clips a window's picture to its shape is kept between animations, every
-// paint runs at once on its own thread, and an animation that starts while
-// one runs keeps the backdrops whose windows have not changed.
+// A capture is an image the compositor can show as it is. Handing it to a
+// layer copies nothing, where painting it into a window of our own copied
+// every pixel, four times as many on a Retina display; so what the setup
+// costs is the captures, a fixed round trip each. Core Animation runs the
+// motion on the render server and ends it with a callback, so nothing ticks
+// here. Every layer and window lives on the main thread, where the daemon
+// runs its application loop, and the calls below go there.
 
-#pragma mark - SkyLight External Declarations
-
-extern int SLSMainConnectionID(void);
-extern CGError SLSNewWindow(int cid, int type, float x, float y, CFTypeRef region, uint32_t *wid);
-extern CGError SLSReleaseWindow(int cid, uint32_t wid);
-extern CGError SLSSetWindowOpacity(int cid, uint32_t wid, bool opaque);
-extern CGError SLSSetWindowLevel(int cid, uint32_t wid, int level);
-extern CGError SLSSetWindowTags(int cid, uint32_t wid, uint64_t *tags, int size);
-extern CGError SLSSetWindowResolution(int cid, uint32_t wid, double res);
-extern CGError SLSGetWindowBounds(int cid, uint32_t wid, CGRect *out);
-extern CGContextRef SLWindowContextCreate(int cid, uint32_t wid, CFDictionaryRef options);
-extern CGError CGSNewRegionWithRect(CGRect *rect, CFTypeRef *region);
-extern CFTypeRef SLSTransactionCreate(int cid);
-extern CGError SLSTransactionCommit(CFTypeRef transaction, int synchronous);
-extern CGError SLSTransactionOrderWindow(CFTypeRef transaction, uint32_t wid, int mode, uint32_t relative);
-extern CGError SLSTransactionSetWindowTransform(
-    CFTypeRef transaction, uint32_t wid, int unused1, int unused2, CGAffineTransform transform);
-
-// The window server's backing store type for SLSNewWindow, and the window
-// tags and level the proxies carry: ignore-for-events plus no-shadow, at the
-// floating level so they sit over every ordinary window and under the Dock
-// and menu bar.
-static const int kMimiProxyBackingBuffered = 2;
-static const uint64_t kMimiProxyTags = (1ULL << 1) | (1ULL << 9);
-static const int kMimiProxyLevel = 3;
 // Window layers at and above the Dock's are never covered, so they are left
 // out of the backdrop.
 static const int kMimiDockLayer = 20;
-static const int kMimiOrderAbove = 1;
-static const int kMimiOrderOut = 0;
 
-// How many windows the pool keeps between animations, and how many window
-// masks are remembered. A pooled backdrop holds a display's worth of pixels.
+// How many window masks are remembered.
 enum {
-	kMimiPoolSize = 8,
 	kMimiMaskCacheSize = 32,
-	kMimiMaxBackdrops = 32,
 };
+
+#pragma mark - Types
 
 // One on-screen window, as the window list reports it. A backdrop remembers
 // the entries it shows, so a later animation can tell whether it still
@@ -73,79 +46,102 @@ typedef struct {
 	CGRect bounds;
 } MimiEntry;
 
-typedef struct {
-	uint32_t number;
-	uint32_t proxy;
-	CGRect from;
-	CGRect to;
-	// alone is whether no other animating window overlaps this one where it
-	// starts, so its picture can be cropped from a composite; picture, mask
-	// and scale hold the capture between the phases of MimiAnimationBegin.
-	// mask, when there is one, is the window's own capture, whose alpha
-	// clips the picture to the window's shape.
-	BOOL alone;
-	CGImageRef picture;
-	CGImageRef mask;
-	double scale;
-	// depth is the window's place in the on-screen list, front first, so
-	// the proxies stack as the windows do.
-	int depth;
-	// carried is a proxy taken over from the running animation, already
-	// painted and on screen, since its window was on its way to the same
-	// frame. taken marks the running animation's entry it came from, which
-	// its teardown then leaves alone.
-	BOOL carried;
-	BOOL taken;
-	// listed is whether the window is in the on-screen list: one entirely
-	// off the display is not, and is captured on its own.
-	BOOL listed;
-	// drawn is the size the proxy was painted at, the window's size when
-	// it was captured, which the placement scales from.
-	CGSize drawn;
-} MimiProxy;
+@interface MimiProxy : NSObject
+@property(nonatomic) uint32_t number;
+@property(nonatomic) CGRect from;
+@property(nonatomic) CGRect to;
+// alone is whether no other animating window overlaps this one where it
+// starts, so its picture can be cropped from a composite. listed is whether
+// the window is in the on-screen list: one entirely off the display is not,
+// and is captured on its own.
+@property(nonatomic) BOOL alone;
+@property(nonatomic) BOOL listed;
+// carried is a proxy taken over from the running animation, its layer
+// already on screen, since its window was on its way to the same frame.
+@property(nonatomic) BOOL carried;
+// depth is the window's place in the on-screen list, front first, so the
+// proxies stack as the windows do.
+@property(nonatomic) int depth;
+@property(nonatomic) double scale;
+// picture and mask hold the capture between the phases of Begin; layer is
+// the proxy once made.
+@property(nonatomic) CGImageRef picture;
+@property(nonatomic) CGImageRef mask;
+@property(nonatomic, strong) CALayer *layer;
+@end
 
-typedef struct {
-	uint32_t window;
-	CGRect bounds;
-	double scale;
-	// over is whether the backdrop sits over the proxies, showing the
-	// windows in front of every moving one, rather than under them.
-	BOOL over;
-	// shows is what the backdrop is a still of, front to back.
-	MimiEntry *shows;
-	int showsCount;
-	// still is the capture waiting to be painted, between the phases of
-	// MimiAnimationBegin. reused is a backdrop kept from the animation
-	// before, already painted and on screen.
-	CGImageRef still;
-	BOOL reused;
-} MimiBackdrop;
+@implementation MimiProxy
 
-static struct {
-	pthread_mutex_t lock;
-	BOOL running;
-	MimiProxy *proxies;
-	int proxyCount;
-	MimiBackdrop *backdrops;
-	int backdropCount;
-	double start;
-	double duration;
-	int easing;
-} gAnim = {.lock = PTHREAD_MUTEX_INITIALIZER};
+- (void)dealloc {
+	if (_picture) {
+		CGImageRelease(_picture);
+	}
+	if (_mask) {
+		CGImageRelease(_mask);
+	}
+}
 
-// The pool of windows not on screen, each made for a size and scale, ready
-// to be painted and ordered in again. Making a window is a round trip, and
-// a request that reaches the window server while a window it just made
-// waits for its first pixels stalls for half a second, so the same windows
-// serve every animation. The lock covers it.
-typedef struct {
-	uint32_t window;
-	CGSize size;
-	double scale;
-} MimiPooled;
+@end
 
-static MimiPooled gPool[kMimiPoolSize];
-static int gPoolCount;
+@interface MimiBackdrop : NSObject
+@property(nonatomic) CGRect bounds;
+@property(nonatomic) CGDirectDisplayID display;
+// over is whether the backdrop sits over the proxies, showing the windows in
+// front of every moving one, rather than under them.
+@property(nonatomic) BOOL over;
+// shows is what the backdrop is a still of, front to back.
+@property(nonatomic) MimiEntry *shows;
+@property(nonatomic) int showsCount;
+@property(nonatomic) CGImageRef still;
+@property(nonatomic, strong) CALayer *layer;
+// reused is a backdrop kept from the animation before, already on screen.
+@property(nonatomic) BOOL reused;
+@end
+
+@implementation MimiBackdrop
+
+- (void)dealloc {
+	free(_shows);
+	if (_still) {
+		CGImageRelease(_still);
+	}
+}
+
+@end
+
+// The window per display the layers live in. Its root layer's bounds are the
+// window's frame in screen coordinates, y down, so every sublayer is placed
+// in screen coordinates whatever the window's frame is.
+@interface MimiHost : NSWindow
+@property(nonatomic) CGDirectDisplayID display;
+@end
+
+@implementation MimiHost
+
+- (BOOL)canBecomeKeyWindow {
+	return NO;
+}
+
+- (BOOL)canBecomeMainWindow {
+	return NO;
+}
+
+- (BOOL)isAccessibilityElement {
+	return NO;
+}
+
+@end
+
+// The animation, main thread only.
+static NSMutableDictionary<NSNumber *, MimiHost *> *gHosts;
+static NSMutableArray<MimiProxy *> *gProxies;
+static NSMutableArray<MimiBackdrop *> *gBackdrops;
+static BOOL gRunning;
+static double gDuration;
+static int gEasing;
+// generation tells an animation's end callback whether it is still the one
+// on screen.
+static unsigned gGeneration;
 
 // The masks remembered by window number, each for the size the window had
 // and the scale of the display it was on. A window's shape only changes
@@ -164,26 +160,6 @@ static int gMaskNext;
 
 #pragma mark - Helpers
 
-static double mimiEase(int easing, double t) {
-	switch (easing) {
-	case MimiEasingEaseIn:
-		return t * t * t;
-	case MimiEasingEaseOut: {
-		double u = 1 - t;
-		return 1 - u * u * u;
-	}
-	case MimiEasingEaseInOut:
-		if (t < 0.5) {
-			return 4 * t * t * t;
-		} else {
-			double u = -2 * t + 2;
-			return 1 - u * u * u / 2;
-		}
-	default:
-		return t;
-	}
-}
-
 // A window is on the display that has its centre.
 static BOOL mimiOnDisplay(CGRect frame, CGRect display) {
 	return CGRectContainsPoint(display, CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame)));
@@ -191,31 +167,14 @@ static BOOL mimiOnDisplay(CGRect frame, CGRect display) {
 
 // A window animates on the display it starts on, or, starting off every
 // display, as a strip's parked column does, on the one it arrives on.
-static BOOL mimiAnimatesOn(const MimiProxy *proxy, CGRect display, CGDirectDisplayID display_id) {
-	if (mimiOnDisplay(proxy->from, display)) {
+static BOOL mimiAnimatesOn(MimiProxy *proxy, CGRect display) {
+	if (mimiOnDisplay(proxy.from, display)) {
 		return YES;
 	}
 	CGDirectDisplayID starts[16];
 	uint32_t startCount = 0;
-	CGGetDisplaysWithPoint(
-	    CGPointMake(CGRectGetMidX(proxy->from), CGRectGetMidY(proxy->from)), 16, starts, &startCount);
-	return startCount == 0 && mimiOnDisplay(proxy->to, display);
-}
-
-static CGRect mimiLerp(CGRect from, CGRect to, double p) {
-	return CGRectMake(
-	    from.origin.x + (to.origin.x - from.origin.x) * p, from.origin.y + (to.origin.y - from.origin.y) * p,
-	    from.size.width + (to.size.width - from.size.width) * p,
-	    from.size.height + (to.size.height - from.size.height) * p);
-}
-
-// The transform that shows a proxy drawn at the origin with size `drawn` at
-// `at`: the window server maps screen to window, so the translation is
-// negated and the scale inverted.
-static CGAffineTransform mimiPlacement(CGSize drawn, CGRect at) {
-	CGAffineTransform move = CGAffineTransformMakeTranslation(-at.origin.x, -at.origin.y);
-	CGAffineTransform scale = CGAffineTransformMakeScale(drawn.width / at.size.width, drawn.height / at.size.height);
-	return CGAffineTransformConcat(move, scale);
+	CGGetDisplaysWithPoint(CGPointMake(CGRectGetMidX(proxy.from), CGRectGetMidY(proxy.from)), 16, starts, &startCount);
+	return startCount == 0 && mimiOnDisplay(proxy.to, display);
 }
 
 static BOOL mimiSameSize(CGSize a, CGSize b) {
@@ -248,139 +207,140 @@ static CFArrayRef mimiNumbers(const MimiEntry *entries, int count) {
 	return numbers;
 }
 
-// Where the proxies are at this instant of the running animation, for the
-// windows a new animation starts from. The caller holds the lock.
-static double mimiProgressLocked(void) {
-	if (gAnim.duration <= 0) {
-		return 1;
+static CAMediaTimingFunction *mimiTiming(int easing) {
+	switch (easing) {
+	case MimiEasingEaseIn:
+		return [CAMediaTimingFunction functionWithControlPoints:0.32:0:0.67:0];
+	case MimiEasingEaseOut:
+		return [CAMediaTimingFunction functionWithControlPoints:0.33:1:0.68:1];
+	case MimiEasingEaseInOut:
+		return [CAMediaTimingFunction functionWithControlPoints:0.65:0:0.35:1];
+	default:
+		return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
 	}
-	double t = (CACurrentMediaTime() - gAnim.start) / gAnim.duration;
-	return mimiEase(gAnim.easing, t < 0 ? 0 : (t > 1 ? 1 : t));
 }
 
-// Whether the window is in flight, and if so where it is now and which
-// proxy carries it.
-static BOOL mimiInFlightLocked(uint32_t number, CGRect *out, int *index) {
-	if (!gAnim.running) {
-		return NO;
+// Run block on the main thread and wait, or right here when this is it.
+static void mimiOnMain(dispatch_block_t block) {
+	if ([NSThread isMainThread]) {
+		block();
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), block);
 	}
-	double p = mimiProgressLocked();
-	for (int i = 0; i < gAnim.proxyCount; i++) {
-		if (gAnim.proxies[i].number == number) {
-			*out = mimiLerp(gAnim.proxies[i].from, gAnim.proxies[i].to, p);
-			*index = i;
-			return YES;
+}
+
+// A layer's frame in screen coordinates, as it is on screen this instant.
+static CGRect mimiPresented(CALayer *layer) {
+	CALayer *shown = layer.presentationLayer ?: layer;
+	return shown.frame;
+}
+
+// Where the window is now if it is in flight, and the proxy that carries it.
+static MimiProxy *mimiInFlight(uint32_t number, CGRect *out) {
+	if (!gRunning) {
+		return nil;
+	}
+	for (MimiProxy *proxy in gProxies) {
+		if (proxy.number == number) {
+			*out = mimiPresented(proxy.layer);
+			return proxy;
 		}
 	}
-	return NO;
+	return nil;
 }
 
-#pragma mark - Windows
-
-// Create a window of the given size at the origin, to be painted with
-// mimiPaint and placed with a transform in the caller's transaction. Returns
-// 0 when the window server refuses.
-static uint32_t mimiNewWindow(int cid, CGSize size, double scale) {
-	CGRect local = CGRectMake(0, 0, size.width, size.height);
-	CFTypeRef region = NULL;
-	if (CGSNewRegionWithRect(&local, &region) != kCGErrorSuccess || !region) {
-		return 0;
+// A window's frame from the window server, in screen coordinates.
+static BOOL mimiWindowBounds(uint32_t number, CGRect *out) {
+	const void *values[] = {(void *)(uintptr_t)number};
+	CFArrayRef ids = CFArrayCreate(NULL, values, 1, NULL);
+	CFArrayRef info = CGWindowListCreateDescriptionFromArray(ids);
+	CFRelease(ids);
+	BOOL found = NO;
+	if (info && CFArrayGetCount(info) == 1) {
+		NSDictionary *entry = (__bridge NSDictionary *)CFArrayGetValueAtIndex(info, 0);
+		found = CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)entry[(id)kCGWindowBounds], out);
 	}
-
-	uint32_t wid = 0;
-	CGError err = SLSNewWindow(cid, kMimiProxyBackingBuffered, 0, 0, region, &wid);
-	CFRelease(region);
-	if (err != kCGErrorSuccess || wid == 0) {
-		MIMI_LOG("SLSNewWindow failed with error %d", (int)err);
-		return 0;
+	if (info) {
+		CFRelease(info);
 	}
-
-	uint64_t tags = kMimiProxyTags;
-	SLSSetWindowResolution(cid, wid, scale);
-	SLSSetWindowTags(cid, wid, &tags, 64);
-	SLSSetWindowOpacity(cid, wid, false);
-	SLSSetWindowLevel(cid, wid, kMimiProxyLevel);
-
-	return wid;
+	return found;
 }
 
-// A window of the given size and scale from the pool, or 0 when it has
-// none. The caller holds the lock.
-static uint32_t mimiPooledLocked(CGSize size, double scale) {
-	for (int i = 0; i < gPoolCount; i++) {
-		if (mimiSameSize(gPool[i].size, size) && gPool[i].scale == scale) {
-			uint32_t wid = gPool[i].window;
-			gPool[i] = gPool[--gPoolCount];
-			return wid;
-		}
-	}
-	return 0;
+#pragma mark - Hosts and layers
+
+// NSWindow frames are y up from the primary display's bottom-left.
+static NSRect mimiCocoaRect(CGRect rect) {
+	double primaryHeight = CGDisplayBounds(CGMainDisplayID()).size.height;
+	return NSMakeRect(
+	    rect.origin.x, primaryHeight - rect.origin.y - rect.size.height, rect.size.width, rect.size.height);
 }
 
-// Keep an ordered-out window for the next animation, or release it when the
-// pool is full. The caller holds the lock.
-static void mimiRecycleLocked(int cid, uint32_t wid, CGSize size, double scale) {
-	if (gPoolCount < kMimiPoolSize) {
-		gPool[gPoolCount++] = (MimiPooled){.window = wid, .size = size, .scale = scale};
-		return;
+// The host for a display, made on first use, at the floating level so it
+// sits over every ordinary window and under the Dock and menu bar, passing
+// events through.
+static MimiHost *mimiHost(CGDirectDisplayID display, CGRect bounds) {
+	if (!gHosts) {
+		gHosts = [NSMutableDictionary new];
 	}
-	SLSReleaseWindow(cid, wid);
+	MimiHost *host = gHosts[@(display)];
+	if (host) {
+		return host;
+	}
+	host = [[MimiHost alloc] initWithContentRect:mimiCocoaRect(bounds)
+	                                   styleMask:NSWindowStyleMaskBorderless
+	                                     backing:NSBackingStoreBuffered
+	                                       defer:NO];
+	host.display = display;
+	host.level = NSFloatingWindowLevel;
+	host.opaque = NO;
+	host.backgroundColor = [NSColor clearColor];
+	host.hasShadow = NO;
+	host.ignoresMouseEvents = YES;
+	host.releasedWhenClosed = NO;
+	host.animationBehavior = NSWindowAnimationBehaviorNone;
+	host.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorStationary |
+	                          NSWindowCollectionBehaviorIgnoresCycle | NSWindowCollectionBehaviorFullScreenAuxiliary;
+	NSView *view = host.contentView;
+	view.wantsLayer = YES;
+	view.layer.geometryFlipped = YES;
+	view.layer.masksToBounds = NO;
+	gHosts[@(display)] = host;
+	return host;
 }
 
-// Draw picture into the window, clipped to mask's alpha when there is one,
-// and release both. A captured image is materialised the first time it is
-// read, which is most of a proxy's cost, and this is that read: the paints
-// of one animation run at once, each on its own thread.
-static void mimiPaint(int cid, uint32_t wid, CGSize size, CGImageRef picture, CGImageRef mask) {
-	CGContextRef context = SLWindowContextCreate(cid, wid, NULL);
-	if (context) {
-		CGRect whole = CGRectMake(0, 0, size.width, size.height);
-		// Copying the pixels in, alpha included, rather than compositing
-		// them over whatever the window showed last: the picture covers
-		// the window.
-		CGContextSetBlendMode(context, kCGBlendModeCopy);
-		CGContextDrawImage(context, whole, picture);
-		if (mask) {
-			CGContextSetBlendMode(context, kCGBlendModeDestinationIn);
-			CGContextDrawImage(context, whole, mask);
-		}
-		CGContextFlush(context);
-		CGContextRelease(context);
-	}
-	CGImageRelease(picture);
+// Place the host over `frame`, in screen coordinates, with its root layer's
+// coordinate space kept as screen coordinates.
+static void mimiPlaceHost(MimiHost *host, CGRect frame) {
+	[host setFrame:mimiCocoaRect(frame) display:NO];
+	CALayer *root = host.contentView.layer;
+	root.bounds = CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
+}
+
+// A layer showing image over `frame`, in screen coordinates, clipped to
+// mask's alpha when there is one. The image is shown as it is, without a
+// copy.
+static CALayer *mimiImageLayer(CGImageRef image, CGImageRef mask, CGRect frame, double scale) {
+	CALayer *layer = [CALayer layer];
+	layer.contents = (__bridge id)image;
+	layer.contentsGravity = kCAGravityResize;
+	layer.contentsScale = scale;
+	layer.frame = frame;
 	if (mask) {
-		CGImageRelease(mask);
+		CALayer *clip = [CALayer layer];
+		clip.contents = (__bridge id)mask;
+		clip.contentsGravity = kCAGravityResize;
+		clip.contentsScale = scale;
+		clip.frame = layer.bounds;
+		clip.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+		layer.mask = clip;
 	}
-}
-
-// Paint picture into a pooled window, when the pool has one of the size,
-// on the group's queue, and hand the window back in *window with *picture
-// and *mask taken. With no pooled window the picture stays for the caller
-// to make one for. The caller holds the lock.
-static void mimiPaintPooledLocked(
-    uint32_t *window, CGSize size, double scale, CGImageRef *picture, CGImageRef *mask, dispatch_group_t group,
-    dispatch_queue_t queue, int cid) {
-	uint32_t wid = mimiPooledLocked(size, scale);
-	if (!wid) {
-		return;
-	}
-	*window = wid;
-	CGImageRef image = *picture;
-	CGImageRef clip = mask ? *mask : NULL;
-	*picture = NULL;
-	if (mask) {
-		*mask = NULL;
-	}
-	dispatch_group_async(group, queue, ^{
-		mimiPaint(cid, wid, size, image, clip);
-	});
+	return layer;
 }
 
 #pragma mark - Masks
 
-// The remembered mask for a window of this size, retained, or NULL. The
-// caller holds the lock.
-static CGImageRef mimiCachedMaskLocked(uint32_t number, CGSize size, double scale) {
+// The remembered mask for a window of this size, retained, or NULL.
+static CGImageRef mimiCachedMask(uint32_t number, CGSize size, double scale) {
 	for (int i = 0; i < gMaskCount; i++) {
 		if (gMasks[i].number == number && mimiSameSize(gMasks[i].size, size) && gMasks[i].scale == scale) {
 			return CGImageRetain(gMasks[i].mask);
@@ -391,8 +351,8 @@ static CGImageRef mimiCachedMaskLocked(uint32_t number, CGSize size, double scal
 
 // Remember a mask, copied into memory of its own so the capture it was
 // cropped from can go. The window's older mask, if any, is replaced;
-// otherwise the oldest entry is. The caller holds the lock.
-static void mimiRememberMaskLocked(uint32_t number, CGSize size, double scale, CGImageRef mask) {
+// otherwise the oldest entry is.
+static void mimiRememberMask(uint32_t number, CGSize size, double scale, CGImageRef mask) {
 	size_t width = CGImageGetWidth(mask);
 	size_t height = CGImageGetHeight(mask);
 	CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
@@ -433,223 +393,94 @@ static void mimiRememberMaskLocked(uint32_t number, CGSize size, double scale, C
 
 #pragma mark - Teardown
 
-static void mimiFreeBackdrop(MimiBackdrop *backdrop) {
-	free(backdrop->shows);
-	backdrop->shows = NULL;
-	backdrop->showsCount = 0;
+// Take every layer of the current animation off screen, but for the
+// backdrops marked reused and the proxies the next animation carries, and
+// hide the hosts left empty.
+static void mimiRetire(NSArray<MimiProxy *> *carried) {
+	[CATransaction begin];
+	[CATransaction setDisableActions:YES];
+	for (MimiProxy *proxy in gProxies) {
+		if (![carried containsObject:proxy]) {
+			[proxy.layer removeFromSuperlayer];
+		}
+	}
+	for (MimiBackdrop *backdrop in gBackdrops) {
+		if (!backdrop.reused) {
+			[backdrop.layer removeFromSuperlayer];
+		}
+	}
+	[CATransaction commit];
+	for (MimiHost *host in gHosts.allValues) {
+		if (host.contentView.layer.sublayers.count == 0) {
+			[host orderOut:nil];
+		}
+	}
+	gProxies = nil;
+	gBackdrops = nil;
+	gRunning = NO;
 }
 
-// Order every window of the current animation out in the transaction,
-// commit it, and pool the windows, except the backdrops marked reused,
-// which the next animation keeps on screen. The caller holds the lock.
-static void mimiRetireLocked(int cid, CFTypeRef transaction) {
-	for (int i = 0; i < gAnim.proxyCount; i++) {
-		if (!gAnim.proxies[i].taken) {
-			SLSTransactionOrderWindow(transaction, gAnim.proxies[i].proxy, kMimiOrderOut, 0);
-		}
+static void mimiReleaseAll(void) {
+	for (MimiBackdrop *backdrop in gBackdrops) {
+		backdrop.reused = NO;
 	}
-	for (int i = 0; i < gAnim.backdropCount; i++) {
-		if (!gAnim.backdrops[i].reused) {
-			SLSTransactionOrderWindow(transaction, gAnim.backdrops[i].window, kMimiOrderOut, 0);
-		}
-	}
-	SLSTransactionCommit(transaction, 1);
-
-	for (int i = 0; i < gAnim.proxyCount; i++) {
-		if (!gAnim.proxies[i].taken) {
-			mimiRecycleLocked(cid, gAnim.proxies[i].proxy, gAnim.proxies[i].drawn, gAnim.proxies[i].scale);
-		}
-	}
-	for (int i = 0; i < gAnim.backdropCount; i++) {
-		if (!gAnim.backdrops[i].reused) {
-			mimiRecycleLocked(cid, gAnim.backdrops[i].window, gAnim.backdrops[i].bounds.size, gAnim.backdrops[i].scale);
-		}
-		mimiFreeBackdrop(&gAnim.backdrops[i]);
-	}
-	free(gAnim.proxies);
-	free(gAnim.backdrops);
-	gAnim.proxies = NULL;
-	gAnim.backdrops = NULL;
-	gAnim.proxyCount = 0;
-	gAnim.backdropCount = 0;
-	gAnim.running = NO;
-}
-
-static void mimiReleaseAllLocked(int cid, CFTypeRef transaction) {
-	for (int i = 0; i < gAnim.backdropCount; i++) {
-		gAnim.backdrops[i].reused = NO;
-	}
-	for (int i = 0; i < gAnim.proxyCount; i++) {
-		gAnim.proxies[i].taken = NO;
-	}
-	mimiRetireLocked(cid, transaction);
-}
-
-#pragma mark - Display link
-
-// The link runs on the daemon's bridge run loop, the thread the workspace
-// observer already lives on, and is made and invalidated there.
-static CADisplayLink *gLink;
-
-@interface MimiAnimationTicker : NSObject
-- (void)tick:(CADisplayLink *)link;
-@end
-
-@implementation MimiAnimationTicker
-
-- (void)tick:(CADisplayLink *)link {
-	pthread_mutex_lock(&gAnim.lock);
-	if (!gAnim.running) {
-		pthread_mutex_unlock(&gAnim.lock);
-		return;
-	}
-
-	int cid = SLSMainConnectionID();
-	double t = (CACurrentMediaTime() - gAnim.start) / gAnim.duration;
-	BOOL done = t >= 1;
-	double p = mimiEase(gAnim.easing, done ? 1 : t);
-
-	CFTypeRef transaction = SLSTransactionCreate(cid);
-	if (done) {
-		mimiReleaseAllLocked(cid, transaction);
-	} else {
-		for (int i = 0; i < gAnim.proxyCount; i++) {
-			MimiProxy *proxy = &gAnim.proxies[i];
-			SLSTransactionSetWindowTransform(
-			    transaction, proxy->proxy, 0, 0, mimiPlacement(proxy->drawn, mimiLerp(proxy->from, proxy->to, p)));
-		}
-		SLSTransactionCommit(transaction, 0);
-	}
-	CFRelease(transaction);
-
-	// Only this animation's link is ended: a new animation may have made
-	// its own since.
-	if (done && gLink == link) {
-		[link invalidate];
-		gLink = nil;
-	}
-	pthread_mutex_unlock(&gAnim.lock);
-}
-
-@end
-
-static MimiAnimationTicker *gTicker;
-
-// The screen the animation is on, for its refresh rate: the one under the
-// first window's destination, or the main screen.
-static NSScreen *mimiScreenLocked(void) {
-	if (gAnim.proxyCount > 0) {
-		CGRect to = gAnim.proxies[0].to;
-		double primaryHeight = [NSScreen screens].firstObject.frame.size.height;
-		// NSScreen frames are y-up from the primary display's bottom-left.
-		NSPoint centre = NSMakePoint(CGRectGetMidX(to), primaryHeight - CGRectGetMidY(to));
-		for (NSScreen *screen in [NSScreen screens]) {
-			if (NSPointInRect(centre, screen.frame)) {
-				return screen;
-			}
-		}
-	}
-	return [NSScreen mainScreen];
-}
-
-// Start a link on the bridge run loop. The caller holds the lock; the link
-// is made under it again on that thread, so a Start and a tick never race.
-static void mimiStartLinkLocked(void) {
-	CFRunLoopRef runLoop = GetRunLoop();
-	if (!runLoop) {
-		return;
-	}
-	if (!gTicker) {
-		gTicker = [MimiAnimationTicker new];
-	}
-	NSScreen *screen = mimiScreenLocked();
-	CFRunLoopPerformBlock(runLoop, kCFRunLoopCommonModes, ^{
-		pthread_mutex_lock(&gAnim.lock);
-		if (gLink) {
-			[gLink invalidate];
-		}
-		gLink = [screen displayLinkWithTarget:gTicker selector:@selector(tick:)];
-		[gLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
-		pthread_mutex_unlock(&gAnim.lock);
-	});
-	CFRunLoopWakeUp(runLoop);
+	mimiRetire(nil);
 }
 
 #pragma mark - Begin
 
 // A backdrop of the running animation that still shows the screen: on this
 // display, on this side of the proxies, and a still of these very windows
-// where they are now. Its picture is at most one animation old. The caller
-// holds the lock.
-static MimiBackdrop *mimiReusableLocked(CGRect bounds, BOOL over, const MimiEntry *shows, int showsCount) {
-	if (!gAnim.running) {
-		return NULL;
+// where they are now. Its picture is at most one animation old.
+static MimiBackdrop *mimiReusable(CGDirectDisplayID display, BOOL over, const MimiEntry *shows, int showsCount) {
+	if (!gRunning) {
+		return nil;
 	}
-	for (int i = 0; i < gAnim.backdropCount; i++) {
-		MimiBackdrop *backdrop = &gAnim.backdrops[i];
-		if (backdrop->over == over && mimiSameRect(backdrop->bounds, bounds) &&
-		    mimiSameEntries(backdrop->shows, backdrop->showsCount, shows, showsCount)) {
+	for (MimiBackdrop *backdrop in gBackdrops) {
+		if (backdrop.display == display && backdrop.over == over &&
+		    mimiSameEntries(backdrop.shows, backdrop.showsCount, shows, showsCount)) {
 			return backdrop;
 		}
 	}
-	return NULL;
+	return nil;
 }
 
-// Note a backdrop to make from a still of the given entries, or, when the
-// running animation has one that still shows them, to keep from it.
-static void mimiAddBackdrop(
-    MimiBackdrop *backdrops, int *count, CGRect bounds, double scale, BOOL over, const MimiEntry *shows, int showsCount,
-    CGImageRef still, MimiBackdrop *reused) {
-	if (*count >= kMimiMaxBackdrops) {
-		if (still) {
-			CGImageRelease(still);
-		}
-		return;
-	}
-	MimiBackdrop *backdrop = &backdrops[(*count)++];
-	*backdrop = (MimiBackdrop){.bounds = bounds, .scale = scale, .over = over, .still = still};
-	backdrop->shows = calloc((size_t)showsCount + 1, sizeof(MimiEntry));
-	memcpy(backdrop->shows, shows, (size_t)showsCount * sizeof(MimiEntry));
-	backdrop->showsCount = showsCount;
+static MimiBackdrop *mimiNewBackdrop(
+    CGDirectDisplayID display, CGRect bounds, BOOL over, const MimiEntry *shows, int showsCount, CGImageRef still,
+    MimiBackdrop *reused) {
+	MimiBackdrop *backdrop = [MimiBackdrop new];
+	backdrop.display = display;
+	backdrop.bounds = bounds;
+	backdrop.over = over;
+	backdrop.still = still;
+	backdrop.shows = calloc((size_t)showsCount + 1, sizeof(MimiEntry));
+	memcpy(backdrop.shows, shows, (size_t)showsCount * sizeof(MimiEntry));
+	backdrop.showsCount = showsCount;
 	if (reused) {
-		backdrop->window = reused->window;
-		backdrop->reused = YES;
-		reused->reused = YES;
+		backdrop.layer = reused.layer;
+		backdrop.reused = YES;
+		reused.reused = YES;
 	}
+	return backdrop;
 }
 
 int MimiScreenCaptureGranted(void) { return CGPreflightScreenCaptureAccess() ? 1 : 0; }
 
 void MimiAnimationWarm(void) {
-	@autoreleasepool {
-		int cid = SLSMainConnectionID();
+	if (![NSApp isRunning] && ![NSThread isMainThread]) {
+		return;
+	}
+	mimiOnMain(^{
 		CGDirectDisplayID displays[16];
 		uint32_t displayCount = 0;
 		CGGetActiveDisplayList(16, displays, &displayCount);
-
-		pthread_mutex_lock(&gAnim.lock);
 		for (uint32_t d = 0; d < displayCount; d++) {
-			CGRect bounds = CGDisplayBounds(displays[d]);
-			double scale = bounds.size.width > 0 ? CGDisplayPixelsWide(displays[d]) / bounds.size.width : 1;
-			// Two per display: the backdrop under the proxies and the one
-			// over them.
-			for (int k = 0; k < 2 && gPoolCount < kMimiPoolSize; k++) {
-				uint32_t wid = mimiNewWindow(cid, bounds.size, scale);
-				if (!wid) {
-					break;
-				}
-				CGContextRef context = SLWindowContextCreate(cid, wid, NULL);
-				if (context) {
-					CGContextClearRect(context, CGRectMake(0, 0, bounds.size.width, bounds.size.height));
-					CGContextFlush(context);
-					CGContextRelease(context);
-				}
-				mimiRecycleLocked(cid, wid, bounds.size, scale);
-			}
+			mimiHost(displays[d], CGDisplayBounds(displays[d]));
 		}
-		pthread_mutex_unlock(&gAnim.lock);
-	}
+	});
 }
+
+static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double duration, int easing);
 
 int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double duration, int easing) {
 	if (!targets || count <= 0) {
@@ -664,446 +495,425 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 	if (!granted) {
 		return -1;
 	}
-
-	@autoreleasepool {
-		int cid = SLSMainConnectionID();
-		pthread_mutex_lock(&gAnim.lock);
-
-		// Where each window starts: its current animated frame if it is
-		// animating, else where the window server has it. A window in
-		// flight to the very frame asked for again, as when the pass that
-		// follows a focus change repeats the one that made it, keeps the
-		// proxy it has, and when no window does more than that the
-		// running animation is left to finish.
-		MimiProxy *next = calloc((size_t)count, sizeof(MimiProxy));
-		int nextCount = 0;
-		int carriedCount = 0;
-		for (int i = 0; i < count; i++) {
-			CGRect from;
-			int flight = -1;
-			if (!mimiInFlightLocked(targets[i].number, &from, &flight)) {
-				if (SLSGetWindowBounds(cid, targets[i].number, &from) != kCGErrorSuccess) {
-					continue;
-				}
-			}
-			if (from.size.width <= 0 || from.size.height <= 0 || targets[i].w <= 0 || targets[i].h <= 0) {
-				continue;
-			}
-			// A window already at its frame is skipped. Most passes move few
-			// windows, or none, and cost nothing here.
-			CGRect to = CGRectMake(targets[i].x, targets[i].y, targets[i].w, targets[i].h);
-			if (mimiSameRect(from, to)) {
-				continue;
-			}
-			next[nextCount].number = targets[i].number;
-			next[nextCount].from = from;
-			next[nextCount].to = to;
-			if (flight >= 0 && mimiSameRect(gAnim.proxies[flight].to, to)) {
-				next[nextCount].carried = YES;
-				next[nextCount].proxy = gAnim.proxies[flight].proxy;
-				next[nextCount].scale = gAnim.proxies[flight].scale;
-				next[nextCount].drawn = gAnim.proxies[flight].drawn;
-				carriedCount++;
-			}
-			nextCount++;
-		}
-		if (nextCount == carriedCount) {
-			free(next);
-			pthread_mutex_unlock(&gAnim.lock);
-			return 0;
-		}
-		for (int i = 0; i < nextCount; i++) {
-			if (next[i].carried) {
-				for (int j = 0; j < gAnim.proxyCount; j++) {
-					if (gAnim.proxies[j].proxy == next[i].proxy) {
-						gAnim.proxies[j].taken = YES;
-					}
-				}
-			}
-		}
-
-		// Everything on screen but the animating windows and our own, a
-		// previous animation's proxies. The list runs front to back, and is
-		// split at the first animating window. Whatever comes before it is
-		// in front of every moving window, a floating window say, and is
-		// drawn over the proxies. The rest goes under them. under is the
-		// scene from the first animating window down, moving windows
-		// included, that the apart windows' pictures are cropped from.
-		// CGWindowListCreateImageFromArray composites a list in the order
-		// given, first on top, so every list keeps the on-screen order.
-		CFArrayRef onScreen = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
-		CFIndex onScreenCount = onScreen ? CFArrayGetCount(onScreen) : 0;
-		MimiEntry *others = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
-		MimiEntry *front = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
-		MimiEntry *under = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
-		int othersCount = 0, frontCount = 0, underCount = 0;
-		pid_t self = getpid();
-		BOOL passed = NO;
-		int depth = 0;
-		for (NSDictionary *info in (__bridge NSArray *)onScreen) {
-			if ([info[(id)kCGWindowOwnerPID] intValue] == self ||
-			    [info[(id)kCGWindowLayer] intValue] >= kMimiDockLayer) {
-				continue;
-			}
-			MimiEntry entry = {.number = [info[(id)kCGWindowNumber] unsignedIntValue]};
-			CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)info[(id)kCGWindowBounds], &entry.bounds);
-			BOOL inFlight = NO;
-			for (int i = 0; i < nextCount && !inFlight; i++) {
-				inFlight = next[i].number == entry.number;
-				if (inFlight) {
-					next[i].depth = depth;
-					next[i].listed = YES;
-				}
-			}
-			depth++;
-			if (inFlight) {
-				passed = YES;
-			} else if (passed) {
-				others[othersCount++] = entry;
-			} else {
-				front[frontCount++] = entry;
-			}
-			if (passed) {
-				under[underCount++] = entry;
-			}
-		}
-		if (onScreen) {
-			CFRelease(onScreen);
-		}
-
-		// Backdrops: at most two per display, the still of what is under
-		// the proxies and, when anything is, the still of what is over them.
-		MimiBackdrop *backdrops = calloc(kMimiMaxBackdrops, sizeof(MimiBackdrop));
-		int backdropCount = 0;
-		CGDirectDisplayID displays[16];
-		uint32_t displayCount = 0;
-		CGGetActiveDisplayList(16, displays, &displayCount);
-
-		// A capture costs the same round trip whatever its area, so the
-		// captures are what the setup waits on. Each one's paint starts
-		// as soon as it is taken, on a thread of its own, when the pool
-		// has a window for it, and runs under the captures that follow.
-		// A window the pool lacks is made only once every capture is
-		// taken, then painted at once: a capture that follows the creation
-		// of a window not yet drawn waits half a second on it, as does a
-		// request that reaches the window server while such a window
-		// waits for its first pixels.
-		dispatch_group_t paints = dispatch_group_create();
-		dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0);
-
-		for (uint32_t d = 0; d < displayCount; d++) {
-			CGRect bounds = CGDisplayBounds(displays[d]);
-			BOOL any = NO;
-			for (int i = 0; i < nextCount; i++) {
-				if (!next[i].carried && next[i].picture == NULL && mimiAnimatesOn(&next[i], bounds, displays[d])) {
-					any = YES;
-					break;
-				}
-			}
-			if (!any) {
-				continue;
-			}
-			double scale = bounds.size.width > 0 ? CGDisplayPixelsWide(displays[d]) / bounds.size.width : 1;
-
-			// The windows that overlap another animating window, as under a
-			// monocle layout, are captured one by one: a composite of the
-			// set shows only the top one. The rest are cropped from one
-			// composite of the scene. Their masks come from one composite of
-			// those windows alone, taken only for the windows whose mask is
-			// not remembered from an earlier animation.
-			MimiEntry *apart = calloc((size_t)nextCount, sizeof(MimiEntry));
-			int apartCount = 0;
-			BOOL anyAlone = NO;
-			for (int i = 0; i < nextCount; i++) {
-				if (next[i].carried || next[i].picture != NULL || !mimiAnimatesOn(&next[i], bounds, displays[d])) {
-					continue;
-				}
-				// A window off the display is not in the scene, and one
-				// not in the list has no place in it either.
-				BOOL overlaps = !next[i].listed || !mimiOnDisplay(next[i].from, bounds);
-				for (int j = 0; j < nextCount && !overlaps; j++) {
-					if (j != i && next[j].picture == NULL && mimiAnimatesOn(&next[j], bounds, displays[d])) {
-						overlaps = !CGRectIsEmpty(CGRectIntersection(next[i].from, next[j].from));
-					}
-				}
-				next[i].alone = !overlaps;
-				if (!overlaps) {
-					anyAlone = YES;
-					next[i].mask = mimiCachedMaskLocked(next[i].number, next[i].from.size, scale);
-					if (!next[i].mask) {
-						apart[apartCount++] = (MimiEntry){.number = next[i].number, .bounds = next[i].from};
-					}
-				}
-			}
-
-			// Deprecated for ScreenCaptureKit, whose screenshot is asynchronous
-			// and far slower to start; this composes the display in some ten
-			// milliseconds, which an animation that starts on the same frame
-			// as the event needs. SLSHWCaptureWindowList, the hardware
-			// capture yabai uses, was measured on macOS 26 at 6 to 10 ms per
-			// window, the cost of one of these composites of a whole display,
-			// and returns one clipped image for a list, so it captures
-			// nothing faster here. The window server serialises captures, so
-			// issuing them concurrently was measured to gain nothing, and a
-			// smaller area or a lower resolution was measured to cost the
-			// same.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-			MimiBackdrop *keptUnder = mimiReusableLocked(bounds, NO, others, othersCount);
-			if (keptUnder) {
-				mimiAddBackdrop(backdrops, &backdropCount, bounds, scale, NO, others, othersCount, NULL, keptUnder);
-			} else if (othersCount > 0) {
-				CFArrayRef list = mimiNumbers(others, othersCount);
-				CGImageRef still = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
-				CFRelease(list);
-				if (still) {
-					mimiAddBackdrop(backdrops, &backdropCount, bounds, scale, NO, others, othersCount, still, NULL);
-					mimiPaintPooledLocked(
-					    &backdrops[backdropCount - 1].window, bounds.size, scale, &backdrops[backdropCount - 1].still,
-					    NULL, paints, queue, cid);
-				}
-			}
-			MimiBackdrop *keptOver = frontCount > 0 ? mimiReusableLocked(bounds, YES, front, frontCount) : NULL;
-			if (keptOver) {
-				mimiAddBackdrop(backdrops, &backdropCount, bounds, scale, YES, front, frontCount, NULL, keptOver);
-			} else if (frontCount > 0) {
-				CFArrayRef list = mimiNumbers(front, frontCount);
-				CGImageRef cover = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
-				CFRelease(list);
-				if (cover) {
-					mimiAddBackdrop(backdrops, &backdropCount, bounds, scale, YES, front, frontCount, cover, NULL);
-					mimiPaintPooledLocked(
-					    &backdrops[backdropCount - 1].window, bounds.size, scale, &backdrops[backdropCount - 1].still,
-					    NULL, paints, queue, cid);
-				}
-			}
-			CGImageRef flight = NULL;
-			if (apartCount > 0) {
-				CFArrayRef list = mimiNumbers(apart, apartCount);
-				flight = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
-				CFRelease(list);
-			}
-			// A window captured on its own comes out opaque, with its
-			// translucent parts a flat tint, since the window server has
-			// nothing behind it to blend with. Composited with what is under
-			// it, it looks as it does on screen, so the apart windows take
-			// their picture from that scene, cropped, and their own capture
-			// only clips it to the window's shape.
-			CGImageRef scene = NULL;
-			if (anyAlone) {
-				CFArrayRef list = mimiNumbers(under, underCount);
-				scene = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
-				CFRelease(list);
-			}
-			free(apart);
-
-			for (int i = 0; i < nextCount; i++) {
-				MimiProxy *proxy = &next[i];
-				if (proxy->carried || proxy->picture != NULL || !mimiAnimatesOn(proxy, bounds, displays[d])) {
-					continue;
-				}
-				if (proxy->alone) {
-					CGRect crop = CGRectMake(
-					    (proxy->from.origin.x - bounds.origin.x) * scale,
-					    (proxy->from.origin.y - bounds.origin.y) * scale, proxy->from.size.width * scale,
-					    proxy->from.size.height * scale);
-					if (scene) {
-						proxy->picture = CGImageCreateWithImageInRect(scene, crop);
-					}
-					if (!proxy->mask && flight) {
-						proxy->mask = CGImageCreateWithImageInRect(flight, crop);
-						if (proxy->mask) {
-							mimiRememberMaskLocked(proxy->number, proxy->from.size, scale, proxy->mask);
-						}
-					}
-					if (!proxy->picture && proxy->mask) {
-						// No scene: the window's own capture is the picture.
-						proxy->picture = proxy->mask;
-						proxy->mask = NULL;
-					}
-				} else if (mimiOnDisplay(proxy->from, bounds)) {
-					proxy->picture = CGWindowListCreateImage(
-					    proxy->from, kCGWindowListOptionIncludingWindow, proxy->number, kCGWindowImageBestResolution);
-				} else {
-					// Off the display, a window has pixels only when asked
-					// for by its own bounds: a rectangle there comes back
-					// empty. Its picture is opaque, a flat tint where the
-					// window is translucent, since nothing is under it to
-					// blend with.
-					proxy->picture = CGWindowListCreateImage(
-					    CGRectNull, kCGWindowListOptionIncludingWindow, proxy->number,
-					    kCGWindowImageBoundsIgnoreFraming | kCGWindowImageBestResolution);
-				}
-				proxy->scale = scale;
-				proxy->drawn = proxy->from.size;
-				if (!proxy->picture) {
-					MIMI_LOG("animation: capturing window %u failed", proxy->number);
-					if (proxy->mask) {
-						CGImageRelease(proxy->mask);
-						proxy->mask = NULL;
-					}
-					continue;
-				}
-				mimiPaintPooledLocked(
-				    &proxy->proxy, proxy->from.size, scale, &proxy->picture, &proxy->mask, paints, queue, cid);
-			}
-#pragma clang diagnostic pop
-
-			if (flight) {
-				CGImageRelease(flight);
-			}
-			if (scene) {
-				CGImageRelease(scene);
-			}
-		}
-		free(others);
-		free(front);
-		free(under);
-
-		// The windows the pool had none of, made now and painted the moment
-		// they exist. A picture still held here is one waiting for such a
-		// window.
-		int kept = 0;
-		for (int i = 0; i < backdropCount; i++) {
-			MimiBackdrop *backdrop = &backdrops[i];
-			if (backdrop->still) {
-				backdrop->window = mimiNewWindow(cid, backdrop->bounds.size, backdrop->scale);
-				if (backdrop->window) {
-					mimiPaint(cid, backdrop->window, backdrop->bounds.size, backdrop->still, NULL);
-				} else {
-					CGImageRelease(backdrop->still);
-				}
-				backdrop->still = NULL;
-			}
-			if (backdrop->window) {
-				backdrops[kept++] = *backdrop;
-			} else {
-				mimiFreeBackdrop(backdrop);
-			}
-		}
-		backdropCount = kept;
-		for (int i = 0; i < nextCount; i++) {
-			if (!next[i].picture) {
-				continue;
-			}
-			next[i].proxy = mimiNewWindow(cid, next[i].from.size, next[i].scale);
-			if (next[i].proxy) {
-				mimiPaint(cid, next[i].proxy, next[i].from.size, next[i].picture, next[i].mask);
-			} else {
-				CGImageRelease(next[i].picture);
-				if (next[i].mask) {
-					CGImageRelease(next[i].mask);
-				}
-			}
-			next[i].picture = NULL;
-			next[i].mask = NULL;
-		}
-		dispatch_group_wait(paints, DISPATCH_TIME_FOREVER);
-
-		// Keep the proxies that were made, in order.
-		kept = 0;
-		for (int i = 0; i < nextCount; i++) {
-			if (next[i].proxy != 0) {
-				next[kept++] = next[i];
-			}
-		}
-
-		// One commit: the under backdrops come in, the new proxies over
-		// them, the over backdrops on top, and the previous animation, if
-		// any, goes out, but for the backdrops this one keeps.
-		CFTypeRef transaction = SLSTransactionCreate(cid);
-		for (int i = 0; i < backdropCount; i++) {
-			if (backdrops[i].reused) {
-				continue;
-			}
-			SLSTransactionSetWindowTransform(
-			    transaction, backdrops[i].window, 0, 0, mimiPlacement(backdrops[i].bounds.size, backdrops[i].bounds));
-			if (!backdrops[i].over) {
-				SLSTransactionOrderWindow(transaction, backdrops[i].window, kMimiOrderAbove, 0);
-			}
-		}
-		// The proxies go in back to front, each above everything, so they
-		// stack as their windows do on screen.
-		for (int i = 0; i < kept; i++) {
-			int back = 0;
-			for (int j = 1; j < kept; j++) {
-				if (next[j].depth > next[back].depth) {
-					back = j;
-				}
-			}
-			SLSTransactionSetWindowTransform(
-			    transaction, next[back].proxy, 0, 0, mimiPlacement(next[back].drawn, next[back].from));
-			SLSTransactionOrderWindow(transaction, next[back].proxy, kMimiOrderAbove, 0);
-			next[back].depth = -1;
-		}
-		for (int i = 0; i < backdropCount; i++) {
-			if (backdrops[i].over) {
-				SLSTransactionOrderWindow(transaction, backdrops[i].window, kMimiOrderAbove, 0);
-			}
-		}
-		mimiRetireLocked(cid, transaction);
-		CFRelease(transaction);
-
-		gAnim.proxies = next;
-		gAnim.proxyCount = kept;
-		gAnim.backdrops = backdrops;
-		gAnim.backdropCount = backdropCount;
-		gAnim.duration = duration;
-		gAnim.easing = easing;
-		gAnim.running = NO;
-
-		pthread_mutex_unlock(&gAnim.lock);
-		return kept;
+	// Without an application loop, as in the CLI, there is nothing to run
+	// the animation on, and the frames move at once.
+	if (![NSApp isRunning]) {
+		return 0;
 	}
+
+	__block int kept = 0;
+	mimiOnMain(^{
+		@autoreleasepool {
+			kept = mimiBeginOnMain(targets, count, duration, easing);
+		}
+	});
+	return kept;
 }
 
-void MimiAnimationStart(const uint32_t *dropped, int count) {
-	int cid = SLSMainConnectionID();
-	pthread_mutex_lock(&gAnim.lock);
-	if (gAnim.running || (gAnim.proxyCount == 0 && gAnim.backdropCount == 0)) {
-		pthread_mutex_unlock(&gAnim.lock);
-		return;
+static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double duration, int easing) {
+	// Where each window starts: its current animated frame if it is
+	// animating, else where the window server has it. A window in flight
+	// to the very frame asked for again, as when the pass that follows a
+	// focus change repeats the one that made it, keeps the proxy it has,
+	// and when no window does more than that the running animation is
+	// left to finish.
+	NSMutableArray<MimiProxy *> *next = [NSMutableArray arrayWithCapacity:(NSUInteger)count];
+	NSMutableArray<MimiProxy *> *carried = [NSMutableArray array];
+	for (int i = 0; i < count; i++) {
+		CGRect from;
+		MimiProxy *flight = mimiInFlight(targets[i].number, &from);
+		if (!flight && !mimiWindowBounds(targets[i].number, &from)) {
+			continue;
+		}
+		if (from.size.width <= 0 || from.size.height <= 0 || targets[i].w <= 0 || targets[i].h <= 0) {
+			continue;
+		}
+		// A window already at its frame is skipped. Most passes move few
+		// windows, or none, and cost nothing here.
+		CGRect to = CGRectMake(targets[i].x, targets[i].y, targets[i].w, targets[i].h);
+		if (mimiSameRect(from, to)) {
+			continue;
+		}
+		MimiProxy *proxy = [MimiProxy new];
+		proxy.number = targets[i].number;
+		proxy.from = from;
+		proxy.to = to;
+		if (flight && mimiSameRect(flight.to, to)) {
+			proxy.carried = YES;
+			proxy.layer = flight.layer;
+			proxy.scale = flight.scale;
+			[carried addObject:flight];
+		}
+		[next addObject:proxy];
+	}
+	if (next.count == carried.count) {
+		return 0;
 	}
 
-	CFTypeRef transaction = SLSTransactionCreate(cid);
-	int kept = 0;
-	for (int i = 0; i < gAnim.proxyCount; i++) {
-		BOOL drop = NO;
-		for (int j = 0; j < count; j++) {
-			if (dropped[j] == gAnim.proxies[i].number) {
-				drop = YES;
+	// Everything on screen but the animating windows and our own. The list
+	// runs front to back, and is split at the first animating window.
+	// Whatever comes before it is in front of every moving window, a
+	// floating window say, and is drawn over the proxies. The rest goes
+	// under them. under is the scene from the first animating window down,
+	// moving windows included, that the apart windows' pictures are cropped
+	// from. CGWindowListCreateImageFromArray composites a list in the order
+	// given, first on top, so every list keeps the on-screen order.
+	CFArrayRef onScreen = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+	CFIndex onScreenCount = onScreen ? CFArrayGetCount(onScreen) : 0;
+	MimiEntry *others = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
+	MimiEntry *front = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
+	MimiEntry *under = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
+	int othersCount = 0, frontCount = 0, underCount = 0;
+	pid_t self = getpid();
+	BOOL passed = NO;
+	int depth = 0;
+	for (NSDictionary *info in (__bridge NSArray *)onScreen) {
+		if ([info[(id)kCGWindowOwnerPID] intValue] == self || [info[(id)kCGWindowLayer] intValue] >= kMimiDockLayer) {
+			continue;
+		}
+		MimiEntry entry = {.number = [info[(id)kCGWindowNumber] unsignedIntValue]};
+		CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)info[(id)kCGWindowBounds], &entry.bounds);
+		BOOL inFlight = NO;
+		for (MimiProxy *proxy in next) {
+			if (proxy.number == entry.number) {
+				proxy.depth = depth;
+				proxy.listed = YES;
+				inFlight = YES;
 				break;
 			}
 		}
-		if (drop) {
-			SLSTransactionOrderWindow(transaction, gAnim.proxies[i].proxy, kMimiOrderOut, 0);
-			mimiRecycleLocked(cid, gAnim.proxies[i].proxy, gAnim.proxies[i].drawn, gAnim.proxies[i].scale);
+		depth++;
+		if (inFlight) {
+			passed = YES;
+		} else if (passed) {
+			others[othersCount++] = entry;
 		} else {
-			gAnim.proxies[kept++] = gAnim.proxies[i];
+			front[frontCount++] = entry;
+		}
+		if (passed) {
+			under[underCount++] = entry;
 		}
 	}
-	gAnim.proxyCount = kept;
+	if (onScreen) {
+		CFRelease(onScreen);
+	}
 
-	if (kept == 0) {
-		mimiReleaseAllLocked(cid, transaction);
-		CFRelease(transaction);
-		pthread_mutex_unlock(&gAnim.lock);
+	// Backdrops: at most two per display, the still of what is under the
+	// proxies and, when anything is, the still of what is over them.
+	NSMutableArray<MimiBackdrop *> *backdrops = [NSMutableArray array];
+	CGDirectDisplayID displays[16];
+	uint32_t displayCount = 0;
+	CGGetActiveDisplayList(16, displays, &displayCount);
+
+	for (uint32_t d = 0; d < displayCount; d++) {
+		CGRect bounds = CGDisplayBounds(displays[d]);
+		BOOL any = NO;
+		for (MimiProxy *proxy in next) {
+			if (!proxy.carried && !proxy.picture && mimiAnimatesOn(proxy, bounds)) {
+				any = YES;
+				break;
+			}
+		}
+		if (!any) {
+			continue;
+		}
+		double scale = bounds.size.width > 0 ? CGDisplayPixelsWide(displays[d]) / bounds.size.width : 1;
+
+		// The windows that overlap another animating window, as under a
+		// monocle layout, are captured one by one: a composite of the set
+		// shows only the top one. The rest are cropped from one composite
+		// of the scene. Their masks come from one composite of those
+		// windows alone, taken only for the windows whose mask is not
+		// remembered from an earlier animation.
+		MimiEntry *apart = calloc(next.count, sizeof(MimiEntry));
+		int apartCount = 0;
+		BOOL anyAlone = NO;
+		for (MimiProxy *proxy in next) {
+			if (proxy.carried || proxy.picture || !mimiAnimatesOn(proxy, bounds)) {
+				continue;
+			}
+			// A window off the display is not in the scene, and one not in
+			// the list has no place in it either.
+			BOOL overlaps = !proxy.listed || !mimiOnDisplay(proxy.from, bounds);
+			for (MimiProxy *other in next) {
+				if (overlaps) {
+					break;
+				}
+				if (other != proxy && !other.picture && mimiAnimatesOn(other, bounds)) {
+					overlaps = !CGRectIsEmpty(CGRectIntersection(proxy.from, other.from));
+				}
+			}
+			proxy.alone = !overlaps;
+			if (!overlaps) {
+				anyAlone = YES;
+				proxy.mask = mimiCachedMask(proxy.number, proxy.from.size, scale);
+				if (!proxy.mask) {
+					apart[apartCount++] = (MimiEntry){.number = proxy.number, .bounds = proxy.from};
+				}
+			}
+		}
+
+		// Deprecated for ScreenCaptureKit, whose screenshot is asynchronous
+		// and far slower to start; this composes the display in some ten
+		// milliseconds, which an animation that starts on the same frame as
+		// the event needs. SLSHWCaptureWindowList, the hardware capture
+		// yabai uses, was measured on macOS 26 at 6 to 10 ms per window,
+		// the cost of one of these composites of a whole display, and
+		// returns one clipped image for a list, so it captures nothing
+		// faster here. The window server serialises captures, so issuing
+		// them concurrently was measured to gain nothing, and a smaller
+		// area or a lower resolution was measured to cost the same.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		MimiBackdrop *keptUnder = mimiReusable(displays[d], NO, others, othersCount);
+		if (keptUnder) {
+			[backdrops addObject:mimiNewBackdrop(displays[d], bounds, NO, others, othersCount, NULL, keptUnder)];
+		} else if (othersCount > 0) {
+			CFArrayRef list = mimiNumbers(others, othersCount);
+			CGImageRef still = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+			CFRelease(list);
+			if (still) {
+				[backdrops addObject:mimiNewBackdrop(displays[d], bounds, NO, others, othersCount, still, nil)];
+			}
+		}
+		MimiBackdrop *keptOver = frontCount > 0 ? mimiReusable(displays[d], YES, front, frontCount) : nil;
+		if (keptOver) {
+			[backdrops addObject:mimiNewBackdrop(displays[d], bounds, YES, front, frontCount, NULL, keptOver)];
+		} else if (frontCount > 0) {
+			CFArrayRef list = mimiNumbers(front, frontCount);
+			CGImageRef cover = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+			CFRelease(list);
+			if (cover) {
+				[backdrops addObject:mimiNewBackdrop(displays[d], bounds, YES, front, frontCount, cover, nil)];
+			}
+		}
+		CGImageRef flight = NULL;
+		if (apartCount > 0) {
+			CFArrayRef list = mimiNumbers(apart, apartCount);
+			flight = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+			CFRelease(list);
+		}
+		// A window captured on its own comes out opaque, with its
+		// translucent parts a flat tint, since the window server has
+		// nothing behind it to blend with. Composited with what is under
+		// it, it looks as it does on screen, so the apart windows take
+		// their picture from that scene, cropped, and their own capture
+		// only clips it to the window's shape.
+		CGImageRef scene = NULL;
+		if (anyAlone) {
+			CFArrayRef list = mimiNumbers(under, underCount);
+			scene = CGWindowListCreateImageFromArray(bounds, list, kCGWindowImageBestResolution);
+			CFRelease(list);
+		}
+		free(apart);
+
+		for (MimiProxy *proxy in next) {
+			if (proxy.carried || proxy.picture || !mimiAnimatesOn(proxy, bounds)) {
+				continue;
+			}
+			if (proxy.alone) {
+				CGRect crop = CGRectMake(
+				    (proxy.from.origin.x - bounds.origin.x) * scale, (proxy.from.origin.y - bounds.origin.y) * scale,
+				    proxy.from.size.width * scale, proxy.from.size.height * scale);
+				if (scene) {
+					proxy.picture = CGImageCreateWithImageInRect(scene, crop);
+				}
+				if (!proxy.mask && flight) {
+					proxy.mask = CGImageCreateWithImageInRect(flight, crop);
+					if (proxy.mask) {
+						mimiRememberMask(proxy.number, proxy.from.size, scale, proxy.mask);
+					}
+				}
+				if (!proxy.picture && proxy.mask) {
+					// No scene: the window's own capture is the picture.
+					proxy.picture = proxy.mask;
+					proxy.mask = NULL;
+				}
+			} else if (mimiOnDisplay(proxy.from, bounds)) {
+				proxy.picture = CGWindowListCreateImage(
+				    proxy.from, kCGWindowListOptionIncludingWindow, proxy.number, kCGWindowImageBestResolution);
+			} else {
+				// Off the display, a window has pixels only when asked for
+				// by its own bounds: a rectangle there comes back empty. Its
+				// picture is opaque, a flat tint where the window is
+				// translucent, since nothing is under it to blend with.
+				proxy.picture = CGWindowListCreateImage(
+				    CGRectNull, kCGWindowListOptionIncludingWindow, proxy.number,
+				    kCGWindowImageBoundsIgnoreFraming | kCGWindowImageBestResolution);
+			}
+			proxy.scale = scale;
+			if (!proxy.picture) {
+				MIMI_LOG("animation: capturing window %u failed", proxy.number);
+				if (proxy.mask) {
+					CGImageRelease(proxy.mask);
+					proxy.mask = NULL;
+				}
+			}
+		}
+#pragma clang diagnostic pop
+
+		if (flight) {
+			CGImageRelease(flight);
+		}
+		if (scene) {
+			CGImageRelease(scene);
+		}
+
+		// The host covers the display and wherever a proxy starts off it.
+		CGRect reach = bounds;
+		for (MimiProxy *proxy in next) {
+			if ((proxy.picture || proxy.carried) && mimiAnimatesOn(proxy, bounds)) {
+				reach = CGRectUnion(reach, proxy.from);
+			}
+		}
+		mimiPlaceHost(mimiHost(displays[d], bounds), reach);
+	}
+	free(others);
+	free(front);
+	free(under);
+
+	// Then the layers, in one transaction: the under backdrops come in, the
+	// proxies over them back to front, the over backdrops on top, and the
+	// previous animation, if any, goes out, but for what this one keeps.
+	[CATransaction begin];
+	[CATransaction setDisableActions:YES];
+	for (MimiBackdrop *backdrop in backdrops) {
+		if (backdrop.reused || backdrop.over) {
+			continue;
+		}
+		backdrop.layer = mimiImageLayer(backdrop.still, NULL, backdrop.bounds, 1);
+		CGImageRelease(backdrop.still);
+		backdrop.still = NULL;
+		[mimiHost(backdrop.display, backdrop.bounds).contentView.layer addSublayer:backdrop.layer];
+	}
+	NSMutableArray<MimiProxy *> *made = [NSMutableArray array];
+	for (MimiProxy *proxy in next) {
+		if (proxy.carried || proxy.picture) {
+			[made addObject:proxy];
+		}
+	}
+	[made sortUsingComparator:^NSComparisonResult(MimiProxy *a, MimiProxy *b) {
+		return a.depth > b.depth ? NSOrderedAscending : (a.depth < b.depth ? NSOrderedDescending : NSOrderedSame);
+	}];
+	for (MimiProxy *proxy in made) {
+		if (!proxy.carried) {
+			proxy.layer = mimiImageLayer(proxy.picture, proxy.mask, proxy.from, proxy.scale);
+			CGImageRelease(proxy.picture);
+			proxy.picture = NULL;
+			if (proxy.mask) {
+				CGImageRelease(proxy.mask);
+				proxy.mask = NULL;
+			}
+		}
+		// Every proxy goes to the top of its host, carried ones included,
+		// so they stack as their windows do.
+		CALayer *root = proxy.layer.superlayer;
+		if (!root) {
+			for (MimiHost *host in gHosts.allValues) {
+				if (mimiAnimatesOn(proxy, CGDisplayBounds(host.display))) {
+					root = host.contentView.layer;
+					break;
+				}
+			}
+		}
+		[proxy.layer removeFromSuperlayer];
+		[root addSublayer:proxy.layer];
+	}
+	for (MimiBackdrop *backdrop in backdrops) {
+		if (!backdrop.over) {
+			continue;
+		}
+		if (!backdrop.reused) {
+			backdrop.layer = mimiImageLayer(backdrop.still, NULL, backdrop.bounds, 1);
+			CGImageRelease(backdrop.still);
+			backdrop.still = NULL;
+		}
+		[backdrop.layer removeFromSuperlayer];
+		[mimiHost(backdrop.display, backdrop.bounds).contentView.layer addSublayer:backdrop.layer];
+	}
+	[CATransaction commit];
+	mimiRetire(carried);
+	for (MimiHost *host in gHosts.allValues) {
+		if (host.contentView.layer.sublayers.count > 0 && !host.visible) {
+			[host orderFrontRegardless];
+		}
+	}
+
+	gProxies = made;
+	gBackdrops = backdrops;
+	gDuration = duration;
+	gEasing = easing;
+	gRunning = NO;
+	return (int)made.count;
+}
+
+void MimiAnimationStart(const uint32_t *dropped, int count) {
+	if (![NSApp isRunning]) {
 		return;
 	}
-	SLSTransactionCommit(transaction, 1);
-	CFRelease(transaction);
+	mimiOnMain(^{
+		if (gRunning || (gProxies.count == 0 && gBackdrops.count == 0)) {
+			return;
+		}
 
-	if (!GetRunLoop()) {
-		// No run loop to tick on, as in the CLI, so the proxies are removed
-		// at once.
-		CFTypeRef teardown = SLSTransactionCreate(cid);
-		mimiReleaseAllLocked(cid, teardown);
-		CFRelease(teardown);
-		pthread_mutex_unlock(&gAnim.lock);
-		return;
-	}
-	gAnim.start = CACurrentMediaTime();
-	gAnim.running = YES;
-	mimiStartLinkLocked();
-	pthread_mutex_unlock(&gAnim.lock);
+		NSMutableArray<MimiProxy *> *kept = [NSMutableArray array];
+		[CATransaction begin];
+		[CATransaction setDisableActions:YES];
+		for (MimiProxy *proxy in gProxies) {
+			BOOL drop = NO;
+			for (int j = 0; j < count; j++) {
+				if (dropped[j] == proxy.number) {
+					drop = YES;
+					break;
+				}
+			}
+			if (drop) {
+				[proxy.layer removeFromSuperlayer];
+			} else {
+				[kept addObject:proxy];
+			}
+		}
+		[CATransaction commit];
+		gProxies = kept;
+
+		if (kept.count == 0) {
+			mimiReleaseAll();
+			return;
+		}
+
+		// The motion runs on the render server from here: one transaction
+		// gives every proxy its destination, from wherever it is shown this
+		// instant, and the callback at its end takes the animation down,
+		// unless another has replaced it since.
+		unsigned generation = ++gGeneration;
+		[CATransaction begin];
+		[CATransaction setAnimationDuration:gDuration];
+		[CATransaction setAnimationTimingFunction:mimiTiming(gEasing)];
+		[CATransaction setCompletionBlock:^{
+			if (gGeneration == generation && gRunning) {
+				mimiReleaseAll();
+			}
+		}];
+		for (MimiProxy *proxy in kept) {
+			CALayer *layer = proxy.layer;
+			CGRect shown = mimiPresented(layer);
+			CGRect to = proxy.to;
+			CGPoint start = CGPointMake(CGRectGetMidX(shown), CGRectGetMidY(shown));
+			CGPoint end = CGPointMake(CGRectGetMidX(to), CGRectGetMidY(to));
+
+			CABasicAnimation *move = [CABasicAnimation animationWithKeyPath:@"position"];
+			move.fromValue = [NSValue valueWithPoint:NSPointFromCGPoint(start)];
+			move.toValue = [NSValue valueWithPoint:NSPointFromCGPoint(end)];
+			CABasicAnimation *size = [CABasicAnimation animationWithKeyPath:@"bounds"];
+			size.fromValue = [NSValue valueWithRect:NSMakeRect(0, 0, shown.size.width, shown.size.height)];
+			size.toValue = [NSValue valueWithRect:NSMakeRect(0, 0, to.size.width, to.size.height)];
+
+			layer.position = end;
+			layer.bounds = CGRectMake(0, 0, to.size.width, to.size.height);
+			[layer addAnimation:move forKey:@"position"];
+			[layer addAnimation:size forKey:@"bounds"];
+		}
+		[CATransaction commit];
+		gRunning = YES;
+	});
 }

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -78,6 +78,15 @@ double *MimiGetWindowFrame(void *window);
 int MimiSetWindowFrame(void *window, double x, double y, double w, double h);
 int MimiSetWindowPosition(void *window, double x, double y);
 
+/// Doubles per window in MimiCopyOnScreenWindows' result: number, x, y,
+/// width, height, and whether the window server named it.
+#define MIMI_WINDOW_DOUBLES 6
+
+/// Every on-screen window as the window server lists it, front to back,
+/// with its name in *names when Screen Recording is granted. The caller
+/// frees the rows and each name.
+double *MimiCopyOnScreenWindows(int *count, char ***names);
+
 #pragma mark - Tiling Margins
 
 bool MimiTiledWindowMarginsEnabled(void);

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -76,6 +76,7 @@ double *MimiCopyScreenFrames(int *count);
 
 double *MimiGetWindowFrame(void *window);
 int MimiSetWindowFrame(void *window, double x, double y, double w, double h);
+int MimiSetWindowPosition(void *window, double x, double y);
 
 #pragma mark - Tiling Margins
 

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -78,14 +78,20 @@ double *MimiGetWindowFrame(void *window);
 int MimiSetWindowFrame(void *window, double x, double y, double w, double h);
 int MimiSetWindowPosition(void *window, double x, double y);
 
-/// Doubles per window in MimiCopyOnScreenWindows' result: number, x, y,
-/// width, height, and whether the window server named it.
-#define MIMI_WINDOW_DOUBLES 6
+/// Doubles per window in MimiCopyWindowList's result: number, x, y, width,
+/// height, whether the window server named it, owner pid, layer, and whether
+/// the owner is a regular, visible application.
+#define MIMI_WINDOW_DOUBLES 9
 
-/// Every on-screen window as the window server lists it, front to back,
-/// with its name in *names when Screen Recording is granted. The caller
-/// frees the rows and each name.
-double *MimiCopyOnScreenWindows(int *count, char ***names);
+/// Every window as the window server lists it, front to back, on screen only
+/// or on every space, with its name in *names when Screen Recording is
+/// granted. The caller frees the rows and each name.
+double *MimiCopyWindowList(int onScreenOnly, int *count, char ***names);
+
+/// An application's windows as Accessibility lists them, each with its
+/// window server number and whether its role is a window, for the ones that
+/// have a number. The caller releases each element and frees the arrays.
+void **MimiCopyApplicationWindowElements(int pid, int *count, unsigned int **numbers, int **windows);
 
 #pragma mark - Tiling Margins
 

--- a/internal/native/window.go
+++ b/internal/native/window.go
@@ -225,6 +225,32 @@ func (e *Element) SetFrame(posX, posY, width, height float64) error {
 	return nil
 }
 
+// SetPosition moves the window to (x, y) in screen coordinates, leaving its
+// size alone: one round trip into the application where SetFrame makes
+// three.
+func (e *Element) SetPosition(posX, posY float64) error {
+	if e.ref == nil {
+		return derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"cannot set window position: element reference is nil",
+		)
+	}
+
+	result := C.MimiSetWindowPosition(
+		e.ref,
+		C.double(posX),
+		C.double(posY), //nolint:nlreturn
+	)
+	if result == 0 {
+		return derrors.New(
+			derrors.CodeAccessibilityFailed,
+			"failed to set window position",
+		)
+	}
+
+	return nil
+}
+
 // PrimaryScreenHeight returns the height of the primary display (the one with the menu bar).
 // This is needed to convert between AX (y-down) and NSScreen (y-up) coordinate systems.
 func PrimaryScreenHeight() (float64, error) {

--- a/internal/native/window.go
+++ b/internal/native/window.go
@@ -251,6 +251,58 @@ func (e *Element) SetPosition(posX, posY float64) error {
 	return nil
 }
 
+// OnScreenWindow is one window as the window server lists it: its number,
+// its frame in screen coordinates, and its title when the window server
+// gives it, which it does only with Screen Recording granted.
+type OnScreenWindow struct {
+	Number uint32
+	Frame  Frame
+	Title  string
+	Named  bool
+}
+
+// OnScreenWindows lists every on-screen window, front to back, in one call
+// to the window server: no application is asked anything.
+func OnScreenWindows() []OnScreenWindow {
+	var (
+		count C.int
+		names **C.char
+	)
+
+	rows := C.MimiCopyOnScreenWindows(&count, &names) //nolint:nlreturn // cgo call expansion
+	if rows == nil {
+		return nil
+	}
+	defer C.free(unsafe.Pointer(rows)) //nolint:nlreturn
+
+	total := int(count)
+	perWindow := int(C.MIMI_WINDOW_DOUBLES)
+	values := unsafe.Slice((*C.double)(unsafe.Pointer(rows)), total*perWindow)
+	titles := unsafe.Slice(names, total)
+	windows := make([]OnScreenWindow, total)
+
+	for index := range windows {
+		row := values[index*perWindow : (index+1)*perWindow]
+		windows[index] = OnScreenWindow{
+			Number: uint32(row[0]),
+			Frame: Frame{
+				X: float64(row[1]),
+				Y: float64(row[2]),
+				W: float64(row[3]),
+				H: float64(row[4]),
+			},
+			Title: C.GoString(titles[index]),
+			Named: row[5] != 0,
+		}
+
+		C.free(unsafe.Pointer(titles[index]))
+	}
+
+	C.free(unsafe.Pointer(names))
+
+	return windows
+}
+
 // PrimaryScreenHeight returns the height of the primary display (the one with the menu bar).
 // This is needed to convert between AX (y-down) and NSScreen (y-up) coordinate systems.
 func PrimaryScreenHeight() (float64, error) {

--- a/internal/native/window.go
+++ b/internal/native/window.go
@@ -251,25 +251,35 @@ func (e *Element) SetPosition(posX, posY float64) error {
 	return nil
 }
 
-// OnScreenWindow is one window as the window server lists it: its number,
-// its frame in screen coordinates, and its title when the window server
-// gives it, which it does only with Screen Recording granted.
-type OnScreenWindow struct {
-	Number uint32
-	Frame  Frame
-	Title  string
-	Named  bool
+// ListedWindow is one window as the window server lists it: its number, its
+// frame in screen coordinates, its owner, its layer, whether the owner is a
+// regular, visible application, and its title when the window server gives
+// it, which it does only with Screen Recording granted.
+type ListedWindow struct {
+	Number  uint32
+	Frame   Frame
+	PID     int
+	Layer   int
+	Regular bool
+	Title   string
+	Named   bool
 }
 
-// OnScreenWindows lists every on-screen window, front to back, in one call
-// to the window server: no application is asked anything.
-func OnScreenWindows() []OnScreenWindow {
+// WindowList lists every window the window server has, front to back, in
+// one call: on screen only, or on every space. No application is asked
+// anything.
+func WindowList(onScreenOnly bool) []ListedWindow {
 	var (
 		count C.int
 		names **C.char
 	)
 
-	rows := C.MimiCopyOnScreenWindows(&count, &names) //nolint:nlreturn // cgo call expansion
+	flag := C.int(0)
+	if onScreenOnly {
+		flag = 1
+	}
+
+	rows := C.MimiCopyWindowList(flag, &count, &names) //nolint:nlreturn // cgo call expansion
 	if rows == nil {
 		return nil
 	}
@@ -279,11 +289,11 @@ func OnScreenWindows() []OnScreenWindow {
 	perWindow := int(C.MIMI_WINDOW_DOUBLES)
 	values := unsafe.Slice((*C.double)(unsafe.Pointer(rows)), total*perWindow)
 	titles := unsafe.Slice(names, total)
-	windows := make([]OnScreenWindow, total)
+	windows := make([]ListedWindow, total)
 
 	for index := range windows {
 		row := values[index*perWindow : (index+1)*perWindow]
-		windows[index] = OnScreenWindow{
+		windows[index] = ListedWindow{
 			Number: uint32(row[0]),
 			Frame: Frame{
 				X: float64(row[1]),
@@ -291,14 +301,66 @@ func OnScreenWindows() []OnScreenWindow {
 				W: float64(row[3]),
 				H: float64(row[4]),
 			},
-			Title: C.GoString(titles[index]),
-			Named: row[5] != 0,
+			Named:   row[5] != 0,
+			PID:     int(row[6]),
+			Layer:   int(row[7]),
+			Regular: row[8] != 0,
+			Title:   C.GoString(titles[index]),
 		}
 
 		C.free(unsafe.Pointer(titles[index]))
 	}
 
 	C.free(unsafe.Pointer(names))
+
+	return windows
+}
+
+// ApplicationWindow is one of an application's windows as Accessibility
+// lists it: the element, its window server number, and whether its role is
+// a window rather than a sheet, a popover or the like.
+type ApplicationWindow struct {
+	Element  *Element
+	Number   uint32
+	IsWindow bool
+}
+
+// ApplicationWindowElements asks one application for its windows: a round
+// trip into it, so a caller asks only when it must.
+func ApplicationWindowElements(pid int) []ApplicationWindow {
+	var (
+		count   C.int
+		numbers *C.uint
+		roles   *C.int
+	)
+
+	elements := C.MimiCopyApplicationWindowElements(
+		C.int(pid),
+		&count,
+		&numbers,
+		&roles, //nolint:nlreturn
+	)
+	if elements == nil {
+		return nil
+	}
+
+	total := int(count)
+	refs := unsafe.Slice((*unsafe.Pointer)(unsafe.Pointer(elements)), total)
+	ids := unsafe.Slice(numbers, total)
+	isWindow := unsafe.Slice(roles, total)
+	windows := make([]ApplicationWindow, total)
+
+	for index := range windows {
+		windows[index] = ApplicationWindow{
+			Element:  &Element{ref: refs[index]},
+			Number:   uint32(ids[index]),
+			IsWindow: isWindow[index] != 0,
+		}
+	}
+
+	C.free(unsafe.Pointer(elements))
+	C.free(unsafe.Pointer(numbers))
+	C.free(unsafe.Pointer(roles))
 
 	return windows
 }

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -526,7 +526,7 @@ double *MimiGetWindowFrame(void *window) {
 	}
 }
 
-double *MimiCopyOnScreenWindows(int *count, char ***names) {
+double *MimiCopyWindowList(int onScreenOnly, int *count, char ***names) {
 	if (!count) {
 		return NULL;
 	}
@@ -536,18 +536,31 @@ double *MimiCopyOnScreenWindows(int *count, char ***names) {
 	}
 
 	@autoreleasepool {
-		CFArrayRef list = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+		CGWindowListOption option = onScreenOnly ? kCGWindowListOptionOnScreenOnly : kCGWindowListOptionAll;
+		CFArrayRef list = CGWindowListCopyWindowInfo(option, kCGNullWindowID);
 		if (!list) {
 			return NULL;
 		}
 		CFIndex total = CFArrayGetCount(list);
 		double *rows = calloc((size_t)total * MIMI_WINDOW_DOUBLES, sizeof(double));
 		char **titles = calloc((size_t)total + 1, sizeof(char *));
+		// Whether each owner is a regular, visible application, looked up
+		// once per owner: it is what makes a window's owner an application
+		// rather than a border drawer or an overlay.
+		NSMutableDictionary<NSNumber *, NSNumber *> *regular = [NSMutableDictionary dictionary];
 		int kept = 0;
 		for (NSDictionary *info in (__bridge NSArray *)list) {
 			CGRect rect;
 			if (!CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)info[(id)kCGWindowBounds], &rect)) {
 				continue;
+			}
+			NSNumber *pid = info[(id)kCGWindowOwnerPID];
+			NSNumber *isRegular = regular[pid];
+			if (!isRegular) {
+				NSRunningApplication *app =
+				    [NSRunningApplication runningApplicationWithProcessIdentifier:(pid_t)pid.intValue];
+				isRegular = @(app && app.activationPolicy == NSApplicationActivationPolicyRegular && !app.hidden);
+				regular[pid] = isRegular;
 			}
 			double *row = rows + (size_t)kept * MIMI_WINDOW_DOUBLES;
 			row[0] = [info[(id)kCGWindowNumber] doubleValue];
@@ -558,6 +571,9 @@ double *MimiCopyOnScreenWindows(int *count, char ***names) {
 			// The name is absent without Screen Recording; "" then.
 			NSString *name = info[(id)kCGWindowName];
 			row[5] = name != nil;
+			row[6] = pid.doubleValue;
+			row[7] = [info[(id)kCGWindowLayer] doubleValue];
+			row[8] = isRegular.boolValue;
 			titles[kept] = strdup(name ? name.UTF8String : "");
 			kept++;
 		}
@@ -572,6 +588,62 @@ double *MimiCopyOnScreenWindows(int *count, char ***names) {
 			free(titles);
 		}
 		return rows;
+	}
+}
+
+void **MimiCopyApplicationWindowElements(int pid, int *count, unsigned int **numbers, int **windows) {
+	if (!count) {
+		return NULL;
+	}
+	*count = 0;
+
+	@autoreleasepool {
+		AXUIElementRef appElement = AXUIElementCreateApplication((pid_t)pid);
+		if (!appElement) {
+			return NULL;
+		}
+		CFTypeRef value = NULL;
+		AXError error = AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute, &value);
+		CFRelease(appElement);
+		if (error != kAXErrorSuccess || !value) {
+			return NULL;
+		}
+		if (CFGetTypeID(value) != CFArrayGetTypeID()) {
+			CFRelease(value);
+			return NULL;
+		}
+		CFArrayRef list = (CFArrayRef)value;
+		CFIndex total = CFArrayGetCount(list);
+		void **elements = calloc((size_t)total + 1, sizeof(void *));
+		unsigned int *ids = calloc((size_t)total + 1, sizeof(unsigned int));
+		int *roles = calloc((size_t)total + 1, sizeof(int));
+		int kept = 0;
+		for (CFIndex i = 0; i < total; i++) {
+			AXUIElementRef window = (AXUIElementRef)CFArrayGetValueAtIndex(list, i);
+			if (!window) {
+				continue;
+			}
+			CGWindowID number = 0;
+			if (_AXUIElementGetWindow(window, &number) != kAXErrorSuccess || number == 0) {
+				continue;
+			}
+			CFTypeRef role = NULL;
+			int isWindow = 0;
+			if (AXUIElementCopyAttributeValue(window, kAXRoleAttribute, &role) == kAXErrorSuccess && role) {
+				isWindow = CFGetTypeID(role) == CFStringGetTypeID() &&
+				           CFStringCompare((CFStringRef)role, CFSTR("AXWindow"), 0) == kCFCompareEqualTo;
+				CFRelease(role);
+			}
+			elements[kept] = (void *)CFRetain(window);
+			ids[kept] = number;
+			roles[kept] = isWindow;
+			kept++;
+		}
+		CFRelease(value);
+		*count = kept;
+		*numbers = ids;
+		*windows = roles;
+		return elements;
 	}
 }
 

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -144,6 +144,22 @@ void *MimiGetFrontmostWindow(void) {
 	}
 }
 
+// The bounds of every on-screen window by number, from the window server.
+static NSDictionary<NSNumber *, NSValue *> *mimiOnScreenBounds(void) {
+	NSMutableDictionary<NSNumber *, NSValue *> *bounds = [NSMutableDictionary dictionary];
+	CFArrayRef list = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+	for (NSDictionary *info in (__bridge NSArray *)list) {
+		CGRect rect;
+		if (CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)info[(id)kCGWindowBounds], &rect)) {
+			bounds[info[(id)kCGWindowNumber]] = [NSValue valueWithBytes:&rect objCType:@encode(CGRect)];
+		}
+	}
+	if (list) {
+		CFRelease(list);
+	}
+	return bounds;
+}
+
 static CGPoint getWindowPosition(AXUIElementRef window) {
 	CFTypeRef positionValue = NULL;
 	if (AXUIElementCopyAttributeValue(window, kAXPositionAttribute, &positionValue) == kAXErrorSuccess &&
@@ -361,21 +377,33 @@ void **MimiGetAllFocusableWindowsOnActiveSpaceWithFocused(int *count, int *focus
 		CFIndex total = *count;
 		NSMutableDictionary<NSValue *, NSValue *> *positions = [NSMutableDictionary dictionaryWithCapacity:total];
 		NSMutableDictionary<NSValue *, NSNumber *> *pids = [NSMutableDictionary dictionaryWithCapacity:total];
-		// A position is a round trip into the window's application; the
-		// reads go out at once, and applications answer side by side.
-		CGPoint *points = calloc((size_t)total, sizeof(CGPoint));
-		dispatch_apply((size_t)total, dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^(size_t i) {
-			points[i] = getWindowPosition((AXUIElementRef)CFArrayGetValueAtIndex(windowsCollector, (CFIndex)i));
-		});
+		// A position read through Accessibility is a round trip into the
+		// window's application, and one just activated answers late. The
+		// window server knows where every window is, in one call for all
+		// of them; a window it does not list, one without a number, is
+		// asked itself.
+		NSDictionary<NSNumber *, NSValue *> *onScreen = mimiOnScreenBounds();
 		for (CFIndex i = 0; i < total; i++) {
 			AXUIElementRef w = (AXUIElementRef)CFArrayGetValueAtIndex(windowsCollector, i);
-			positions[[NSValue valueWithPointer:w]] = [NSValue valueWithBytes:&points[i] objCType:@encode(CGPoint)];
+			CGWindowID number = 0;
+			NSValue *known = nil;
+			if (_AXUIElementGetWindow(w, &number) == kAXErrorSuccess && number != 0) {
+				known = onScreen[@(number)];
+			}
+			CGPoint pos;
+			if (known) {
+				CGRect bounds;
+				[known getValue:&bounds];
+				pos = bounds.origin;
+			} else {
+				pos = getWindowPosition(w);
+			}
+			positions[[NSValue valueWithPointer:w]] = [NSValue valueWithBytes:&pos objCType:@encode(CGPoint)];
 
 			pid_t pid = 0;
 			AXUIElementGetPid(w, &pid);
 			pids[[NSValue valueWithPointer:w]] = @(pid);
 		}
-		free(points);
 
 		NSArray *sortedWindows =
 		    [(__bridge NSArray *)windowsCollector sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
@@ -495,6 +523,55 @@ double *MimiGetWindowFrame(void *window) {
 		}
 
 		return result;
+	}
+}
+
+double *MimiCopyOnScreenWindows(int *count, char ***names) {
+	if (!count) {
+		return NULL;
+	}
+	*count = 0;
+	if (names) {
+		*names = NULL;
+	}
+
+	@autoreleasepool {
+		CFArrayRef list = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+		if (!list) {
+			return NULL;
+		}
+		CFIndex total = CFArrayGetCount(list);
+		double *rows = calloc((size_t)total * MIMI_WINDOW_DOUBLES, sizeof(double));
+		char **titles = calloc((size_t)total + 1, sizeof(char *));
+		int kept = 0;
+		for (NSDictionary *info in (__bridge NSArray *)list) {
+			CGRect rect;
+			if (!CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)info[(id)kCGWindowBounds], &rect)) {
+				continue;
+			}
+			double *row = rows + (size_t)kept * MIMI_WINDOW_DOUBLES;
+			row[0] = [info[(id)kCGWindowNumber] doubleValue];
+			row[1] = rect.origin.x;
+			row[2] = rect.origin.y;
+			row[3] = rect.size.width;
+			row[4] = rect.size.height;
+			// The name is absent without Screen Recording; "" then.
+			NSString *name = info[(id)kCGWindowName];
+			row[5] = name != nil;
+			titles[kept] = strdup(name ? name.UTF8String : "");
+			kept++;
+		}
+		CFRelease(list);
+		*count = kept;
+		if (names) {
+			*names = titles;
+		} else {
+			for (int i = 0; i < kept; i++) {
+				free(titles[i]);
+			}
+			free(titles);
+		}
+		return rows;
 	}
 }
 

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -158,6 +158,93 @@ static CGPoint getWindowPosition(AXUIElementRef window) {
 	return CGPointZero;
 }
 
+// The application's windows that are focusable and on the active space, or
+// NULL for a process that is not a regular, visible application. The
+// window list and each window's attributes are round trips into the
+// application.
+static CFMutableArrayRef mimiCollectFocusableWindowsOfApplication(pid_t pid) {
+	@autoreleasepool {
+		NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+		if (!app || app.activationPolicy != NSApplicationActivationPolicyRegular || app.hidden)
+			return NULL;
+
+		AXUIElementRef appElement = AXUIElementCreateApplication(pid);
+		if (!appElement)
+			return NULL;
+
+		CFTypeRef windowsValue = NULL;
+		AXError error = AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute, &windowsValue);
+		CFRelease(appElement);
+		if (error != kAXErrorSuccess || !windowsValue)
+			return NULL;
+		if (CFGetTypeID(windowsValue) != CFArrayGetTypeID()) {
+			CFRelease(windowsValue);
+			return NULL;
+		}
+
+		CFMutableArrayRef collected = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+		CFArrayRef windows = (CFArrayRef)windowsValue;
+		CFIndex windowCount = CFArrayGetCount(windows);
+
+		for (CFIndex i = 0; i < windowCount; i++) {
+			AXUIElementRef window = (AXUIElementRef)CFArrayGetValueAtIndex(windows, i);
+			if (!window)
+				continue;
+
+			CFStringRef attrs[] = {
+			    kAXRoleAttribute,
+			    kAXMinimizedAttribute,
+			    CFSTR("AXWindowIsOnActiveSpace"),
+			};
+			CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 3, &kCFTypeArrayCallBacks);
+			if (!attrArray)
+				continue;
+
+			CFArrayRef values = NULL;
+			AXUIElementCopyMultipleAttributeValues(window, attrArray, 0, &values);
+			CFRelease(attrArray);
+
+			if (!values) {
+				continue;
+			}
+
+			bool shouldInclude = false;
+
+			if (CFArrayGetCount(values) > 0) {
+				CFTypeRef roleVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 0);
+				if (roleVal && CFGetTypeID(roleVal) == CFStringGetTypeID() &&
+				    CFStringCompare((CFStringRef)roleVal, CFSTR("AXWindow"), 0) == kCFCompareEqualTo) {
+					shouldInclude = true;
+				}
+			}
+
+			if (shouldInclude && CFArrayGetCount(values) > 1) {
+				CFTypeRef minVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 1);
+				if (minVal && CFGetTypeID(minVal) == CFBooleanGetTypeID() && CFBooleanGetValue((CFBooleanRef)minVal)) {
+					shouldInclude = false;
+				}
+			}
+
+			if (shouldInclude && CFArrayGetCount(values) > 2) {
+				CFTypeRef spaceVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 2);
+				if (spaceVal && CFGetTypeID(spaceVal) == CFBooleanGetTypeID() &&
+				    !CFBooleanGetValue((CFBooleanRef)spaceVal)) {
+					shouldInclude = false;
+				}
+			}
+
+			CFRelease(values);
+
+			if (shouldInclude) {
+				CFArrayAppendValue(collected, window);
+			}
+		}
+
+		CFRelease(windowsValue);
+		return collected;
+	}
+}
+
 // Internal helper: returns CFArrayRef of focusable windows on the active
 // space. On success, sets *outCount to the number of windows and (if
 // requested) *outFocusedIndex to the 0-based index of the focused window, or
@@ -211,95 +298,23 @@ static CFArrayRef mimiCollectFocusableWindowsOnActiveSpace(int *outCount, int *o
 			CFRelease(focusedApp);
 		}
 
-		for (NSNumber *ownerPID in ownerPIDs) {
-			pid_t pid = (pid_t)ownerPID.intValue;
-
-			NSRunningApplication *app = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
-			if (!app)
-				continue;
-			if (app.activationPolicy != NSApplicationActivationPolicyRegular)
-				continue;
-			if (app.hidden)
-				continue;
-
-			AXUIElementRef appElement = AXUIElementCreateApplication(pid);
-			if (!appElement)
-				continue;
-
-			CFTypeRef windowsValue = NULL;
-			AXError error = AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute, &windowsValue);
-			if (error != kAXErrorSuccess || !windowsValue) {
-				CFRelease(appElement);
+		// Each application is asked on a thread of its own, since a window
+		// list is a round trip into the application, and one that is busy,
+		// as the one just focused tends to be, answers late. The windows
+		// are then collected in application order, as one thread would.
+		NSUInteger appCount = ownerPIDs.count;
+		CFMutableArrayRef *perApp = calloc(appCount, sizeof(CFMutableArrayRef));
+		dispatch_apply(appCount, dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^(size_t index) {
+			perApp[index] = mimiCollectFocusableWindowsOfApplication((pid_t)ownerPIDs[index].intValue);
+		});
+		for (NSUInteger index = 0; index < appCount; index++) {
+			if (!perApp[index]) {
 				continue;
 			}
-
-			if (CFGetTypeID(windowsValue) != CFArrayGetTypeID()) {
-				CFRelease(windowsValue);
-				CFRelease(appElement);
-				continue;
-			}
-
-			CFArrayRef windows = (CFArrayRef)windowsValue;
-			CFIndex windowCount = CFArrayGetCount(windows);
-
-			for (CFIndex i = 0; i < windowCount; i++) {
-				AXUIElementRef window = (AXUIElementRef)CFArrayGetValueAtIndex(windows, i);
-				if (!window)
-					continue;
-
-				CFStringRef attrs[] = {
-				    kAXRoleAttribute,
-				    kAXMinimizedAttribute,
-				    CFSTR("AXWindowIsOnActiveSpace"),
-				};
-				CFArrayRef attrArray = CFArrayCreate(NULL, (const void **)attrs, 3, &kCFTypeArrayCallBacks);
-				if (!attrArray)
-					continue;
-
-				CFArrayRef values = NULL;
-				AXUIElementCopyMultipleAttributeValues(window, attrArray, 0, &values);
-				CFRelease(attrArray);
-
-				if (!values) {
-					continue;
-				}
-
-				bool shouldInclude = false;
-
-				if (CFArrayGetCount(values) > 0) {
-					CFTypeRef roleVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 0);
-					if (roleVal && CFGetTypeID(roleVal) == CFStringGetTypeID() &&
-					    CFStringCompare((CFStringRef)roleVal, CFSTR("AXWindow"), 0) == kCFCompareEqualTo) {
-						shouldInclude = true;
-					}
-				}
-
-				if (shouldInclude && CFArrayGetCount(values) > 1) {
-					CFTypeRef minVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 1);
-					if (minVal && CFGetTypeID(minVal) == CFBooleanGetTypeID() &&
-					    CFBooleanGetValue((CFBooleanRef)minVal)) {
-						shouldInclude = false;
-					}
-				}
-
-				if (shouldInclude && CFArrayGetCount(values) > 2) {
-					CFTypeRef spaceVal = (CFTypeRef)CFArrayGetValueAtIndex(values, 2);
-					if (spaceVal && CFGetTypeID(spaceVal) == CFBooleanGetTypeID() &&
-					    !CFBooleanGetValue((CFBooleanRef)spaceVal)) {
-						shouldInclude = false;
-					}
-				}
-
-				CFRelease(values);
-
-				if (shouldInclude) {
-					CFArrayAppendValue(windowsCollector, window);
-				}
-			}
-
-			CFRelease(windowsValue);
-			CFRelease(appElement);
+			CFArrayAppendArray(windowsCollector, perApp[index], CFRangeMake(0, CFArrayGetCount(perApp[index])));
+			CFRelease(perApp[index]);
 		}
+		free(perApp);
 
 		// After enumeration, find the focused window's position in the
 		// collected list via CFEqual (matches the Go-side equality check
@@ -346,15 +361,21 @@ void **MimiGetAllFocusableWindowsOnActiveSpaceWithFocused(int *count, int *focus
 		CFIndex total = *count;
 		NSMutableDictionary<NSValue *, NSValue *> *positions = [NSMutableDictionary dictionaryWithCapacity:total];
 		NSMutableDictionary<NSValue *, NSNumber *> *pids = [NSMutableDictionary dictionaryWithCapacity:total];
+		// A position is a round trip into the window's application; the
+		// reads go out at once, and applications answer side by side.
+		CGPoint *points = calloc((size_t)total, sizeof(CGPoint));
+		dispatch_apply((size_t)total, dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^(size_t i) {
+			points[i] = getWindowPosition((AXUIElementRef)CFArrayGetValueAtIndex(windowsCollector, (CFIndex)i));
+		});
 		for (CFIndex i = 0; i < total; i++) {
 			AXUIElementRef w = (AXUIElementRef)CFArrayGetValueAtIndex(windowsCollector, i);
-			CGPoint pos = getWindowPosition(w);
-			positions[[NSValue valueWithPointer:w]] = [NSValue valueWithBytes:&pos objCType:@encode(CGPoint)];
+			positions[[NSValue valueWithPointer:w]] = [NSValue valueWithBytes:&points[i] objCType:@encode(CGPoint)];
 
 			pid_t pid = 0;
 			AXUIElementGetPid(w, &pid);
 			pids[[NSValue valueWithPointer:w]] = @(pid);
 		}
+		free(points);
 
 		NSArray *sortedWindows =
 		    [(__bridge NSArray *)windowsCollector sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
@@ -474,6 +495,27 @@ double *MimiGetWindowFrame(void *window) {
 		}
 
 		return result;
+	}
+}
+
+int MimiSetWindowPosition(void *window, double x, double y) {
+	if (!window)
+		return 0;
+
+	@autoreleasepool {
+		CGPoint point = CGPointMake((CGFloat)x, (CGFloat)y);
+		AXValueRef positionValue = AXValueCreate(kAXValueCGPointType, &point);
+		if (!positionValue)
+			return 0;
+
+		AXError posError = AXUIElementSetAttributeValue((AXUIElementRef)window, kAXPositionAttribute, positionValue);
+		CFRelease(positionValue);
+		if (posError != kAXErrorSuccess) {
+			MIMI_LOG("AXUIElementSetAttributeValue(kAXPositionAttribute) failed with error %d", (int)posError);
+			return 0;
+		}
+
+		return 1;
 	}
 }
 

--- a/internal/tiling/contract.go
+++ b/internal/tiling/contract.go
@@ -59,9 +59,10 @@ type Input struct {
 type Output struct {
 	Frames []action.WindowFrame `json:"frames"`
 	State  json.RawMessage      `json:"state"`
-	// Focus, when set, is the window the layout wants keyboard focus on
-	// once the frames are applied: how a layout moves focus along its own
-	// structure, a strip's next column say, where spatial focus cannot.
+	// Focus, when set, is the window the layout wants keyboard focus on,
+	// given before the frames are applied: how a layout moves focus along
+	// its own structure, a strip's next column say, where spatial focus
+	// cannot.
 	Focus uint32 `json:"focus,omitempty"`
 }
 

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -449,6 +449,18 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 		}
 	}
 
+	// Focus goes first: it is what the user pressed a key for, and it is
+	// one round trip, while the frames wait on a screen capture when they
+	// animate. A window focuses as well off screen as on it.
+	if focus != 0 {
+		focusErr := e.run(func() error { return e.desktop.Focus(focus) })
+		if focusErr != nil {
+			e.logger.Debugw("tiling pass could not focus", "window", focus, "err", focusErr)
+		}
+	}
+
+	applyStart := time.Now()
+
 	err = e.run(func() error {
 		if len(frames) == 0 {
 			return nil
@@ -456,13 +468,6 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 
 		return e.desktop.Apply(frames, e.animation)
 	})
-
-	if focus != 0 {
-		focusErr := e.run(func() error { return e.desktop.Focus(focus) })
-		if focusErr != nil {
-			e.logger.Debugw("tiling pass could not focus", "window", focus, "err", focusErr)
-		}
-	}
 
 	// Whatever the apply reported, some frames may have landed: remember
 	// them all as requested, then read back where they are.
@@ -486,6 +491,8 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 		len(inputs),
 		"frames",
 		len(frames),
+		"apply_ms",
+		time.Since(applyStart).Milliseconds(),
 	)
 
 	return nil
@@ -598,24 +605,32 @@ func (e *Engine) inputsLocked(event Event) ([]Input, error) {
 }
 
 // displayOf is the id of the display whose frame holds the center of frame,
-// or the first display's when none does.
+// or, when none does, the one that center is nearest: a column a strip
+// parks off the edge of a display stays that display's.
 func displayOf(frame action.Frame, displays []action.DisplayEntry) uint32 {
 	centerX := frame.X + frame.Width/half
 	centerY := frame.Y + frame.Height/half
 
+	var (
+		nearest  uint32
+		distance = math.Inf(1)
+	)
+
 	for _, display := range displays {
 		bounds := display.Frame
-		if centerX >= bounds.X && centerX < bounds.X+bounds.Width &&
-			centerY >= bounds.Y && centerY < bounds.Y+bounds.Height {
+		outsideX := math.Max(bounds.X-centerX, math.Max(0, centerX-(bounds.X+bounds.Width)))
+		outsideY := math.Max(bounds.Y-centerY, math.Max(0, centerY-(bounds.Y+bounds.Height)))
+
+		if outsideX == 0 && outsideY == 0 {
 			return display.ID
+		}
+
+		if d := outsideX*outsideX + outsideY*outsideY; d < distance {
+			nearest, distance = display.ID, d
 		}
 	}
 
-	if len(displays) > 0 {
-		return displays[0].ID
-	}
-
-	return 0
+	return nearest
 }
 
 // spacesChangedLocked reports whether any display the inputs were read on

--- a/internal/tiling/engine_test.go
+++ b/internal/tiling/engine_test.go
@@ -36,6 +36,8 @@ type fakeDesktop struct {
 	animations []*action.Animation
 	applyErr   error
 	focused    []uint32
+	// calls is the order of Apply and Focus, by name.
+	calls []string
 }
 
 func (d *fakeDesktop) Focus(number uint32) error {
@@ -43,6 +45,7 @@ func (d *fakeDesktop) Focus(number uint32) error {
 	defer d.mu.Unlock()
 
 	d.focused = append(d.focused, number)
+	d.calls = append(d.calls, "focus")
 
 	return nil
 }
@@ -76,6 +79,7 @@ func (d *fakeDesktop) Apply(frames []action.WindowFrame, animation *action.Anima
 
 	d.applied = append(d.applied, frames)
 	d.animations = append(d.animations, animation)
+	d.calls = append(d.calls, "apply")
 
 	return nil
 }
@@ -481,6 +485,57 @@ func TestEngine_Run_PassesOnStartupAndOnEnablingReloads(t *testing.T) {
 // contract: a display gets a run of its own with only its windows, its
 // state is keyed by its own space, and a space switched on one display
 // leaves the other's state untouched.
+// TestEngine_Pass_KeepsAnOffScreenWindowWithItsNearestDisplay pins where a
+// window whose center is on no display is laid out: with the display it is
+// nearest, as a column a strip parks off a secondary display's edge is,
+// rather than with the first display.
+func TestEngine_Pass_KeepsAnOffScreenWindowWithItsNearestDisplay(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	desktop.displays = []action.DisplayEntry{
+		{
+			Index:   1,
+			ID:      7,
+			Frame:   action.Frame{Width: 1000, Height: 1000},
+			Visible: action.Frame{Width: 1000, Height: 1000},
+		},
+		{
+			Index:   2,
+			ID:      8,
+			Frame:   action.Frame{X: 200, Y: 1000, Width: 1000, Height: 1000},
+			Visible: action.Frame{X: 200, Y: 1000, Width: 1000, Height: 1000},
+		},
+	}
+	desktop.windows = action.WindowsInfo{Focused: 0, Windows: []action.WindowEntry{
+		{
+			Number: 1,
+			PID:    10,
+			App:    "A",
+			Frame:  action.Frame{X: 300, Y: 1100, Width: 500, Height: 500},
+		},
+		// Parked left of the second display: its center is on no display.
+		{
+			Number: 2,
+			PID:    11,
+			App:    "B",
+			Frame:  action.Frame{X: -400, Y: 1100, Width: 500, Height: 500},
+		},
+	}}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(`jq -c '{frames: [], state: null}'`), shell)
+
+	inputs, _, err := engine.Preview(context.Background(), tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+
+	if len(inputs) != 1 || inputs[0].Display.ID != 8 || len(inputs[0].Windows) != 2 {
+		t.Fatalf("inputs = %+v; want both windows on display 8 alone", inputs)
+	}
+}
+
 func TestEngine_Pass_RunsOncePerDisplayWithStateOfItsOwn(t *testing.T) {
 	t.Parallel()
 
@@ -609,8 +664,8 @@ func TestEngine_Input_GapFollowsTheConfigThenTheMargin(t *testing.T) {
 }
 
 // TestEngine_Pass_FocusesTheWindowTheLayoutAsksFor pins the one thing a
-// layout may ask for beyond frames: keyboard focus on a window, applied
-// after the frames, and alone when there are no frames.
+// layout may ask for beyond frames: keyboard focus on a window, given
+// before the frames, and alone when there are no frames.
 func TestEngine_Pass_FocusesTheWindowTheLayoutAsksFor(t *testing.T) {
 	t.Parallel()
 
@@ -629,6 +684,31 @@ func TestEngine_Pass_FocusesTheWindowTheLayoutAsksFor(t *testing.T) {
 			len(desktop.applied),
 			desktop.focused,
 		)
+	}
+}
+
+// TestEngine_Pass_FocusesBeforeTheFramesMove pins that the focus a layout
+// asks for lands before its frames do: the focus is what the user asked
+// for, and the frames may wait on a screen capture.
+func TestEngine_Pass_FocusesBeforeTheFramesMove(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(
+		enabled(
+			`jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 10, height: 10}}], state: null, focus: 1}'`,
+		),
+		shell,
+	)
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: tiling.EventCommand, Name: "focus"})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	if got, want := strings.Join(desktop.calls, ","), "focus,apply"; got != want {
+		t.Fatalf("calls = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR makes tiling navigation with `[tiling.animation]` on feel immediate. A scrolling pass used to spend about 115 ms of blocking setup before anything moved: four whole-display captures, a bitmap copy of each into windows of our own, a fresh window server window with an occasional half-second stall, and the focus only after all of it. The same scroll now costs two captures, about 25 to 35 ms on a 1080p display, and the focus lands first.

What changed, for a user:

- The focus a layout asks for lands before its frames move, so the key press feels instant.
- The animation is drawn with Core Animation layers in one transparent window per display, showing the captures as they are instead of copying every pixel. Retina displays no longer pay four times the paint.
- A window arriving from off screen slides in instead of popping in when the animation ends, and keeps its picture while parked, so it needs no capture on its way back.
- A pass that asks for frames already in flight leaves the running animation to finish, which removes a restart that read as a bounce at longer durations.
- Windows above the floating level, such as a picture-in-picture player, show through on their own and need no still of their own.
- Every pass enumerates windows from the window server, holding each window's Accessibility element by number, and asks an application only for windows it has not seen. An enumeration right after an activation went from 50 to 80 ms, waiting on the busy application, to 8 to 12 ms. Frames and titles come from the window server too; titles fall back to asking the application without Screen Recording.
- A window whose size is unchanged is moved with one Accessibility call instead of three.
- A window parked off the edge of a secondary display stays with that display instead of migrating to the first one.

Config keeps working unchanged. `duration_ms` values that felt laggy because the setup swallowed them can now be raised.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Measured on macOS 26, an M3 with a 1080p external display and the built-in Retina display, with the strip layout:

| Per scroll | Before | After |
| --- | --- | --- |
| Captures | 4 | 2 |
| Animation setup, 1080p | 115 ms | 48 to 65 ms with two daemons capturing, 25 to 35 ms expected alone |
| Window enumeration after an activation | 50 to 80 ms | 8 to 12 ms |
| Accessibility frame writes | 20 to 80 ms | 0 to 5 ms |

Measured and rejected on the way: capturing at a lower resolution or a smaller area costs the same, as a capture is a fixed round trip; hardware capture and Accessibility-stepped motion were already ruled out earlier.

Two semantic notes. The focused window is now the frontmost ordinary window in the window server's order rather than the Accessibility server's answer, since that query waits on the busy application like everything else; right after our own focus call the order can lag by a few milliseconds, and the pass that reacts to the focus event comes after it settles. And `golangci-lint run --fix` corrupts cgo files when it applies an `nlreturn` fix after a multi-line C call; the `nolint` goes on the last argument line as the existing code does.

Tested live on both displays: focus cycling in every direction, resize presets and explicit sizes, display moves, `apply_frames`, `query windows`, strip scrolling in both directions, off-screen arrivals, rapid navigation mid-flight, and the picture-in-picture player staying on top, plus the integration and baseline suites.
