### PR TITLE
feat(border): draw a border under every window with the focused one in its own colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | List every display               | `mimi query displays`                                                     |
 | Apply a layout from a script     | `my-layout \| mimi action apply_frames` (see `examples/tiling/`)           |
 | Tile automatically, your way     | `[tiling]` in the config, see `docs/TILING.md`                            |
+| Outline the focused window       | `[border]` in the config, see `docs/CONFIGURATION.md`                     |
 
 Full reference → [CLI Guide](docs/CLI.md)
 

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -95,6 +95,28 @@ duration_ms = 150
 easing = "ease-out"
 
 # =============================================================================
+# Borders
+# =============================================================================
+# Draw a ring around every window on the spaces in front, the way JankyBorders
+# does. The focused window gets active_color and the rest get inactive_color.
+# Each ring is a window of mimi's own, ordered under the window it belongs to,
+# so it never covers another window. Needs Accessibility. Every key here is
+# reloadable.
+# =============================================================================
+
+[border]
+enabled = false
+# Points, 1 to 32.
+width = 4
+# The window corner radius the ring follows on its inside. Leave unset to
+# follow each window's own corners (macOS 26 and later; earlier releases get
+# a document window's). Set a number to draw every ring alike; 0 is square.
+# radius = 12
+# #rrggbb or #rrggbbaa.
+active_color = "#e2e2e3"
+inactive_color = "#414141"
+
+# =============================================================================
 # Hooks
 # =============================================================================
 # Each hook is an array of entries. An entry can be either:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,6 +143,7 @@ internal/
   observe/          Hook daemon event routing
   hooks/            Hook registry and executor
   tiling/           The engine that runs the user's layout program on events
+  border/           The engine that keeps a border under every window on events
   config/           TOML config loading
   daemon/           Daemon lifecycle
   permissions/      Accessibility permission checks

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,6 +25,7 @@ failure is logged.
 - `settings.resize_debounce_ms`
 - `[hooks]` (every hook kind)
 - `[tiling]` (every field)
+- `[border]` (every field)
 
 **Restart-only**. The daemon reads these once at startup. Restart it to apply
 (`mimi daemon stop && mimi daemon start`):
@@ -255,6 +256,40 @@ macOS gates every screen capture behind Screen Recording.
 - Until it is granted, windows move at once and a warning says so.
 - Grant it in System Settings > Privacy & Security > Screen & System Audio
   Recording, then restart mimi. macOS applies the grant on the next start.
+
+---
+
+## Borders
+
+```toml
+[border]
+enabled = true
+width = 4                   # points, 1 to 32
+# radius = 12               # force one corner radius; unset follows each window's own, 0 is square
+active_color = "#e2e2e3"    # the focused window, #rrggbb or #rrggbbaa
+inactive_color = "#414141"  # every other window
+```
+
+With `[border]` enabled, the daemon draws a ring around every window on the
+spaces in front, the way JankyBorders does. The focused window gets
+`active_color` and every other window gets `inactive_color`. A border follows
+its window as it moves or resizes, changes colour when focus moves, and goes
+away when the window closes, leaves the space or its application hides. A
+full-screen window gets none.
+
+Each border is a window of mimi's own, ordered directly under the window it
+belongs to. The border never covers another application's content, and a
+window that overlaps a bordered one covers the border as it covers the
+window. A colour with an alpha channel draws a translucent border.
+
+Windows have different corner radii. With `radius` unset, each border uses
+the radius the window server reports for its window, which macOS 26 added.
+Earlier releases report none, and every border uses 12 points there. Set
+`radius` to draw every border with one radius.
+
+Borders need Accessibility, as window hooks do, because focus and moves come
+from the same observers. Without it, borders stay off and the daemon logs a
+warning. When the tiling animation moves a window, its border moves with it.
 
 ---
 

--- a/internal/border/doc.go
+++ b/internal/border/doc.go
@@ -1,0 +1,4 @@
+// Package border draws a border under every window on the spaces in front,
+// in one color for the focused window and another for the rest, and keeps
+// them in step with the windows as they move, open, close and change focus.
+package border

--- a/internal/border/engine.go
+++ b/internal/border/engine.go
@@ -1,0 +1,157 @@
+package border
+
+import (
+	"context"
+	"sync"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/events"
+	"github.com/y3owk1n/mimi/internal/native"
+)
+
+// Drawer is what the engine needs from the screen. It sets the style the
+// borders are drawn in, brings them up to date with the windows, and takes
+// them down. The daemon uses the native drawer and the tests use a fake.
+type Drawer struct {
+	SetStyle func(native.BorderStyle)
+	Sync     func(refocus bool)
+	Clear    func()
+}
+
+// NativeDrawer draws on the screen.
+func NativeDrawer() Drawer {
+	return Drawer{
+		SetStyle: native.SetBorderStyle,
+		Sync:     native.SyncBorders,
+		Clear:    native.ClearBorders,
+	}
+}
+
+// Engine keeps the borders in step with the windows. It is safe to use from
+// several goroutines: Update replaces the configuration under a lock, and
+// Run and Nudge read it under the same lock.
+type Engine struct {
+	draw Drawer
+
+	mu      sync.Mutex
+	enabled bool
+	style   native.BorderStyle
+}
+
+// New returns an engine that draws nothing until Update enables it.
+func New(draw Drawer) *Engine {
+	return &Engine{draw: draw}
+}
+
+// Update applies the [border] section. It is what the daemon calls at
+// startup and on every reload. Enabling draws the borders at once;
+// disabling takes them down; a change of style redraws them.
+func (e *Engine) Update(cfg config.BorderConfig) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	wasEnabled, hadStyle := e.enabled, e.style
+
+	e.enabled = cfg.Enabled
+	e.style = styleOf(cfg)
+
+	switch {
+	case !cfg.Enabled && wasEnabled:
+		e.draw.Clear()
+	case cfg.Enabled && (!wasEnabled || hadStyle != e.style):
+		e.draw.SetStyle(e.style)
+	}
+}
+
+// styleOf is the config as the drawer takes it. The colors were validated
+// with the config, so a color that fails to parse here is a programming
+// error and draws as clear.
+func styleOf(cfg config.BorderConfig) native.BorderStyle {
+	active, _ := config.ParseColor(cfg.ActiveColor)
+	inactive, _ := config.ParseColor(cfg.InactiveColor)
+
+	return native.BorderStyle{
+		Width:    cfg.Width,
+		Radius:   cfg.CornerRadius(),
+		Active:   native.Color(active),
+		Inactive: native.Color(inactive),
+	}
+}
+
+// Enabled reports whether borders are drawn.
+func (e *Engine) Enabled() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.enabled
+}
+
+// wakingKinds are the events after which the windows, their stacking or
+// the focus may differ from what the borders show.
+//
+//nolint:gochecknoglobals // a fixed set
+var wakingKinds = map[events.EventKind]bool{
+	events.Startup:          true,
+	events.AppActivate:      true,
+	events.AppDeactivate:    true,
+	events.AppHide:          true,
+	events.AppUnhide:        true,
+	events.AppQuit:          true,
+	events.WindowFocus:      true,
+	events.WindowCreated:    true,
+	events.WindowClosed:     true,
+	events.WindowMove:       true,
+	events.WindowResize:     true,
+	events.WorkspaceChanged: true,
+	events.AXAttached:       true,
+}
+
+// KindFilter is the bus filter for the engine's subscription: the waking
+// kinds, and only while the engine is enabled, so a disabled engine costs
+// the bus no sends.
+func (e *Engine) KindFilter() events.KindFilter {
+	return func(kind events.EventKind) bool {
+		return wakingKinds[kind] && e.Enabled()
+	}
+}
+
+// Run drains sub until ctx is done, bringing the borders up to date after
+// every event, and takes them down at the end.
+func (e *Engine) Run(ctx context.Context, sub events.Subscriber) {
+	for {
+		select {
+		case <-ctx.Done():
+			e.Close()
+
+			return
+		case _, ok := <-sub:
+			if !ok {
+				return
+			}
+
+			if e.Enabled() {
+				e.draw.Sync(true)
+			}
+		}
+	}
+}
+
+// Nudge follows a window being dragged: the borders are brought up to date
+// with the frames alone, since a drag moves no focus. The router calls it
+// for every raw move and resize, ahead of the debounce.
+func (e *Engine) Nudge() {
+	if e.Enabled() {
+		e.draw.Sync(false)
+	}
+}
+
+// Close takes the borders down. The engine is not used after it.
+func (e *Engine) Close() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.enabled {
+		e.enabled = false
+		e.draw.Clear()
+	}
+}

--- a/internal/border/engine_test.go
+++ b/internal/border/engine_test.go
@@ -1,0 +1,150 @@
+package border_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/border"
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/events"
+	"github.com/y3owk1n/mimi/internal/native"
+)
+
+// fakeDrawer records what the engine asked of the screen.
+type fakeDrawer struct {
+	styles []native.BorderStyle
+	syncs  chan bool
+	clears int
+}
+
+func newFakeDrawer() *fakeDrawer {
+	return &fakeDrawer{syncs: make(chan bool, 16)}
+}
+
+func (f *fakeDrawer) drawer() border.Drawer {
+	return border.Drawer{
+		SetStyle: func(style native.BorderStyle) { f.styles = append(f.styles, style) },
+		Sync:     func(refocus bool) { f.syncs <- refocus },
+		Clear:    func() { f.clears++ },
+	}
+}
+
+func enabledConfig() config.BorderConfig {
+	return config.BorderConfig{
+		Enabled:       true,
+		Width:         4,
+		ActiveColor:   "#ff0000",
+		InactiveColor: "#00000080",
+	}
+}
+
+func TestEngine_UpdateStylesEnablesAndClears(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeDrawer()
+	engine := border.New(fake.drawer())
+
+	if engine.KindFilter()(events.WindowFocus) {
+		t.Fatal("a disabled engine admits window_focus, want nothing")
+	}
+
+	engine.Update(enabledConfig())
+
+	if len(fake.styles) != 1 {
+		t.Fatalf("SetStyle called %d times, want 1", len(fake.styles))
+	}
+
+	style := fake.styles[0]
+	if style.Width != 4 || style.Active.Red != 1 || style.Inactive.Alpha != 128.0/255 {
+		t.Errorf("style = %+v, want the config's width and colors", style)
+	}
+
+	if style.Radius != native.FollowWindowRadius {
+		t.Errorf("style.Radius = %v, want FollowWindowRadius", style.Radius)
+	}
+
+	if !engine.KindFilter()(events.WindowFocus) || engine.KindFilter()(events.WindowTitleChange) {
+		t.Error("an enabled engine admits the waking kinds and nothing else")
+	}
+
+	// The same config again redraws nothing.
+	engine.Update(enabledConfig())
+
+	if len(fake.styles) != 1 {
+		t.Errorf("SetStyle called %d times after an unchanged reload, want 1", len(fake.styles))
+	}
+
+	cfg := enabledConfig()
+	cfg.Width = 8
+	engine.Update(cfg)
+
+	if len(fake.styles) != 2 {
+		t.Errorf("SetStyle called %d times after a restyle, want 2", len(fake.styles))
+	}
+
+	cfg.Enabled = false
+	engine.Update(cfg)
+
+	if fake.clears != 1 {
+		t.Errorf("Clear called %d times after disabling, want 1", fake.clears)
+	}
+}
+
+func TestEngine_RunSyncsOnEventsAndNudges(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeDrawer()
+	engine := border.New(fake.drawer())
+	engine.Update(enabledConfig())
+
+	bus := events.NewBus()
+	sub := bus.SubscribeWithFilter(4, engine.KindFilter())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		engine.Run(ctx, sub)
+		close(done)
+	}()
+
+	bus.Publish(events.Event{Kind: events.WindowFocus})
+
+	select {
+	case refocus := <-fake.syncs:
+		if !refocus {
+			t.Error("a focus event synced without refocus, want refocus")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no sync after a window_focus event")
+	}
+
+	engine.Nudge()
+
+	select {
+	case refocus := <-fake.syncs:
+		if refocus {
+			t.Error("a nudge synced with refocus, want the frames alone")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no sync after a nudge")
+	}
+
+	cancel()
+	<-done
+
+	if fake.clears != 1 {
+		t.Errorf("Clear called %d times after Run ended, want 1", fake.clears)
+	}
+
+	engine.Nudge()
+
+	select {
+	case <-fake.syncs:
+		t.Error("a closed engine synced on a nudge")
+	default:
+	}
+}

--- a/internal/config/border_test.go
+++ b/internal/config/border_test.go
@@ -1,0 +1,123 @@
+package config //nolint:testpackage // reads the validated config directly
+
+import (
+	"strings"
+	"testing"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+const (
+	borderedConfig = "[border]\nenabled = true\n"
+	widthMessage   = "border.width must be between 1 and 32"
+)
+
+func TestLoad_BorderDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(writeConfig(t, borderedConfig))
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	if !cfg.Border.Enabled {
+		t.Fatal("border.enabled = false, want true")
+	}
+
+	if got, want := cfg.Border.Width, defaultBorderWidth; got != want {
+		t.Errorf("border.width = %v, want %v", got, want)
+	}
+
+	if got, want := cfg.Border.CornerRadius(), float64(FollowWindowRadius); got != want {
+		t.Errorf("border.radius = %v, want %v (follow the window)", got, want)
+	}
+
+	if got, want := cfg.Border.ActiveColor, defaultBorderActiveColor; got != want {
+		t.Errorf("border.active_color = %q, want %q", got, want)
+	}
+
+	if got, want := cfg.Border.InactiveColor, defaultBorderInactiveColor; got != want {
+		t.Errorf("border.inactive_color = %q, want %q", got, want)
+	}
+
+	// Off is the default.
+	cfg, err = Load(writeConfig(t, ""))
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	if cfg.Border.Enabled {
+		t.Fatal("border.enabled defaults to true, want false")
+	}
+
+	// A radius of 0 is square corners, not following the window.
+	cfg, err = Load(writeConfig(t, borderedConfig+"radius = 0\n"))
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	if got := cfg.Border.CornerRadius(); got != 0 {
+		t.Errorf("border.radius = %v, want 0", got)
+	}
+}
+
+func TestLoad_RejectsABorderItCannotDraw(t *testing.T) {
+	t.Parallel()
+
+	for name, testCase := range map[string]struct {
+		extra    string
+		fragment string
+	}{
+		"thin":     {"width = 0.5\n", widthMessage},
+		"wide":     {"width = 33\n", widthMessage},
+		"radius":   {"radius = -1\n", "border.radius must be >= 0"},
+		"active":   {"active_color = \"red\"\n", "border.active_color must be #rrggbb or #rrggbbaa"},
+		"inactive": {"inactive_color = \"#12345\"\n", "border.inactive_color must be #rrggbb or #rrggbbaa"},
+		"not hex":  {"active_color = \"#gggggg\"\n", "border.active_color must be #rrggbb or #rrggbbaa"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Load(writeConfig(t, borderedConfig+testCase.extra))
+			if !derrors.IsCode(err, derrors.CodeInvalidConfig) {
+				t.Fatalf("Load() error = %v, want CodeInvalidConfig", err)
+			}
+
+			if !strings.Contains(err.Error(), testCase.fragment) {
+				t.Errorf("error %q does not mention %q", err.Error(), testCase.fragment)
+			}
+		})
+	}
+}
+
+func TestLoad_ChecksADisabledBorderToo(t *testing.T) {
+	t.Parallel()
+
+	_, err := Load(writeConfig(t, "[border]\nenabled = false\nwidth = 99\n"))
+	if !derrors.IsCode(err, derrors.CodeInvalidConfig) ||
+		!strings.Contains(err.Error(), widthMessage) {
+		t.Fatalf("Load() error = %v, want the width message", err)
+	}
+}
+
+func TestParseColor(t *testing.T) {
+	t.Parallel()
+
+	for text, want := range map[string]Color{
+		"#ff0000":   {Red: 1, Alpha: 1},
+		"00ff00":    {Green: 1, Alpha: 1},
+		"#0000ff80": {Blue: 1, Alpha: 128.0 / 255},
+		"#FFFFFF":   {Red: 1, Green: 1, Blue: 1, Alpha: 1},
+	} {
+		got, err := ParseColor(text)
+		if err != nil {
+			t.Errorf("ParseColor(%q) error = %v", text, err)
+
+			continue
+		}
+
+		if got != want {
+			t.Errorf("ParseColor(%q) = %+v, want %+v", text, got, want)
+		}
+	}
+}

--- a/internal/config/color.go
+++ b/internal/config/color.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// Color is a color as the config spells it, each channel from 0 to 1.
+type Color struct {
+	Red, Green, Blue, Alpha float64
+}
+
+// channelMax is the largest value a two-digit hex channel holds.
+const channelMax = 255
+
+// ParseColor reads a color written as #rrggbb or #rrggbbaa, the leading #
+// optional. The alpha is 1 when left out.
+func ParseColor(text string) (Color, error) {
+	hex := strings.TrimPrefix(strings.TrimSpace(text), "#")
+	if len(hex) != 6 && len(hex) != 8 {
+		return Color{}, derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"color %q must be #rrggbb or #rrggbbaa",
+			text,
+		)
+	}
+
+	var channels [4]float64
+
+	channels[3] = 1
+
+	for index := range len(hex) / 2 {
+		value, err := strconv.ParseUint(hex[index*2:index*2+2], 16, 8)
+		if err != nil {
+			return Color{}, derrors.Newf(
+				derrors.CodeInvalidConfig,
+				"color %q must be #rrggbb or #rrggbbaa",
+				text,
+			)
+		}
+
+		channels[index] = float64(value) / channelMax
+	}
+
+	return Color{Red: channels[0], Green: channels[1], Blue: channels[2], Alpha: channels[3]}, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Hooks    HooksConfig    `json:"hooks"    reload:"reloadable" toml:"hooks"`
 	Systray  SystrayConfig  `json:"systray"  reload:"per-field"  toml:"systray"`
 	Tiling   TilingConfig   `json:"tiling"   reload:"reloadable" toml:"tiling"`
+	Border   BorderConfig   `json:"border"   reload:"reloadable" toml:"border"`
 
 	// UnknownHookKeys lists the keys found under [hooks] that name no hook
 	// kind, sorted. Loading records them rather than reporting them so each
@@ -109,6 +110,37 @@ type AnimationConfig struct {
 	Easing     string `json:"easing"     toml:"easing"`
 }
 
+// BorderConfig holds the [border] section: whether the daemon draws a
+// border around every window on the spaces in front, how wide, the radius
+// of the window corner it follows, and the colors for the focused window
+// and for the rest. Colors are written as #rrggbb or #rrggbbaa. The whole
+// section is reloadable; it needs Accessibility, like the window events it
+// follows.
+type BorderConfig struct {
+	Enabled bool    `json:"enabled" toml:"enabled"`
+	Width   float64 `json:"width"   toml:"width"`
+	// Radius is the corner radius of the window the border follows on its
+	// inside, in points. Left unset, each border follows its own window's
+	// corner as the window server reports it; 0 draws square corners.
+	Radius        *float64 `json:"radius"        toml:"radius"`
+	ActiveColor   string   `json:"activeColor"   toml:"active_color"`
+	InactiveColor string   `json:"inactiveColor" toml:"inactive_color"`
+}
+
+// CornerRadius is the radius the border follows: Radius when set, else
+// FollowWindowRadius, each window's own.
+func (b BorderConfig) CornerRadius() float64 {
+	if b.Radius != nil {
+		return *b.Radius
+	}
+
+	return FollowWindowRadius
+}
+
+// FollowWindowRadius is the CornerRadius of a [border] section with no
+// radius set: every border follows its own window's corner.
+const FollowWindowRadius = -1
+
 // HooksConfig holds all hook entries grouped by event kind.
 type HooksConfig struct {
 	AppActivate       []HookEntry `json:"onAppActivate"       toml:"on_app_activate"`
@@ -158,6 +190,7 @@ type rawConfig struct {
 	Hooks    rawHooksConfig   `json:"hooks"    toml:"hooks"`
 	Systray  rawSystrayConfig `json:"systray"  toml:"systray"`
 	Tiling   TilingConfig     `json:"tiling"   toml:"tiling"`
+	Border   BorderConfig     `json:"border"   toml:"border"`
 }
 
 type rawSystrayConfig struct {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -125,6 +125,7 @@ func Load(path string) (*Config, error) {
 		Settings:        raw.Settings,
 		Hooks:           hooks,
 		Tiling:          raw.Tiling,
+		Border:          raw.Border,
 		UnknownHookKeys: unknownHookKeys,
 	}
 
@@ -157,6 +158,15 @@ const (
 	defaultTilingTimeoutSecs     = 5
 	defaultTilingAnimationMS     = 150
 	defaultTilingAnimationEasing = "ease-out"
+)
+
+// The [border] defaults: a ring a few points wide, light on the focused
+// window and dark on the rest.
+const (
+	defaultBorderWidth         = 4.0
+	defaultBorderActiveColor   = "#e2e2e3"
+	defaultBorderInactiveColor = "#414141"
+	maxBorderWidth             = 32.0
 )
 
 func applyDefaults(cfg *Config, systrayEnabledSet bool) {
@@ -199,6 +209,18 @@ func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 
 	if cfg.Tiling.Animation.Easing == "" {
 		cfg.Tiling.Animation.Easing = defaultTilingAnimationEasing
+	}
+
+	if cfg.Border.Width == 0 {
+		cfg.Border.Width = defaultBorderWidth
+	}
+
+	if cfg.Border.ActiveColor == "" {
+		cfg.Border.ActiveColor = defaultBorderActiveColor
+	}
+
+	if cfg.Border.InactiveColor == "" {
+		cfg.Border.InactiveColor = defaultBorderInactiveColor
 	}
 
 	if settings.PIDFile == "" {
@@ -270,6 +292,8 @@ func validate(cfg *Config) error {
 		)
 	}
 
+	errs = append(errs, validateBorder(cfg.Border)...)
+
 	// HookKinds is a slice, so these errors come out in its declared order.
 	// The map this replaced meant validate reported the same broken config in
 	// a different order on every run.
@@ -306,6 +330,33 @@ func validate(cfg *Config) error {
 	}
 
 	return nil
+}
+
+func validateBorder(border BorderConfig) []string {
+	var errs []string
+
+	if border.Width < 1 || border.Width > maxBorderWidth {
+		errs = append(
+			errs,
+			fmt.Sprintf("border.width must be between 1 and %d", int(maxBorderWidth)),
+		)
+	}
+
+	if border.Radius != nil && *border.Radius < 0 {
+		errs = append(errs, "border.radius must be >= 0")
+	}
+
+	_, err := ParseColor(border.ActiveColor)
+	if err != nil {
+		errs = append(errs, "border.active_color must be #rrggbb or #rrggbbaa")
+	}
+
+	_, err = ParseColor(border.InactiveColor)
+	if err != nil {
+		errs = append(errs, "border.inactive_color must be #rrggbb or #rrggbbaa")
+	}
+
+	return errs
 }
 
 func expandPaths(cfg *Config) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/border"
 	"github.com/y3owk1n/mimi/internal/config"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/events"
@@ -31,6 +32,9 @@ const (
 	logSubBufSize  = 128
 	hookSubBufSize = 256
 	tileSubBufSize = 64
+	// borderSubBufSize is small on purpose. Every event asks for the same
+	// sync, and the drawer folds the ones that pile up into one.
+	borderSubBufSize = 16
 )
 
 // Run starts the mimi daemon: window/space observers, hooks executor, and config watcher.
@@ -137,6 +141,10 @@ func runCore(
 		logger.Warn("accessibility permission not granted — tiling disabled")
 	}
 
+	if cfg.Border.Enabled && !accessibilityGranted {
+		logger.Warn("accessibility permission not granted — borders disabled")
+	}
+
 	// A tiling command from the CLI reaches the engine here, off the action
 	// worker: the engine puts its own desktop work on that worker.
 	ipcServer.HandleDirect(action.NameTiling, func(cmd action.Command) error {
@@ -146,6 +154,7 @@ func runCore(
 	go pipeline.router.Run(ctx)
 	go pipeline.executor.Run(ctx, pipeline.hookSub)
 	go pipeline.tiler.Run(ctx, pipeline.tileSub)
+	go pipeline.borders.Run(ctx, pipeline.borderSub)
 	go logging.WriteEventLog(ctx, pipeline.logSub, cfg.Settings.LogFile, logger)
 
 	cfgReloader := newReloader(
@@ -155,6 +164,7 @@ func runCore(
 		pipeline.axTracker,
 		pipeline.router,
 		pipeline.tiler,
+		pipeline.borders,
 		logger,
 	)
 
@@ -208,8 +218,8 @@ func setupObservers(cfg *config.Config, logger *zap.SugaredLogger) (*native.Obse
 
 // eventPipeline bundles the dependencies setupEventPipeline wires together:
 // the event bus, the hook registry and its executor, the AX tracker and
-// router that react to window state, the tiling engine, and the three
-// subscribers that drain the bus. Packaging them here means callers — runCore and, in turn, the
+// router that react to window state, the tiling engine, the border engine,
+// and the four subscribers that drain the bus. Packaging them here means callers — runCore and, in turn, the
 // reloader — pass the bundle once instead of threading the same handful of
 // pointers by hand through every call site, which is how the fsnotify and
 // SIGHUP reload paths drifted from each other in the first place.
@@ -220,9 +230,11 @@ type eventPipeline struct {
 	reg       *hooks.Registry
 	executor  *hooks.Executor
 	tiler     *tiling.Engine
+	borders   *border.Engine
 	logSub    events.Subscriber
 	hookSub   events.Subscriber
 	tileSub   events.Subscriber
+	borderSub events.Subscriber
 }
 
 // setupEventPipeline wires the pipeline. serialize is where the tiling
@@ -268,6 +280,14 @@ func setupEventPipeline(
 	tiler.Update(tilingConfigFor(cfg, accessibilityGranted, logger), cfg.Settings.HookShell)
 	tileSub := bus.SubscribeWithFilter(tileSubBufSize, tiler.KindFilter())
 
+	// The border engine is likewise always built and subscribed, and admits
+	// nothing while disabled. A drag reaches it ahead of the debounce, so
+	// a border follows the window rather than catching up when it settles.
+	borders := border.New(border.NativeDrawer())
+	borders.Update(borderConfigFor(cfg, accessibilityGranted))
+	borderSub := bus.SubscribeWithFilter(borderSubBufSize, borders.KindFilter())
+	router.SetRawListener(func(events.Event) { borders.Nudge() })
+
 	// The event log is opt-in via [settings].log_file; when present, write
 	// every event so the user can replay what happened. When disabled, the
 	// always-false filter prevents the bus from sending into a channel
@@ -294,9 +314,11 @@ func setupEventPipeline(
 		reg:       reg,
 		executor:  executor,
 		tiler:     tiler,
+		borders:   borders,
 		logSub:    logSub,
 		hookSub:   hookSub,
 		tileSub:   tileSub,
+		borderSub: borderSub,
 	}
 
 	return pipeline, ctx, cancel, nil
@@ -487,6 +509,7 @@ func shutdown(cancel context.CancelFunc, pipeline *eventPipeline, logger *zap.Su
 	pipeline.bus.Unsubscribe(pipeline.logSub)
 	pipeline.bus.Unsubscribe(pipeline.hookSub)
 	pipeline.bus.Unsubscribe(pipeline.tileSub)
+	pipeline.bus.Unsubscribe(pipeline.borderSub)
 }
 
 // logEventDropCounts logs the native observer's and the event bus's drop
@@ -518,10 +541,22 @@ func removePID(path string) {
 }
 
 // hasWindowEvents reports whether anything in cfg needs the AX window
-// observers: a window hook, or the tiling engine, which wakes on the same
-// events.
+// observers: a window hook, the tiling engine, or the borders, which wake on
+// the same events.
 func hasWindowEvents(cfg *config.Config) bool {
-	return cfg.Hooks.HasGroup(config.GroupWindow) || cfg.Tiling.Enabled
+	return cfg.Hooks.HasGroup(config.GroupWindow) || cfg.Tiling.Enabled || cfg.Border.Enabled
+}
+
+// borderConfigFor is the [border] section as the engine gets it: as
+// written, except that without Accessibility it is disabled, since the
+// focused window and every move come from the window observers.
+func borderConfigFor(cfg *config.Config, accessibilityGranted bool) config.BorderConfig {
+	borderCfg := cfg.Border
+	if !accessibilityGranted {
+		borderCfg.Enabled = false
+	}
+
+	return borderCfg
 }
 
 // tilingConfigFor is the [tiling] section as the engine gets it: as written,

--- a/internal/daemon/reloader.go
+++ b/internal/daemon/reloader.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/y3owk1n/mimi/internal/border"
 	"github.com/y3owk1n/mimi/internal/config"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/hooks"
@@ -44,6 +45,7 @@ type reloader struct {
 	axTracker *observe.AXTracker
 	router    *observe.Router
 	tiler     *tiling.Engine
+	borders   *border.Engine
 	logger    *zap.SugaredLogger
 }
 
@@ -63,6 +65,7 @@ func newReloader(
 	axTracker *observe.AXTracker,
 	router *observe.Router,
 	tiler *tiling.Engine,
+	borders *border.Engine,
 	logger *zap.SugaredLogger,
 ) *reloader {
 	if logger == nil {
@@ -76,6 +79,7 @@ func newReloader(
 		axTracker: axTracker,
 		router:    router,
 		tiler:     tiler,
+		borders:   borders,
 		logger:    logger,
 	}
 }
@@ -128,6 +132,10 @@ func (rl *reloader) Apply(cfg *config.Config) (reloadChanges, error) {
 
 	if rl.tiler != nil {
 		rl.tiler.Update(tilingConfigFor(cfg, perm.Accessibility, rl.logger), cfg.Settings.HookShell)
+	}
+
+	if rl.borders != nil {
+		rl.borders.Update(borderConfigFor(cfg, perm.Accessibility))
 	}
 
 	return reloadChanges{

--- a/internal/daemon/reloader_test.go
+++ b/internal/daemon/reloader_test.go
@@ -54,7 +54,7 @@ func newTestReloader(
 	)
 	executor := hooks.NewExecutor(reg, &initialCfg.Settings, logger)
 
-	cfgReloader := newReloader(initialCfg, reg, executor, axTracker, router, nil, nil)
+	cfgReloader := newReloader(initialCfg, reg, executor, axTracker, router, nil, nil, nil)
 
 	return cfgReloader, reg
 }

--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -1,5 +1,6 @@
 #import "animate.h"
 
+#import "border.h"
 #import "mimi_log.h"
 #import "workspace.h"
 
@@ -69,6 +70,12 @@ typedef struct {
 @property(nonatomic) CGImageRef picture;
 @property(nonatomic) CGImageRef mask;
 @property(nonatomic, strong) CALayer *layer;
+// ring is the border drawn under the window, carried along under the
+// proxy while the real one waits under the still, or nil when the window
+// has none. ringWidth and ringRadius are how it is drawn.
+@property(nonatomic, strong) CAShapeLayer *ring;
+@property(nonatomic) double ringWidth;
+@property(nonatomic) double ringRadius;
 @end
 
 @implementation MimiProxy
@@ -396,6 +403,28 @@ static void mimiShow(void) {
 	usleep((useconds_t)(1e6 / refresh));
 }
 
+// The ring of a border, as the border draws it, over the window frame
+// `frame` in screen coordinates.
+static CAShapeLayer *mimiRingLayer(CGRect frame, double width, double radius, MimiColor color, double scale) {
+	CAShapeLayer *ring = [CAShapeLayer layer];
+	ring.fillRule = kCAFillRuleEvenOdd;
+	ring.contentsScale = scale;
+	ring.frame = CGRectInset(frame, -width, -width);
+	CGPathRef path = MimiBorderRingPath(frame.size, width, radius);
+	ring.path = path;
+	CGPathRelease(path);
+	CGColorRef fill = CGColorCreateSRGB(color.red, color.green, color.blue, color.alpha);
+	ring.fillColor = fill;
+	CGColorRelease(fill);
+	return ring;
+}
+
+// Take a proxy's layers off screen.
+static void mimiRemoveProxy(MimiProxy *proxy) {
+	[proxy.layer removeFromSuperlayer];
+	[proxy.ring removeFromSuperlayer];
+}
+
 // A layer showing image over `frame`, in screen coordinates, clipped to
 // mask's alpha when there is one. The image is shown as it is, without a
 // copy.
@@ -481,7 +510,7 @@ static void mimiRetire(NSArray<MimiProxy *> *carried) {
 	[CATransaction setDisableActions:YES];
 	for (MimiProxy *proxy in gProxies) {
 		if (![carried containsObject:proxy]) {
-			[proxy.layer removeFromSuperlayer];
+			mimiRemoveProxy(proxy);
 		}
 	}
 	for (MimiBackdrop *backdrop in gBackdrops) {
@@ -697,6 +726,21 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 		return 0;
 	}
 
+	// Our own windows to leave out of the stills: the hosts, and the borders
+	// under the animating windows, which move with them as rings under the
+	// proxies. The borders under every other window stay in the stills where
+	// they are.
+	NSMutableSet<NSNumber *> *own = [NSMutableSet set];
+	for (MimiHost *host in gHosts.allValues) {
+		[own addObject:@(host.windowNumber)];
+	}
+	for (MimiProxy *proxy in next) {
+		uint32_t border = MimiBorderWindowNumber(proxy.number);
+		if (border) {
+			[own addObject:@(border)];
+		}
+	}
+
 	// Everything on screen but the animating windows and our own. The list
 	// runs front to back, and is split at the first animating window.
 	// Whatever comes before it is in front of every moving window, a
@@ -711,11 +755,10 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 	MimiEntry *front = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
 	MimiEntry *under = calloc((size_t)onScreenCount + 1, sizeof(MimiEntry));
 	int othersCount = 0, frontCount = 0, underCount = 0;
-	pid_t self = getpid();
 	BOOL passed = NO;
 	int depth = 0;
 	for (NSDictionary *info in (__bridge NSArray *)onScreen) {
-		if ([info[(id)kCGWindowOwnerPID] intValue] == self || [info[(id)kCGWindowLayer] intValue] > kMimiHostLayer) {
+		if ([own containsObject:info[(id)kCGWindowNumber]] || [info[(id)kCGWindowLayer] intValue] > kMimiHostLayer) {
 			continue;
 		}
 		MimiEntry entry = {.number = [info[(id)kCGWindowNumber] unsignedIntValue]};
@@ -958,6 +1001,13 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 				CGImageRelease(proxy.mask);
 				proxy.mask = NULL;
 			}
+			double width = 0, radius = 0;
+			MimiColor color;
+			if (MimiBorderRing(proxy.number, &width, &radius, &color)) {
+				proxy.ring = mimiRingLayer(proxy.from, width, radius, color, proxy.scale);
+				proxy.ringWidth = width;
+				proxy.ringRadius = radius;
+			}
 		}
 		// Every proxy goes to the top of its host, carried ones included,
 		// so they stack as their windows do.
@@ -970,7 +1020,10 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 				}
 			}
 		}
-		[proxy.layer removeFromSuperlayer];
+		mimiRemoveProxy(proxy);
+		if (proxy.ring) {
+			[root addSublayer:proxy.ring];
+		}
 		[root addSublayer:proxy.layer];
 	}
 	for (MimiBackdrop *backdrop in backdrops) {
@@ -1023,7 +1076,7 @@ void MimiAnimationStart(const uint32_t *dropped, int count) {
 				}
 			}
 			if (drop) {
-				[proxy.layer removeFromSuperlayer];
+				mimiRemoveProxy(proxy);
 			} else {
 				[kept addObject:proxy];
 			}
@@ -1067,6 +1120,36 @@ void MimiAnimationStart(const uint32_t *dropped, int count) {
 			layer.bounds = CGRectMake(0, 0, to.size.width, to.size.height);
 			[layer addAnimation:move forKey:@"position"];
 			[layer addAnimation:size forKey:@"bounds"];
+
+			// The ring goes with it, grown by its width, its path drawn
+			// again for the size it ends at.
+			CAShapeLayer *ring = proxy.ring;
+			if (!ring) {
+				continue;
+			}
+			double width = proxy.ringWidth;
+			CGRect ringShown = mimiPresented(ring);
+			CGRect ringTo = CGRectInset(to, -width, -width);
+			CGPathRef ringPath = MimiBorderRingPath(to.size, width, proxy.ringRadius);
+
+			CABasicAnimation *ringMove = [CABasicAnimation animationWithKeyPath:@"position"];
+			ringMove.fromValue =
+			    [NSValue valueWithPoint:NSMakePoint(CGRectGetMidX(ringShown), CGRectGetMidY(ringShown))];
+			ringMove.toValue = [NSValue valueWithPoint:NSMakePoint(CGRectGetMidX(ringTo), CGRectGetMidY(ringTo))];
+			CABasicAnimation *ringSize = [CABasicAnimation animationWithKeyPath:@"bounds"];
+			ringSize.fromValue = [NSValue valueWithRect:NSMakeRect(0, 0, ringShown.size.width, ringShown.size.height)];
+			ringSize.toValue = [NSValue valueWithRect:NSMakeRect(0, 0, ringTo.size.width, ringTo.size.height)];
+			CABasicAnimation *ringShape = [CABasicAnimation animationWithKeyPath:@"path"];
+			ringShape.fromValue = (__bridge id)(ring.presentationLayer ?: ring).path;
+			ringShape.toValue = (__bridge id)ringPath;
+
+			ring.position = CGPointMake(CGRectGetMidX(ringTo), CGRectGetMidY(ringTo));
+			ring.bounds = CGRectMake(0, 0, ringTo.size.width, ringTo.size.height);
+			ring.path = ringPath;
+			CGPathRelease(ringPath);
+			[ring addAnimation:ringMove forKey:@"position"];
+			[ring addAnimation:ringSize forKey:@"bounds"];
+			[ring addAnimation:ringShape forKey:@"path"];
 		}
 		[CATransaction commit];
 		[CATransaction flush];

--- a/internal/native/application.m
+++ b/internal/native/application.m
@@ -7,6 +7,7 @@
 #import "mimi_log.h"
 
 #import <Cocoa/Cocoa.h>
+#import <dlfcn.h>
 
 #pragma mark - SkyLight External Declarations
 
@@ -23,6 +24,39 @@ extern uint32_t SLSWindowIteratorGetWindowID(CFTypeRef iterator);
 extern uint64_t SLSWindowIteratorGetTags(CFTypeRef iterator);
 extern uint64_t SLSWindowIteratorGetAttributes(CFTypeRef iterator);
 extern int SLSWindowIteratorGetLevel(CFTypeRef iterator);
+
+// The corner radii of the window under an iterator, in points, as macOS 26
+// added it. Looked up at first use, since earlier releases have no such
+// function.
+typedef CFArrayRef (*MimiCornerRadiiFn)(CFTypeRef iterator);
+
+static MimiCornerRadiiFn mimiCornerRadii(void) {
+	static MimiCornerRadiiFn fn;
+	static dispatch_once_t once;
+	dispatch_once(&once, ^{
+		fn = (MimiCornerRadiiFn)dlsym(RTLD_DEFAULT, "SLSWindowIteratorGetCornerRadii");
+	});
+	return fn;
+}
+
+// The corner radius of the window under iterator, or -1 when unknown.
+static double mimiIteratorRadius(CFTypeRef iterator) {
+	MimiCornerRadiiFn fn = mimiCornerRadii();
+	if (!fn)
+		return -1;
+	CFArrayRef radii = fn(iterator);
+	if (!radii)
+		return -1;
+	double radius = -1;
+	if (CFArrayGetCount(radii) > 0) {
+		CFNumberRef value = CFArrayGetValueAtIndex(radii, 0);
+		if (value)
+			CFNumberGetValue(value, kCFNumberDoubleType, &radius);
+	}
+	CFRelease(radii);
+	return radius;
+}
+
 extern AXError _AXUIElementGetWindow(AXUIElementRef element, CGWindowID *out);
 
 /// Every space a window can be on: current, other, and full-screen ones.
@@ -71,20 +105,20 @@ static NSArray<NSNumber *> *mimiAllSpaceIDs(void) {
 	return ids;
 }
 
-/// Window numbers of every real, unminimized window on any space, whoever
-/// owns them.
-static NSSet<NSNumber *> *mimiRealWindowNumbers(void) {
-	NSMutableSet<NSNumber *> *real = [NSMutableSet set];
-	NSArray<NSNumber *> *spaces = mimiAllSpaceIDs();
-	if (spaces.count == 0)
-		return real;
+CFArrayRef MimiCopyRealWindowsOnSpaces(CFArrayRef spaceIDs, CFArrayRef *radii) {
+	NSMutableArray<NSNumber *> *real = [NSMutableArray array];
+	NSMutableArray<NSNumber *> *corners = [NSMutableArray array];
+	if (radii)
+		*radii = CFBridgingRetain(corners);
+	if (!spaceIDs || CFArrayGetCount(spaceIDs) == 0)
+		return CFBridgingRetain(real);
 
 	uint64_t setTags = 0;
 	uint64_t clearTags = 0;
 	CFArrayRef windows = SLSCopyWindowsWithOptionsAndTags(
-	    SLSMainConnectionID(), 0, (__bridge CFArrayRef)spaces, kMimiWindowsNotMinimized, &setTags, &clearTags);
+	    SLSMainConnectionID(), 0, spaceIDs, kMimiWindowsNotMinimized, &setTags, &clearTags);
 	if (!windows)
-		return real;
+		return CFBridgingRetain(real);
 
 	CFIndex count = CFArrayGetCount(windows);
 	if (count > 0) {
@@ -97,6 +131,7 @@ static NSSet<NSNumber *> *mimiRealWindowNumbers(void) {
 					        SLSWindowIteratorGetTags(iterator), SLSWindowIteratorGetAttributes(iterator),
 					        SLSWindowIteratorGetParentID(iterator), SLSWindowIteratorGetLevel(iterator))) {
 						[real addObject:@(SLSWindowIteratorGetWindowID(iterator))];
+						[corners addObject:@(radii ? mimiIteratorRadius(iterator) : -1)];
 					}
 				}
 				CFRelease(iterator);
@@ -106,7 +141,15 @@ static NSSet<NSNumber *> *mimiRealWindowNumbers(void) {
 	}
 
 	CFRelease(windows);
-	return real;
+	return CFBridgingRetain(real);
+}
+
+/// Window numbers of every real, unminimized window on any space, whoever
+/// owns them.
+static NSSet<NSNumber *> *mimiRealWindowNumbers(void) {
+	NSArray<NSNumber *> *spaces = mimiAllSpaceIDs();
+	NSArray<NSNumber *> *real = CFBridgingRelease(MimiCopyRealWindowsOnSpaces((__bridge CFArrayRef)spaces, NULL));
+	return [NSSet setWithArray:real];
 }
 
 #pragma mark - Helpers

--- a/internal/native/border.go
+++ b/internal/native/border.go
@@ -1,0 +1,63 @@
+package native
+
+/*
+#include "border.h"
+*/
+import "C"
+
+// Color is a color with each channel from 0 to 1.
+type Color struct {
+	Red, Green, Blue, Alpha float64
+}
+
+// BorderStyle is how window borders are drawn: how wide, the radius of the
+// window corner the border follows on its inside, or FollowWindowRadius to
+// follow each window's own corner, and the colors for the focused window
+// and for every other.
+type BorderStyle struct {
+	Width    float64
+	Radius   float64
+	Active   Color
+	Inactive Color
+}
+
+// FollowWindowRadius is the Radius that follows each window's own corner
+// as the window server reports it, which macOS 26 added; on earlier
+// releases every window is drawn with the radius of a document window.
+const FollowWindowRadius = -1
+
+// SetBorderStyle draws borders under every real window on the spaces in
+// front, in the given style, from now on. It restyles the borders already
+// shown.
+func SetBorderStyle(style BorderStyle) {
+	cStyle := C.MimiBorderStyle{
+		width:    C.double(style.Width),
+		radius:   C.double(style.Radius),
+		active:   cColor(style.Active),
+		inactive: cColor(style.Inactive),
+	}
+	C.MimiBordersSetStyle(&cStyle)
+}
+
+// SyncBorders brings the borders up to date with the windows. refocus asks
+// Accessibility which window is focused first; a drag leaves focus alone,
+// so a caller reporting one passes false. Calls made before the last has
+// drawn fold into it.
+func SyncBorders(refocus bool) {
+	C.MimiBordersSync(boolToInt(refocus))
+}
+
+// ClearBorders takes every border off the screen and draws none until the
+// next SetBorderStyle.
+func ClearBorders() {
+	C.MimiBordersClear()
+}
+
+func cColor(color Color) C.MimiColor {
+	return C.MimiColor{
+		red:   C.double(color.Red),
+		green: C.double(color.Green),
+		blue:  C.double(color.Blue),
+		alpha: C.double(color.Alpha),
+	}
+}

--- a/internal/native/border.h
+++ b/internal/native/border.h
@@ -1,0 +1,57 @@
+#ifndef MIMI_BORDER_H
+#define MIMI_BORDER_H
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+
+/// A colour, each channel 0 to 1.
+typedef struct {
+	double red;
+	double green;
+	double blue;
+	double alpha;
+} MimiColor;
+
+/// How borders are drawn: how wide, the radius of the window's corner the
+/// border follows on its inside, or -1 to follow each window's own corner as
+/// the window server reports it, and the colour for the focused window and
+/// for every other.
+typedef struct {
+	double width;
+	double radius;
+	MimiColor active;
+	MimiColor inactive;
+} MimiBorderStyle;
+
+/// Draw borders with the given style from now on, restyling the borders
+/// already on screen. Borders are drawn for every real window on the spaces
+/// in front, under the window they belong to, so nothing draws over another
+/// application's content.
+void MimiBordersSetStyle(const MimiBorderStyle *style);
+
+/// Bring the borders up to date with the windows: add one for a window
+/// without, move one whose window moved, drop one whose window is gone.
+/// With refocus set, ask Accessibility which window is focused first; a
+/// drag leaves focus where it was, so a caller reporting one leaves it
+/// unset. Calls made before the last one has run are folded into it.
+void MimiBordersSync(int refocus);
+
+/// Take every border off the screen and draw none until the next
+/// MimiBordersSetStyle.
+void MimiBordersClear(void);
+
+/// The window number of the border drawn under window number, or 0 when it
+/// has none. Main thread only.
+uint32_t MimiBorderWindowNumber(uint32_t number);
+
+/// Describe the border drawn under window number, for drawing a copy of it
+/// elsewhere: how wide, the corner radius it follows, and its colour. Returns
+/// 0 when the window has none. Main thread only.
+int MimiBorderRing(uint32_t number, double *width, double *radius, MimiColor *color);
+
+/// A ring path for a window of size, in a rect grown by width on every side
+/// with its origin at zero: the outside rounded by radius plus width, the
+/// window's own rect cut out rounded by radius. The caller releases it.
+CGPathRef MimiBorderRingPath(CGSize size, double width, double radius);
+
+#endif  // MIMI_BORDER_H

--- a/internal/native/border.m
+++ b/internal/native/border.m
@@ -1,0 +1,359 @@
+#import "border.h"
+
+#import "mimi.h"
+#import "mimi_log.h"
+
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
+#import <stdatomic.h>
+#import <unistd.h>
+
+extern int SLSMainConnectionID(void);
+extern CGError SLSOrderWindow(int cid, uint32_t wid, int mode, uint32_t relativeTo);
+
+// SLSOrderWindow's mode for ordering under the relative window.
+static const int kMimiOrderBelow = -1;
+
+// A border is a window of our own, a little larger than the window it
+// belongs to and ordered right under it, so the window covers the middle and
+// the ring around it shows. Nothing is drawn over another application's
+// content, and a window that overlaps a bordered one covers the border as it
+// covers the window. The ring is a shape layer with the window's corner cut
+// out of it, so the corners under the window's own rounded ones stay clear.
+//
+// The window server is asked which windows are real and on the spaces in
+// front, the same test the queries use, and Accessibility which is focused,
+// once per sync from the thread that asks. Every window and layer lives on
+// the main thread, where the daemon runs its application loop.
+
+#pragma mark - Types
+
+@interface MimiBorder : NSWindow
+// targetBounds is the target's frame the border was last drawn for, in screen
+// coordinates, y down.
+@property(nonatomic) CGRect targetBounds;
+// radius is the window's own corner radius, or -1 when the window server
+// does not say.
+@property(nonatomic) double radius;
+@property(nonatomic) BOOL active;
+@property(nonatomic, strong) CAShapeLayer *ring;
+@end
+
+@implementation MimiBorder
+
+- (BOOL)canBecomeKeyWindow {
+	return NO;
+}
+
+- (BOOL)canBecomeMainWindow {
+	return NO;
+}
+
+- (BOOL)isAccessibilityElement {
+	return NO;
+}
+
+@end
+
+// The corner radius drawn for a window whose own the window server does not
+// report, when the style follows the window: what macOS gives a document
+// window.
+static const double kMimiFallbackRadius = 12;
+
+// Put border right under its window, in one window server call. AppKit's
+// own ordering takes a shown window off the screen and back, which flashes.
+static void mimiOrderUnder(MimiBorder *border, uint32_t number) {
+	// AppKit has to show the window once for the window server to know it.
+	if (!border.visible)
+		[border orderFront:nil];
+	SLSOrderWindow(SLSMainConnectionID(), (uint32_t)border.windowNumber, kMimiOrderBelow, number);
+}
+
+// The borders by the number of the window each belongs to, main thread only.
+static NSMutableDictionary<NSNumber *, MimiBorder *> *gBorders;
+static MimiBorderStyle gStyle;
+static BOOL gEnabled;
+static uint32_t gFocused;
+
+// A sync asked for while one waits to run is folded into it, since a drag
+// asks faster than the main thread draws.
+static atomic_int gQueued;
+static atomic_int gWantRefocus;
+static atomic_uint gFocusRequest;
+
+#pragma mark - Helpers
+
+// NSWindow frames are y up from the primary display's bottom-left.
+static NSRect mimiBorderCocoaRect(CGRect rect) {
+	double primaryHeight = CGDisplayBounds(CGMainDisplayID()).size.height;
+	return NSMakeRect(
+	    rect.origin.x, primaryHeight - rect.origin.y - rect.size.height, rect.size.width, rect.size.height);
+}
+
+static CGColorRef mimiBorderColor(MimiColor color) {
+	return CGColorCreateSRGB(color.red, color.green, color.blue, color.alpha);
+}
+
+// The window the user is typing into, by number, or 0 when there is none.
+// An Accessibility round trip into the frontmost application.
+static uint32_t mimiFocusedWindowNumber(void) {
+	void *window = MimiGetFrontmostWindow();
+	if (!window)
+		return 0;
+	uint32_t number = MimiGetWindowNumber(window);
+	MimiReleaseElement(window);
+	return number;
+}
+
+// The space ids in front on every display, and the displays' bounds.
+static NSArray<NSNumber *> *mimiSpacesInFront(CGRect *displays, uint32_t *displayCount) {
+	NSMutableArray<NSNumber *> *spaces = [NSMutableArray array];
+	CGDirectDisplayID ids[16];
+	uint32_t count = 0;
+	CGGetActiveDisplayList(16, ids, &count);
+	for (uint32_t i = 0; i < count; i++) {
+		displays[i] = CGDisplayBounds(ids[i]);
+		uint64_t sid = MimiDisplayActiveSpaceID(ids[i]);
+		if (sid)
+			[spaces addObject:@(sid)];
+	}
+	*displayCount = count;
+	return spaces;
+}
+
+// Whether frame fills a display, which is how a full-screen window sits: a
+// border under one has nothing to show.
+static BOOL mimiFillsADisplay(CGRect frame, const CGRect *displays, uint32_t displayCount) {
+	for (uint32_t i = 0; i < displayCount; i++) {
+		if (CGRectEqualToRect(frame, displays[i]))
+			return YES;
+	}
+	return NO;
+}
+
+// The window server's description of each window: its owner and bounds.
+// The ids go in as the pointers CGWindowListCreateDescriptionFromArray
+// reads, not as numbers.
+static CFArrayRef mimiDescribe(NSArray<NSNumber *> *numbers) {
+	CFIndex count = (CFIndex)numbers.count;
+	const void **ids = calloc((size_t)count + 1, sizeof(void *));
+	for (CFIndex i = 0; i < count; i++) {
+		ids[i] = (const void *)(uintptr_t)numbers[(NSUInteger)i].unsignedIntValue;
+	}
+	CFArrayRef list = CFArrayCreate(NULL, ids, count, NULL);
+	free(ids);
+	CFArrayRef described = list ? CGWindowListCreateDescriptionFromArray(list) : NULL;
+	if (list)
+		CFRelease(list);
+	return described;
+}
+
+#pragma mark - Drawing
+
+static MimiBorder *mimiNewBorder(void) {
+	MimiBorder *border = [[MimiBorder alloc] initWithContentRect:NSMakeRect(0, 0, 1, 1)
+	                                                   styleMask:NSWindowStyleMaskBorderless
+	                                                     backing:NSBackingStoreBuffered
+	                                                       defer:NO];
+	border.level = NSNormalWindowLevel;
+	border.opaque = NO;
+	border.backgroundColor = [NSColor clearColor];
+	border.hasShadow = NO;
+	border.ignoresMouseEvents = YES;
+	border.releasedWhenClosed = NO;
+	border.animationBehavior = NSWindowAnimationBehaviorNone;
+	border.collectionBehavior = NSWindowCollectionBehaviorStationary | NSWindowCollectionBehaviorIgnoresCycle;
+	NSView *view = border.contentView;
+	view.wantsLayer = YES;
+	CAShapeLayer *ring = [CAShapeLayer layer];
+	ring.fillRule = kCAFillRuleEvenOdd;
+	ring.anchorPoint = CGPointZero;
+	ring.position = CGPointZero;
+	ring.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+	[view.layer addSublayer:ring];
+	border.ring = ring;
+	return border;
+}
+
+CGPathRef MimiBorderRingPath(CGSize size, double width, double radius) {
+	CGRect frame = CGRectMake(0, 0, size.width + 2 * width, size.height + 2 * width);
+	CGRect hole = CGRectInset(frame, width, width);
+	double inner = MIN(radius, MIN(hole.size.width, hole.size.height) / 2);
+	CGMutablePathRef path = CGPathCreateMutable();
+	CGPathAddRoundedRect(path, NULL, frame, inner + width, inner + width);
+	// The hole is a rounded rect even when square, so every ring path has
+	// the same elements and one animates into another.
+	CGPathAddRoundedRect(path, NULL, hole, MAX(inner, 0.001), MAX(inner, 0.001));
+	return path;
+}
+
+// The corner radius drawn for border: the style's, or the window's own.
+static double mimiRadiusFor(MimiBorder *border) {
+	if (gStyle.radius >= 0)
+		return gStyle.radius;
+	return border.radius >= 0 ? border.radius : kMimiFallbackRadius;
+}
+
+// Draw border for bounds, in the colour for whether it is active: the
+// window frame is bounds grown by the width, and the ring is the window
+// frame with bounds cut out, both with rounded corners.
+static void mimiDrawBorder(MimiBorder *border, CGRect bounds, BOOL active) {
+	double width = gStyle.width;
+	CGRect outer = CGRectInset(bounds, -width, -width);
+	[border setFrame:mimiBorderCocoaRect(outer) display:NO];
+
+	CGRect frame = CGRectMake(0, 0, outer.size.width, outer.size.height);
+	CGPathRef path = MimiBorderRingPath(bounds.size, width, mimiRadiusFor(border));
+
+	CGColorRef color = mimiBorderColor(active ? gStyle.active : gStyle.inactive);
+	[CATransaction begin];
+	[CATransaction setDisableActions:YES];
+	border.ring.contentsScale = border.backingScaleFactor;
+	border.ring.bounds = frame;
+	border.ring.path = path;
+	border.ring.fillColor = color;
+	[CATransaction commit];
+	CGColorRelease(color);
+	CGPathRelease(path);
+
+	border.targetBounds = bounds;
+	border.active = active;
+}
+
+static void mimiCloseAll(void) {
+	for (MimiBorder *border in gBorders.allValues) {
+		[border close];
+	}
+	[gBorders removeAllObjects];
+}
+
+#pragma mark - Sync
+
+// Bring the borders up to date, on the main thread. focused is the window
+// Accessibility named, or 0 to keep the last answer.
+static void mimiSyncOnMain(uint32_t focused, BOOL refocus) {
+	if (!gEnabled)
+		return;
+	uint32_t raised = 0;
+	if (refocus && focused != gFocused) {
+		gFocused = focused;
+		raised = focused;
+	}
+
+	CGRect displays[16];
+	uint32_t displayCount = 0;
+	NSArray<NSNumber *> *spaces = mimiSpacesInFront(displays, &displayCount);
+	CFArrayRef radiiRef = NULL;
+	NSArray<NSNumber *> *numbers =
+	    CFBridgingRelease(MimiCopyRealWindowsOnSpaces((__bridge CFArrayRef)spaces, &radiiRef));
+	NSArray<NSNumber *> *radii = CFBridgingRelease(radiiRef);
+	CFArrayRef described = mimiDescribe(numbers);
+
+	pid_t self = getpid();
+	NSMutableSet<NSNumber *> *seen = [NSMutableSet set];
+	int made = 0;
+	for (NSDictionary *info in (__bridge NSArray *)described) {
+		if ([info[(id)kCGWindowOwnerPID] intValue] == self)
+			continue;
+		CGRect bounds;
+		if (!CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)info[(id)kCGWindowBounds], &bounds))
+			continue;
+		if (CGRectIsEmpty(bounds) || mimiFillsADisplay(bounds, displays, displayCount))
+			continue;
+
+		NSNumber *key = info[(id)kCGWindowNumber];
+		uint32_t number = key.unsignedIntValue;
+		BOOL active = number == gFocused;
+		MimiBorder *border = gBorders[key];
+		BOOL fresh = border == nil;
+		if (fresh) {
+			border = mimiNewBorder();
+			gBorders[key] = border;
+			made++;
+		}
+		NSUInteger at = [numbers indexOfObject:key];
+		double radius = at < radii.count ? radii[at].doubleValue : -1;
+		BOOL reshaped = radius != border.radius;
+		border.radius = radius;
+		if (fresh || reshaped || !CGRectEqualToRect(border.targetBounds, bounds) || border.active != active) {
+			mimiDrawBorder(border, bounds, active);
+		}
+		// The window server keeps no tie between a window and the border
+		// under it, so a window that comes to the front leaves its border
+		// where it was, and the border follows it. The rest of the stack
+		// has not moved, so the other borders are left alone. Ordering a
+		// shown window again is what flashes.
+		if (fresh || number == raised) {
+			mimiOrderUnder(border, number);
+		}
+		[seen addObject:key];
+	}
+	if (described)
+		CFRelease(described);
+
+	int dropped = 0;
+	for (NSNumber *key in gBorders.allKeys) {
+		if ([seen containsObject:key])
+			continue;
+		[gBorders[key] close];
+		[gBorders removeObjectForKey:key];
+		dropped++;
+	}
+
+	if (made || dropped) {
+		MIMI_LOG("borders synced: %lu shown, %d added, %d dropped", (unsigned long)gBorders.count, made, dropped);
+	}
+}
+
+#pragma mark - C Interface
+
+void MimiBordersSetStyle(const MimiBorderStyle *style) {
+	MimiBorderStyle copy = *style;
+	uint32_t focused = mimiFocusedWindowNumber();
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (!gBorders)
+			gBorders = [NSMutableDictionary new];
+		gStyle = copy;
+		gEnabled = YES;
+		for (MimiBorder *border in gBorders.allValues) {
+			mimiDrawBorder(border, border.targetBounds, border.active);
+		}
+		mimiSyncOnMain(focused, YES);
+	});
+}
+
+void MimiBordersSync(int refocus) {
+	if (refocus) {
+		atomic_store(&gFocusRequest, mimiFocusedWindowNumber());
+		atomic_store(&gWantRefocus, 1);
+	}
+	if (atomic_exchange(&gQueued, 1))
+		return;
+	dispatch_async(dispatch_get_main_queue(), ^{
+		atomic_store(&gQueued, 0);
+		BOOL want = atomic_exchange(&gWantRefocus, 0) != 0;
+		mimiSyncOnMain(atomic_load(&gFocusRequest), want);
+	});
+}
+
+uint32_t MimiBorderWindowNumber(uint32_t number) {
+	MimiBorder *border = gEnabled ? gBorders[@(number)] : nil;
+	return border ? (uint32_t)border.windowNumber : 0;
+}
+
+int MimiBorderRing(uint32_t number, double *width, double *radius, MimiColor *color) {
+	MimiBorder *border = gEnabled ? gBorders[@(number)] : nil;
+	if (!border)
+		return 0;
+	*width = gStyle.width;
+	*radius = mimiRadiusFor(border);
+	*color = border.active ? gStyle.active : gStyle.inactive;
+	return 1;
+}
+
+void MimiBordersClear(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		gEnabled = NO;
+		mimiCloseAll();
+	});
+}

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -48,6 +48,12 @@ char *MimiCopyApplicationName(int pid);
 /// Copy a running application's bundle identifier as a UTF-8 string the
 /// caller frees, or NULL when no application has that pid or it has none.
 char *MimiCopyApplicationBundleID(int pid);
+/// Copy the numbers of every real, unminimized window on the given spaces
+/// (an array of space ids), whoever owns them, as an array of NSNumber in
+/// the window server's order. With radii given, it is set to a parallel
+/// array of each window's corner radius in points, or -1 where the window
+/// server does not say (before macOS 26). The caller releases both.
+CFArrayRef MimiCopyRealWindowsOnSpaces(CFArrayRef spaceIDs, CFArrayRef *radii);
 /// Copy an application's real, unminimized windows on every space, front to
 /// back. Sets *count; the caller frees the array. Auxiliary windows (popovers,
 /// sheets, tab previews) are left out.

--- a/internal/observe/router.go
+++ b/internal/observe/router.go
@@ -46,6 +46,11 @@ type Router struct {
 	listRunning    func() []int
 	stopped        bool
 	debounceWindow time.Duration
+	// onRaw hears every move and resize as it happens, ahead of the
+	// debounce, for a subscriber that follows a drag rather than waits for
+	// it to settle. It is called on the router's goroutine and must not
+	// block.
+	onRaw func(events.Event)
 }
 
 type resizeState struct {
@@ -106,6 +111,14 @@ func (r *Router) SetDebounceWindow(window time.Duration) {
 
 	r.mu.Lock()
 	r.debounceWindow = window
+	r.mu.Unlock()
+}
+
+// SetRawListener names the function every raw move and resize goes to as
+// it arrives, ahead of the debounce. nil clears it.
+func (r *Router) SetRawListener(listener func(events.Event)) {
+	r.mu.Lock()
+	r.onRaw = listener
 	r.mu.Unlock()
 }
 
@@ -176,6 +189,14 @@ func (r *Router) handle(evt events.Event) {
 			r.cancelRetry(evt.PID)
 		}
 	case events.WindowResizing, events.WindowMoving:
+		r.mu.Lock()
+		onRaw := r.onRaw
+		r.mu.Unlock()
+
+		if onRaw != nil {
+			onRaw(evt)
+		}
+
 		r.debounceResize(evt)
 
 		return


### PR DESCRIPTION
## Description

This PR adds window borders in the style of JankyBorders: a ring around every window on the spaces in front, with the focused window in one colour and the rest in another.

New `[border]` section, off by default, every key reloadable:

```toml
[border]
enabled = true
width = 4                   # points, 1 to 32
# radius = 12               # unset follows each window's own corner radius; 0 is square
active_color = "#e2e2e3"    # #rrggbb or #rrggbbaa
inactive_color = "#414141"
```

Each ring is a window of mimi's own, ordered directly under its window through the window server, so it never draws over another application's content and an overlapping window hides it as it hides the window. Rings follow drags as they happen (the router now hands raw move and resize events to a listener ahead of the debounce), change colour with focus, and appear and disappear with windows, spaces and hidden applications. Full-screen windows get none.

With `radius` unset, each ring uses the corner radius the window server reports for its window on macOS 26 and later (16 for a terminal, 26 for an AppKit document window on this machine), and 12 points on earlier releases.

The tiling animation carries a ring under each moving picture, so borders no longer vanish for the length of the animation when a focus change moves windows.

Borders need Accessibility, like window hooks, and are disabled with a warning without it. Existing configs are unaffected.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Verified on screen on macOS 26: focus changes, resizes, space switches both ways, restyle and disable on reload, and the animation with the strip layout, where every ring slides with its window. Memory settled around 50 MB RSS after about 900 focus and resize actions.

Ordering the ring under its window uses `SLSOrderWindow`, and the per-window radius uses `SLSWindowIteratorGetCornerRadii`, looked up with `dlsym` since it exists only from macOS 26. Both are private, like the space APIs already in use.

How to test:

1. Add the `[border]` section above with `enabled = true` and run `mimi start`.
2. Click between windows; the ring colour follows focus.
3. Drag or resize a window; the ring follows it.
4. Switch spaces; rings appear on the new space and go with the old.
5. Change a colour or the width and run `mimi config reload`.
