### PR TITLE
fix(tiling): scroll edge columns whole and carry proxies across held scrolls

### DIFF
--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -448,6 +448,20 @@ static CALayer *mimiImageLayer(CGImageRef image, CGImageRef mask, CGRect frame, 
 
 #pragma mark - Masks
 
+// A window's own picture, asked for by its number. It is whole even where
+// the window hangs past the display's edge, where a capture of the screen
+// has nothing to show. It is opaque, a flat tint where the window is
+// translucent, since nothing is under it to blend with. Its alpha carries
+// the window's shape.
+static CGImageRef mimiWholeWindow(uint32_t number) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+	return CGWindowListCreateImage(
+	    CGRectNull, kCGWindowListOptionIncludingWindow, number,
+	    kCGWindowImageBoundsIgnoreFraming | kCGWindowImageBestResolution);
+#pragma clang diagnostic pop
+}
+
 // The remembered mask for a window of this size, retained, or NULL.
 static CGImageRef mimiCachedMask(uint32_t number, CGSize size, double scale) {
 	for (int i = 0; i < gMaskCount; i++) {
@@ -693,6 +707,7 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 	// left to finish.
 	NSMutableArray<MimiProxy *> *next = [NSMutableArray arrayWithCapacity:(NSUInteger)count];
 	NSMutableArray<MimiProxy *> *carried = [NSMutableArray array];
+	BOOL retargeted = NO;
 	for (int i = 0; i < count; i++) {
 		CGRect from;
 		MimiProxy *flight = mimiInFlight(targets[i].number, &from);
@@ -712,15 +727,22 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 		proxy.number = targets[i].number;
 		proxy.from = from;
 		proxy.to = to;
-		if (flight && mimiSameRect(flight.to, to)) {
+		// A window in flight keeps its proxy, sent on to the new frame
+		// from where it is shown. A scroll held on a key repeats before
+		// the last step lands, and a capture then would find the window
+		// already at its last frame, cut at the display's edge.
+		if (flight) {
 			proxy.carried = YES;
 			proxy.layer = flight.layer;
 			proxy.scale = flight.scale;
 			[carried addObject:flight];
+			if (!mimiSameRect(flight.to, to)) {
+				retargeted = YES;
+			}
 		}
 		[next addObject:proxy];
 	}
-	if (next.count == carried.count) {
+	if (next.count == carried.count && !retargeted) {
 		return 0;
 	}
 
@@ -803,6 +825,25 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 			}
 		}
 		if (!any) {
+			// Nothing to capture here. The carried proxies still need the
+			// stills under and over them, so those stay as they are.
+			BOOL flying = NO;
+			for (MimiProxy *proxy in next) {
+				if (proxy.carried && mimiAnimatesOn(proxy, bounds)) {
+					flying = YES;
+					break;
+				}
+			}
+			if (!flying) {
+				continue;
+			}
+			for (MimiBackdrop *backdrop in gBackdrops) {
+				if (backdrop.display == displays[d]) {
+					[backdrops addObject:mimiNewBackdrop(
+					                         displays[d], bounds, backdrop.over, backdrop.shows, backdrop.showsCount,
+					                         NULL, backdrop)];
+				}
+			}
 			continue;
 		}
 		double scale = bounds.size.width > 0 ? CGDisplayPixelsWide(displays[d]) / bounds.size.width : 1;
@@ -909,13 +950,19 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 				CGRect crop = CGRectMake(
 				    (proxy.from.origin.x - bounds.origin.x) * scale, (proxy.from.origin.y - bounds.origin.y) * scale,
 				    proxy.from.size.width * scale, proxy.from.size.height * scale);
-				if (scene) {
-					proxy.picture = CGImageCreateWithImageInRect(scene, crop);
-				}
-				if (!proxy.mask && flight) {
-					proxy.mask = CGImageCreateWithImageInRect(flight, crop);
-					if (proxy.mask) {
-						mimiRememberMask(proxy.number, proxy.from.size, scale, proxy.mask);
+				if (!CGRectContainsRect(bounds, proxy.from)) {
+					// Cut at the display's edge, the crop would show only
+					// the part on screen, stretched over the whole.
+					proxy.picture = mimiWholeWindow(proxy.number);
+				} else {
+					if (scene) {
+						proxy.picture = CGImageCreateWithImageInRect(scene, crop);
+					}
+					if (!proxy.mask && flight) {
+						proxy.mask = CGImageCreateWithImageInRect(flight, crop);
+						if (proxy.mask) {
+							mimiRememberMask(proxy.number, proxy.from.size, scale, proxy.mask);
+						}
 					}
 				}
 				if (!proxy.picture && proxy.mask) {
@@ -923,9 +970,11 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 					proxy.picture = proxy.mask;
 					proxy.mask = NULL;
 				}
-			} else if (mimiOnDisplay(proxy.from, bounds)) {
+			} else if (CGRectContainsRect(bounds, proxy.from)) {
 				proxy.picture = CGWindowListCreateImage(
 				    proxy.from, kCGWindowListOptionIncludingWindow, proxy.number, kCGWindowImageBestResolution);
+			} else if (mimiOnDisplay(proxy.from, bounds)) {
+				proxy.picture = mimiWholeWindow(proxy.number);
 			} else {
 				// A window parked by an earlier animation comes back with
 				// the picture it left with. Otherwise, off the display, a
@@ -937,9 +986,7 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 				if (proxy.picture) {
 					proxy.mask = mimiCachedMask(proxy.number, proxy.from.size, scale);
 				} else {
-					proxy.picture = CGWindowListCreateImage(
-					    CGRectNull, kCGWindowListOptionIncludingWindow, proxy.number,
-					    kCGWindowImageBoundsIgnoreFraming | kCGWindowImageBestResolution);
+					proxy.picture = mimiWholeWindow(proxy.number);
 				}
 			}
 			proxy.scale = scale;


### PR DESCRIPTION
## Description

This PR fixes the strip animation stretching the left and right columns while scrolling, and makes a scroll held on a key run as one continuous motion.

A column hanging past the display's edge was cut out of the display capture, which holds only its on-screen part, and the proxy layer scaled that part across the whole column. Such a window is now captured whole by its own number, the way parked columns already are. The picture is opaque, so a translucent window shows a flat tint at the edge until it lands, the same trade-off parked columns make.

A pass that landed mid-animation threw the proxies away and captured every window again. The window was already at its last frame and cut at the edge, so every key repeat stuttered and stretched. A proxy in flight is now carried on to its new frame from where it is shown, and the stills under and over it stay in place. A held scroll captures nothing after the first step.

No config change. Existing configs keep working.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

The change is in the Objective-C capture path, which has no unit tier. It was verified live, see below.

## How to test

1. Use `examples/tiling/strip.py` with `[tiling.animation]` enabled and a long `duration_ms`.
2. Run `mimi tiling cmd scroll right` twice and screenshot mid-animation. Before, the columns entering from the left and right were drawn about twice their width. After, they scroll at their natural width with their full content.
3. Fire `mimi tiling cmd scroll left 0.05` a dozen times 60ms apart. Before, each step recaptured and stuttered. After, the strip slides as one motion.

## Additional Context

Verified live on macOS 26 with screenshots taken mid-animation from the unfixed and fixed binaries.
