### PR TITLE
fix(tiling): leave focus on a floating window after a close in strip

### DIFF
--- a/examples/tiling/rules.py
+++ b/examples/tiling/rules.py
@@ -59,13 +59,16 @@ def serve(layout):
 
 def narrow(inp):
     """The input with `windows` narrowed to the tileable ones and `focused`
-    re-pointed at the same window, or -1 if it went."""
+    re-pointed at the same window, or -1 if it went. `focusFloating` is
+    True when it went because the focused window floats, so a layout can
+    tell focus on a floating window from focus on nothing."""
     focused_number = (
         inp["windows"][inp["focused"]]["number"] if inp["focused"] >= 0 else None
     )
     inp["windows"] = [w for w in inp["windows"] if not floating(w)]
     numbers = [w["number"] for w in inp["windows"]]
     inp["focused"] = numbers.index(focused_number) if focused_number in numbers else -1
+    inp["focusFloating"] = focused_number is not None and inp["focused"] < 0
     return inp
 
 

--- a/examples/tiling/strip.py
+++ b/examples/tiling/strip.py
@@ -216,6 +216,7 @@ def main(inp):
         state["floating"] = sorted(floats)
     windows = [w for w in inp["windows"] if w["number"] not in state.get("floating", [])]
     by_number = {w["number"]: w for w in windows}
+    focus_floating = inp["focusFloating"] or (focused is not None and focused not in by_number)
     if focused not in by_number:
         focused = None
 
@@ -324,9 +325,10 @@ def main(inp):
         offset = scroll_into_view(columns, nearest, box, GAP, offset)
 
     # A window that went away leaves focus wherever macOS put it, which may
-    # be nothing tiled at all. Then the first column in view takes it; on any
-    # other event focus outside the strip is the user's choice and stays.
-    if focus is None and at is None and event["kind"] in ("window_closed", "app_quit", "app_hide"):
+    # be nothing at all. Then the first column in view takes it. Focus on a
+    # floating window stays, as when a Quick Look panel closes and Finder
+    # takes focus back. So does focus outside the strip on any other event.
+    if focus is None and at is None and not focus_floating and event["kind"] in ("window_closed", "app_quit", "app_hide"):
         xs, _ = starts(columns, box, GAP)
         for column, left in zip(columns, xs):
             if left >= offset - 0.5:


### PR DESCRIPTION
## Description

This PR stops the strip layout from stealing focus from a floating window after another window closes.

When a window closed, the strip took focus for its first visible column whenever the focused window was not on the strip. It could not tell focus on a floating window from focus on nothing, because `rules.py` drops floating windows before the layout runs and points `focused` at -1 in both cases.

Closing a Quick Look panel over a floating Finder window hit this. macOS handed focus back to Finder, then the strip pulled it onto a tiled window.

`narrow()` in `rules.py` now sets `focusFloating` on the input when it dropped the focused window, and `strip.py` takes focus after a close only when no window holds it. Windows floated with `togglefloat` are handled the same way. The other example layouts never emit a focus, so they are unchanged.

## Related Issues

None.

## Type of Change

- [x] `fix` — Bug fix

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Tested live: daemon on the strip layout, Finder floating, Quick Look opened and closed with space. With the original `strip.py` focus landed on Safari, with this change it stays on Finder. Also fed synthetic `window_closed` inputs to `strip.py` directly. With Finder focused it emits no focus, with no focused window it still picks the first column.

Users on home-manager or a copied `~/.config/mimi/tiling/` need to update both `rules.py` and `strip.py`.