### PR TITLE
feat(permissions): guide the user through Screen Recording at startup

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -250,10 +250,15 @@ window server slide the pictures into place. No application does any work
 while the animation runs. Taking those pictures is a screen capture, and
 macOS gates every screen capture behind Screen Recording.
 
-- The daemon asks for the permission once, at startup and on reload, and only
-  while the animation is enabled. With it disabled, the default, mimi
-  captures nothing and never asks.
-- Until it is granted, windows move at once and a warning says so.
+- The daemon asks for the permission once, at startup, and only while the
+  animation is enabled. With it disabled, the default, mimi captures nothing
+  and never asks. A dialog offers to open the macOS permission flow, to
+  continue once granted, or to skip the animation for this run.
+- Requesting clears the standing decision first. An unsigned build is a new
+  program to macOS on every rebuild while System Settings keeps showing the
+  old entry as allowed, so without the reset macOS would never prompt again.
+- Until it is granted, windows move at once and a warning says so. Enabling
+  the animation on a reload does not prompt. Restart mimi to be asked.
 - Grant it in System Settings > Privacy & Security > Screen & System Audio
   Recording, then restart mimi. macOS applies the grant on the next start.
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -120,6 +120,10 @@ func runCore(
 		return nil
 	}
 
+	if !promptScreenCapture(cfg, accessibilityGranted, logger) {
+		return nil
+	}
+
 	// The IPC server is built before the pipeline because the tiling engine
 	// drives the desktop through its action worker; it starts listening
 	// below, once the pipeline runs.
@@ -559,12 +563,33 @@ func borderConfigFor(cfg *config.Config, accessibilityGranted bool) config.Borde
 	return borderCfg
 }
 
+// promptScreenCapture shows the Screen Recording alert once, at startup,
+// when the tiling animation is enabled and macOS has not granted the
+// permission. A config that leaves the animation off never prompts. It
+// reports false when mimi must quit for a grant to take effect.
+func promptScreenCapture(
+	cfg *config.Config,
+	accessibilityGranted bool,
+	logger *zap.SugaredLogger,
+) bool {
+	if !accessibilityGranted || !cfg.Tiling.Enabled || !cfg.Tiling.Animation.Enabled ||
+		permissions.ScreenCaptureGranted() {
+		return true
+	}
+
+	if permissions.ShowScreenCaptureStartupAlert() == permissions.ScreenCaptureStartupRestartRequired {
+		logger.Info("screen recording permission granted, restart required")
+
+		return false
+	}
+
+	return true
+}
+
 // tilingConfigFor is the [tiling] section as the engine gets it: as written,
 // except that without Accessibility it is disabled, and without Screen
-// Recording its animation is. The daemon asks for Screen Recording only when
-// the animation is on, so a config that leaves it off never prompts. macOS
-// prompts once and keeps the answer, and a grant takes effect on the next
-// start.
+// Recording its animation is. It never prompts. promptScreenCapture asks at
+// startup, and a grant takes effect on the next start.
 func tilingConfigFor(
 	cfg *config.Config,
 	accessibilityGranted bool,
@@ -575,15 +600,13 @@ func tilingConfigFor(
 		tilingCfg.Enabled = false
 	}
 
-	if tilingCfg.Enabled && tilingCfg.Animation.Enabled && !native.ScreenCaptureGranted() {
-		if !permissions.RequestScreenCapture() {
-			logger.Warn(
-				"screen recording permission not granted, tiling animation disabled. " +
-					"Grant it in System Settings > Privacy & Security > Screen & System Audio Recording, then restart mimi",
-			)
+	if tilingCfg.Enabled && tilingCfg.Animation.Enabled && !permissions.ScreenCaptureGranted() {
+		logger.Warn(
+			"screen recording permission not granted, tiling animation disabled. " +
+				"Grant it in System Settings > Privacy & Security > Screen & System Audio Recording, then restart mimi",
+		)
 
-			tilingCfg.Animation.Enabled = false
-		}
+		tilingCfg.Animation.Enabled = false
 	}
 
 	if tilingCfg.Enabled && tilingCfg.Animation.Enabled {

--- a/internal/native/animate.go
+++ b/internal/native/animate.go
@@ -100,9 +100,3 @@ func StartFrameAnimation(dropped []uint32) {
 func WarmFrameAnimation() {
 	C.MimiAnimationWarm()
 }
-
-// ScreenCaptureGranted reports whether macOS lets mimi capture the screen,
-// which animating frames needs. It never prompts.
-func ScreenCaptureGranted() bool {
-	return C.MimiScreenCaptureGranted() != 0
-}

--- a/internal/native/animate.h
+++ b/internal/native/animate.h
@@ -40,7 +40,4 @@ void MimiAnimationStart(const uint32_t *dropped, int count);
 /// animation.
 void MimiAnimationWarm(void);
 
-/// Report whether the process may capture the screen, without prompting.
-int MimiScreenCaptureGranted(void);
-
 #endif  // MIMI_ANIMATE_H

--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -640,8 +640,6 @@ static MimiBackdrop *mimiNewBackdrop(
 	return backdrop;
 }
 
-int MimiScreenCaptureGranted(void) { return CGPreflightScreenCaptureAccess() ? 1 : 0; }
-
 void MimiAnimationWarm(void) {
 	if (![NSApp isRunning] && ![NSThread isMainThread]) {
 		return;

--- a/internal/permissions/check.go
+++ b/internal/permissions/check.go
@@ -20,6 +20,10 @@ type ConfigOnboardingChoice int
 // AccessibilityStartupChoice represents the user's choice in the startup permission alert.
 type AccessibilityStartupChoice int
 
+// ScreenCaptureStartupChoice represents the user's choice in the startup
+// Screen Recording alert.
+type ScreenCaptureStartupChoice int
+
 const (
 	// ConfigOnboardingCreate indicates the user chose to create a config file.
 	ConfigOnboardingCreate ConfigOnboardingChoice = 1
@@ -32,6 +36,13 @@ const (
 	AccessibilityStartupQuit AccessibilityStartupChoice = 2
 	// AccessibilityStartupRestartRequired indicates user needs to restart the app after granting permission.
 	AccessibilityStartupRestartRequired AccessibilityStartupChoice = 3
+
+	// ScreenCaptureStartupGranted indicates Screen Recording permission is granted.
+	ScreenCaptureStartupGranted ScreenCaptureStartupChoice = 1
+	// ScreenCaptureStartupSkip indicates the user chose to run without animation.
+	ScreenCaptureStartupSkip ScreenCaptureStartupChoice = 2
+	// ScreenCaptureStartupRestartRequired indicates the user needs to restart the app after granting permission.
+	ScreenCaptureStartupRestartRequired ScreenCaptureStartupChoice = 3
 )
 
 // CheckResult holds the results of a permissions check.
@@ -64,11 +75,22 @@ func RequestAccessibility() bool {
 	return C.MimiRequestAccessibilityPermissions() != 0
 }
 
-// RequestScreenCapture asks macOS for Screen Recording permission, which
-// animating tiling frames needs. macOS prompts the first time and remembers
-// the answer; a grant takes effect when mimi next starts.
+// ScreenCaptureGranted reports whether macOS lets mimi capture the screen,
+// which animating tiling frames needs. It never prompts.
+func ScreenCaptureGranted() bool {
+	return C.MimiCheckScreenCapturePermission() != 0
+}
+
+// RequestScreenCapture clears the standing Screen Recording decision and
+// asks macOS again, which prompts. A grant takes effect when mimi next starts.
 func RequestScreenCapture() bool {
 	return C.MimiRequestScreenCapturePermission() != 0
+}
+
+// ShowScreenCaptureStartupAlert displays startup guidance for granting
+// Screen Recording permission.
+func ShowScreenCaptureStartupAlert() ScreenCaptureStartupChoice {
+	return ScreenCaptureStartupChoice(C.MimiShowScreenCapturePermissionStartupAlert())
 }
 
 // ShowConfigOnboardingAlert displays startup guidance for creating the first config file.

--- a/internal/permissions/permissions.h
+++ b/internal/permissions/permissions.h
@@ -4,6 +4,12 @@ int MimiCheckAccessibilityPermissions(void);
 int MimiRequestAccessibilityPermissions(void);
 int MimiShowAccessibilityPermissionStartupAlert(void);
 int MimiShowConfigOnboardingAlert(const char *configPath);
-/// Ask macOS for Screen Recording permission, which prompts the first time
-/// and otherwise reports the standing decision.
+/// Report whether macOS lets mimi capture the screen. Never prompts.
+int MimiCheckScreenCapturePermission(void);
+/// Clear the standing Screen Recording decision and ask macOS again, which
+/// prompts. Reports the decision as it stands after the request.
 int MimiRequestScreenCapturePermission(void);
+/// Show the startup guidance for granting Screen Recording. Returns 1 when
+/// granted, 2 when the user chose to skip animation, 3 when mimi must restart
+/// for a grant to take effect.
+int MimiShowScreenCapturePermissionStartupAlert(void);

--- a/internal/permissions/permissions.m
+++ b/internal/permissions/permissions.m
@@ -16,7 +16,12 @@ static int MimiRunOnMainThreadSync(int (^block)(void)) {
 	return result;
 }
 
-static int MimiResetAccessibilityPermissionDecision(void) {
+// MimiResetPermissionDecision clears the TCC decision macOS holds for mimi
+// under service, so that the next request prompts again. An unsigned build
+// is a new program to TCC on every rebuild, while System Settings keeps
+// showing the old entry as allowed. Without the reset the request never
+// prompts and mimi never gets the permission.
+static int MimiResetPermissionDecision(NSString *service) {
 	NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
 	if (bundleID == nil || [bundleID length] == 0) {
 		bundleID = @"com.y3owk1n.mimi";
@@ -24,7 +29,7 @@ static int MimiResetAccessibilityPermissionDecision(void) {
 
 	NSTask *task = [[NSTask alloc] init];
 	task.launchPath = @"/usr/bin/tccutil";
-	task.arguments = @[ @"reset", @"Accessibility", bundleID ];
+	task.arguments = @[ @"reset", service, bundleID ];
 
 	@try {
 		[task launch];
@@ -33,16 +38,45 @@ static int MimiResetAccessibilityPermissionDecision(void) {
 		int status = [task terminationStatus];
 		if (status != 0) {
 			MIMI_LOG(
-			    "tccutil reset Accessibility %@ exited with status %d; system permission dialog may not appear",
-			    bundleID, status);
+			    "tccutil reset %@ %@ exited with status %d; system permission dialog may not appear", service, bundleID,
+			    status);
 			return 0;
 		}
 	} @catch (NSException *exception) {
-		MIMI_LOG("failed to reset Accessibility permission decision: %@", exception);
+		MIMI_LOG("failed to reset %@ permission decision: %@", service, exception);
 		return 0;
 	}
 
 	return 1;
+}
+
+// MimiPresentAlert runs alert as a floating modal, restores the accessory
+// activation policy, and returns the button pressed.
+static NSModalResponse MimiPresentAlert(NSAlert *alert) {
+	[[alert window] setLevel:NSFloatingWindowLevel];
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+	[[alert window] center];
+	[[alert window] makeKeyAndOrderFront:nil];
+	[NSApp activateIgnoringOtherApps:YES];
+
+	NSModalResponse response = [alert runModal];
+	[[alert window] orderOut:nil];
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+	return response;
+}
+
+// MimiShowRestartRequiredAlert tells the user the grant for permission takes
+// effect on the next start, and that mimi is quitting.
+static void MimiShowRestartRequiredAlert(NSString *permission) {
+	NSAlert *alert = [[NSAlert alloc] init];
+	alert.messageText = @"Mimi Restart Required";
+	alert.informativeText =
+	    [NSString stringWithFormat:@"macOS requires restarting Mimi for %@ permissions to take effect.\n\n"
+	                                "Mimi will now quit. Please relaunch the application.",
+	                               permission];
+	alert.alertStyle = NSAlertStyleInformational;
+	[alert addButtonWithTitle:@"Quit Mimi"];
+	MimiPresentAlert(alert);
 }
 
 int MimiCheckAccessibilityPermissions(void) {
@@ -52,7 +86,7 @@ int MimiCheckAccessibilityPermissions(void) {
 
 int MimiRequestAccessibilityPermissions(void) {
 	@autoreleasepool {
-		if (!MimiResetAccessibilityPermissionDecision()) {
+		if (!MimiResetPermissionDecision(@"Accessibility")) {
 			MIMI_LOG("continuing with Accessibility permission request after reset failure");
 		}
 
@@ -62,7 +96,17 @@ int MimiRequestAccessibilityPermissions(void) {
 	}
 }
 
-int MimiRequestScreenCapturePermission(void) { return CGRequestScreenCaptureAccess() ? 1 : 0; }
+int MimiCheckScreenCapturePermission(void) { return CGPreflightScreenCaptureAccess() ? 1 : 0; }
+
+int MimiRequestScreenCapturePermission(void) {
+	@autoreleasepool {
+		if (!MimiResetPermissionDecision(@"ScreenCapture")) {
+			MIMI_LOG("continuing with ScreenCapture permission request after reset failure");
+		}
+
+		return CGRequestScreenCaptureAccess() ? 1 : 0;
+	}
+}
 
 int MimiShowAccessibilityPermissionStartupAlert(void) {
 	return MimiRunOnMainThreadSync(^int {
@@ -83,15 +127,7 @@ int MimiShowAccessibilityPermissionStartupAlert(void) {
 				[alert addButtonWithTitle:@"Granted, Start Mimi"];
 				[alert addButtonWithTitle:@"Quit"];
 
-				[[alert window] setLevel:NSFloatingWindowLevel];
-				[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-				[[alert window] center];
-				[[alert window] makeKeyAndOrderFront:nil];
-				[NSApp activateIgnoringOtherApps:YES];
-
-				NSModalResponse response = [alert runModal];
-				[[alert window] orderOut:nil];
-				[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+				NSModalResponse response = MimiPresentAlert(alert);
 
 				if (response == NSAlertFirstButtonReturn) {
 					MimiRequestAccessibilityPermissions();
@@ -100,23 +136,48 @@ int MimiShowAccessibilityPermissionStartupAlert(void) {
 						return 1;
 					}
 
-					NSAlert *restartAlert = [[NSAlert alloc] init];
-					restartAlert.messageText = @"Mimi Restart Required";
-					restartAlert.informativeText =
-					    @"macOS requires restarting Mimi for Accessibility permissions to take effect.\n\n"
-					     "Mimi will now quit. Please relaunch the application.";
-					restartAlert.alertStyle = NSAlertStyleInformational;
-					[restartAlert addButtonWithTitle:@"Quit Mimi"];
+					MimiShowRestartRequiredAlert(@"Accessibility");
+					return 3;
+				} else if (response == NSAlertThirdButtonReturn) {
+					return 2;
+				}
+			}
 
-					[[restartAlert window] setLevel:NSFloatingWindowLevel];
-					[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-					[[restartAlert window] center];
-					[[restartAlert window] makeKeyAndOrderFront:nil];
-					[NSApp activateIgnoringOtherApps:YES];
+			return 1;
+		}
+	});
+}
 
-					[restartAlert runModal];
-					[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+int MimiShowScreenCapturePermissionStartupAlert(void) {
+	return MimiRunOnMainThreadSync(^int {
+		@autoreleasepool {
+			[NSApplication sharedApplication];
 
+			while (MimiCheckScreenCapturePermission() != 1) {
+				NSAlert *alert = [[NSAlert alloc] init];
+				alert.messageText = @"Screen Recording Permission Needed";
+				alert.informativeText =
+				    @"Mimi needs Screen Recording permission to animate tiling layouts. "
+				    @"Click Request Permission to open the macOS permission flow, grant access in System Settings, "
+				    @"then return here and click Granted, Continue. "
+				    @"Skip Animation starts Mimi with windows moving at once.";
+				alert.alertStyle = NSAlertStyleWarning;
+				alert.icon = [NSImage imageNamed:NSImageNameCaution];
+
+				[alert addButtonWithTitle:@"Request Permission"];
+				[alert addButtonWithTitle:@"Granted, Continue"];
+				[alert addButtonWithTitle:@"Skip Animation"];
+
+				NSModalResponse response = MimiPresentAlert(alert);
+
+				if (response == NSAlertFirstButtonReturn) {
+					MimiRequestScreenCapturePermission();
+				} else if (response == NSAlertSecondButtonReturn) {
+					if (MimiCheckScreenCapturePermission() == 1) {
+						return 1;
+					}
+
+					MimiShowRestartRequiredAlert(@"Screen Recording");
 					return 3;
 				} else if (response == NSAlertThirdButtonReturn) {
 					return 2;
@@ -144,15 +205,7 @@ int MimiShowConfigOnboardingAlert(const char *configPath) {
 			[alert addButtonWithTitle:@"Create Config"];
 			[alert addButtonWithTitle:@"Quit"];
 
-			[[alert window] setLevel:NSFloatingWindowLevel];
-			[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-			[[alert window] center];
-			[[alert window] makeKeyAndOrderFront:nil];
-			[NSApp activateIgnoringOtherApps:YES];
-
-			NSModalResponse response = [alert runModal];
-			[[alert window] orderOut:nil];
-			[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+			NSModalResponse response = MimiPresentAlert(alert);
 
 			if (response == NSAlertFirstButtonReturn) {
 				return 1;


### PR DESCRIPTION
## Description

This PR adds a startup dialog for Screen Recording permission, matching the one Accessibility already has.

When tiling animation is enabled and the permission is missing, mimi used to fire the system request once and silently fall back to moving windows at once. On an unsigned build that request never prompts again, because every rebuild is a new program to macOS while System Settings keeps showing the old entry as allowed. The user sees mimi listed as allowed, yet the animation never runs.

Now a dialog offers to request the permission, to continue once granted, or to skip the animation for this run. Requesting clears the standing decision first so the system prompt appears again. Confirming a grant that macOS does not yet report shows the restart notice and quits, since the grant applies on the next start. One deliberate limitation: enabling the animation on a config reload no longer prompts. It warns and moves windows at once until mimi restarts.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, the change is a native modal dialog and a TCC reset, neither of which runs headless
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

No config keys, commands, or hook variables change. Existing configs keep working; a config with the animation off, the default, never sees the dialog.

The dialog runs on the main thread after the observers start, so it works from the daemon's run loop. The Accessibility reset helper was generalised to take the TCC service name, and the three alerts now share one presentation helper.
