### PR TITLE
fix(tiling): take every animation layer down after a held scroll

### DIFF
--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -516,39 +516,60 @@ static void mimiRememberMask(uint32_t number, CGSize size, double scale, CGImage
 
 #pragma mark - Teardown
 
-// Take every layer of the current animation off screen, but for the
-// backdrops marked reused and the proxies the next animation carries, and
-// hide the hosts left empty.
-static void mimiRetire(NSArray<MimiProxy *> *carried) {
+// Take every layer of the running animation off screen, but for those in
+// keep, and forget the animation. It sweeps every host whole, so a layer
+// nothing tracks any more cannot stay on screen. It leaves the hosts
+// where they are, since ordering one out and back in the same turn shows
+// the windows under it for a frame.
+static void mimiRetire(NSSet<CALayer *> *keep) {
 	[CATransaction begin];
 	[CATransaction setDisableActions:YES];
-	for (MimiProxy *proxy in gProxies) {
-		if (![carried containsObject:proxy]) {
-			mimiRemoveProxy(proxy);
-		}
-	}
-	for (MimiBackdrop *backdrop in gBackdrops) {
-		if (!backdrop.reused) {
-			[backdrop.layer removeFromSuperlayer];
+	for (MimiHost *host in gHosts.allValues) {
+		for (CALayer *layer in [host.root.sublayers copy]) {
+			if (![keep containsObject:layer]) {
+				[layer removeFromSuperlayer];
+			}
 		}
 	}
 	[CATransaction commit];
-	for (MimiHost *host in gHosts.allValues) {
-		if (host.root.sublayers.count == 0) {
-			[host orderOut:nil];
-		}
-	}
 	gProxies = nil;
 	gBackdrops = nil;
 	gRunning = NO;
 }
 
-static void mimiReleaseAll(void) {
-	for (MimiBackdrop *backdrop in gBackdrops) {
-		backdrop.reused = NO;
+// Hide the hosts left with nothing to show.
+static void mimiHideIdleHosts(void) {
+	for (MimiHost *host in gHosts.allValues) {
+		if (host.root.sublayers.count == 0) {
+			[host orderOut:nil];
+		}
 	}
-	mimiRetire(nil);
 }
+
+static void mimiReleaseAll(void) {
+	mimiRetire(nil);
+	mimiHideIdleHosts();
+}
+
+// The end callback takes the animation down. This guard runs behind it,
+// for when the callback never comes or Start never follows a Begin, so a
+// still of the screen cannot outlive one animation.
+static void mimiReleaseAfter(double seconds, BOOL running) {
+	unsigned generation = gGeneration;
+	dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(seconds * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+		if (gGeneration != generation || gRunning != running) {
+			return;
+		}
+		MIMI_LOG("animation: %s; releasing", running ? "end callback never came" : "never started");
+		mimiReleaseAll();
+	});
+}
+
+// How long a Begin waits for its Start before the guard takes the
+// animation down, longer than any frame write.
+static const double kMimiStartWithin = 3.0;
+// How long past its duration a running animation is given to end.
+static const double kMimiEndSlack = 0.5;
 
 #pragma mark - Begin
 
@@ -699,6 +720,13 @@ int MimiAnimationBegin(const MimiAnimationTarget *targets, int count, double dur
 }
 
 static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double duration, int easing) {
+	// A Begin that never got its Start left its layers on screen, and
+	// disarmed the end callback that would have taken them down.
+	if (!gRunning && (gProxies.count > 0 || gBackdrops.count > 0)) {
+		MIMI_LOG("animation: stale layers found; releasing");
+		mimiReleaseAll();
+	}
+
 	// Where each window starts: its current animated frame if it is
 	// animating, else where the window server has it. A window in flight
 	// to the very frame asked for again, as when the pass that follows a
@@ -735,6 +763,9 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 			proxy.carried = YES;
 			proxy.layer = flight.layer;
 			proxy.scale = flight.scale;
+			proxy.ring = flight.ring;
+			proxy.ringWidth = flight.ringWidth;
+			proxy.ringRadius = flight.ringRadius;
 			[carried addObject:flight];
 			if (!mimiSameRect(flight.to, to)) {
 				retargeted = YES;
@@ -1013,9 +1044,25 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 	free(front);
 	free(under);
 
-	// Then the layers, in one transaction: the under backdrops come in, the
-	// proxies over them back to front, the over backdrops on top, and the
-	// previous animation, if any, goes out, but for what this one keeps.
+	// The previous animation, if any, goes out, but for the carried proxies
+	// and the backdrops this one reuses. Then the new layers go in, in one
+	// transaction, with the under backdrops first, the proxies over them
+	// back to front, and the over backdrops on top. Nothing reaches the
+	// screen before the flush below, so the order costs no frame.
+	NSMutableSet<CALayer *> *keep = [NSMutableSet set];
+	for (MimiProxy *proxy in carried) {
+		[keep addObject:proxy.layer];
+		if (proxy.ring) {
+			[keep addObject:proxy.ring];
+		}
+	}
+	for (MimiBackdrop *backdrop in backdrops) {
+		if (backdrop.reused) {
+			[keep addObject:backdrop.layer];
+		}
+	}
+	mimiRetire(keep);
+
 	[CATransaction begin];
 	[CATransaction setDisableActions:YES];
 	for (MimiBackdrop *backdrop in backdrops) {
@@ -1084,7 +1131,17 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 		[mimiHost(backdrop.display, backdrop.bounds).root addSublayer:backdrop.layer];
 	}
 	[CATransaction commit];
-	mimiRetire(carried);
+
+	// Every capture failed, so there is nothing to move. The stills go out
+	// before they are ever shown, or they would cover the windows with no
+	// animation to end.
+	if (made.count == 0) {
+		MIMI_LOG("animation: no window could be pictured; releasing");
+		mimiReleaseAll();
+		return 0;
+	}
+
+	mimiHideIdleHosts();
 	for (MimiHost *host in gHosts.allValues) {
 		if (host.root.sublayers.count > 0 && !host.visible) {
 			[host orderFrontRegardless];
@@ -1097,6 +1154,8 @@ static int mimiBeginOnMain(const MimiAnimationTarget *targets, int count, double
 	gDuration = duration;
 	gEasing = easing;
 	gRunning = NO;
+	gGeneration++;
+	mimiReleaseAfter(kMimiStartWithin, NO);
 	return (int)made.count;
 }
 
@@ -1199,5 +1258,6 @@ void MimiAnimationStart(const uint32_t *dropped, int count) {
 		[CATransaction commit];
 		[CATransaction flush];
 		gRunning = YES;
+		mimiReleaseAfter(gDuration + kMimiEndSlack, YES);
 	});
 }


### PR DESCRIPTION
## Description

This PR stops a held scroll key from leaving ghost borders and, in the worst case, an empty desktop behind.

**What changed.** After a burst of rapid tiling commands with animation on, every layer of the frame animation now comes down once the last step lands. The border ring under a window in flight follows that window into the next animation step instead of being left where the previous step ended. A pass that sets up an animation but has nothing it can move takes its stills down at once, and a pass that finds the leftovers of one that never started clears them first. Two timers guard the rest, so a still of the screen can never outlive one animation: a Begin with no Start within 3s, and an animation whose end callback never arrives within its duration plus 0.5s.

**Why.** Since #226 a scroll held on a key carries each in-flight proxy into the next animation, but the ring drawn under it was not carried, and teardown only removed layers the current proxy list knew about. Every overlapping step left one ring on the host window until the daemon restarted. The same teardown could leave the full-display still up with no animation to end it, which on a strip layout looks like an empty desktop with every window unreachable.

**How to test.** With `[tiling]` on a strip layout, `[tiling.animation] enabled = true` and `[border] enabled = true`, hold the key bound to `mimi tiling cmd scroll right`, then `scroll left`, for a few seconds each. Before, rings accumulated at old column positions and stayed. After, none remain once scrolling stops. A scripted version of this (scroll commands every 30ms, eight columns) left mimi's full-display animation host window on screen after the storm on `main` and no host at all with this change, with all windows at their strip frames both times.

## Related Issues

None filed.

## Type of Change

- [x] `fix` — Bug fix

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality (the animation is Objective-C on the live window server, with no test seam; verified by the scripted storm above)
- [ ] Documentation updated (not applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The empty-desktop trigger was not reproduced in the scripted run, only the leftover-layer state it depends on. The guards close every path found that can keep a still up, and the new paths log `animation: ... releasing` so a recurrence is diagnosable with `settings.log_file` set.
