### PR TITLE
fix(tiling): do not take a full-screen switch for a drag

### DIFF
--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -763,6 +763,12 @@ func isDrag(kind string) bool {
 // resizes itself a little on every move, and raises both. A drag that
 // changed position more than it changed size is a move; anything else,
 // which includes a dragged edge, is a resize.
+//
+// A window entering or leaving full screen raises the same events, and
+// nothing is a drag then. macOS animates the space switch and reports every
+// window on the display at a frame along the way, so those frames are
+// neither compared nor remembered. The switch raises the event that lays
+// the space out.
 func (e *Engine) userDragged() (string, []uint32) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -771,14 +777,18 @@ func (e *Engine) userDragged() (string, []uint32) {
 		return "", nil
 	}
 
-	if time.Since(e.appliedAt) < e.resizeGrace {
-		e.rememberLocked()
-
+	windows, displays, fullScreen, err := e.readDesktop()
+	if err != nil {
 		return "", nil
 	}
 
-	windows, err := e.readWindows()
-	if err != nil {
+	if inFullScreenTransition(windows.Windows, displays, fullScreen) {
+		return "", nil
+	}
+
+	if time.Since(e.appliedAt) < e.resizeGrace {
+		e.rememberFrames(windows)
+
 		return "", nil
 	}
 
@@ -818,11 +828,41 @@ func (e *Engine) rememberLocked() {
 		return
 	}
 
+	e.rememberFrames(windows)
+}
+
+// rememberFrames keeps where the windows the engine placed are in windows.
+// The caller holds the lock.
+func (e *Engine) rememberFrames(windows action.WindowsInfo) {
 	for _, win := range windows.Windows {
 		if _, ok := e.applied[win.Number]; ok {
 			e.applied[win.Number] = win.Frame
 		}
 	}
+}
+
+// inFullScreenTransition reports whether the desktop is switching to or from
+// a full-screen space. Either a display shows one, or a window covers a
+// display's whole frame, menu bar included. Only a full-screen window can do
+// that, and it does while its space is not yet, or no longer, in front.
+func inFullScreenTransition(
+	windows []action.WindowEntry,
+	displays []action.DisplayEntry,
+	fullScreen map[uint32]bool,
+) bool {
+	for _, display := range displays {
+		if fullScreen[display.ID] {
+			return true
+		}
+
+		for _, win := range windows {
+			if sameFrame(win.Frame, display.Frame) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (e *Engine) readWindows() (action.WindowsInfo, error) {
@@ -837,6 +877,36 @@ func (e *Engine) readWindows() (action.WindowsInfo, error) {
 	})
 
 	return windows, err
+}
+
+// readDesktop reads the windows, the displays, and which displays show a
+// full-screen space, in one turn of the serializer.
+func (e *Engine) readDesktop() (action.WindowsInfo, []action.DisplayEntry, map[uint32]bool, error) {
+	var (
+		windows    action.WindowsInfo
+		displays   []action.DisplayEntry
+		fullScreen map[uint32]bool
+	)
+
+	err := e.run(func() error {
+		var err error
+
+		windows, err = e.desktop.Windows()
+		if err != nil {
+			return err
+		}
+
+		displays, err = e.desktop.Displays()
+		if err != nil {
+			return err
+		}
+
+		fullScreen, err = e.desktop.FullScreenDisplays()
+
+		return err
+	})
+
+	return windows, displays, fullScreen, err
 }
 
 func sameFrame(first, second action.Frame) bool {

--- a/internal/tiling/resize_test.go
+++ b/internal/tiling/resize_test.go
@@ -202,3 +202,194 @@ func TestEngine_KindFilter_RefusesDragsUnlessAsked(t *testing.T) {
 		t.Fatal("KindFilter admits moves or resizes without relayout_on_drag")
 	}
 }
+
+// transitionDesktop is a desktop of several windows whose frames, and
+// whether its display shows a full-screen space, a test sets as macOS would
+// report them mid-way through a full-screen switch.
+type transitionDesktop struct {
+	mu         sync.Mutex
+	windows    []action.WindowEntry
+	fullScreen bool
+	applies    int
+}
+
+func (d *transitionDesktop) Windows() (action.WindowsInfo, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return action.WindowsInfo{
+		Focused: 0,
+		Windows: append([]action.WindowEntry(nil), d.windows...),
+	}, nil
+}
+
+func (d *transitionDesktop) Displays() ([]action.DisplayEntry, error) {
+	return []action.DisplayEntry{{
+		Index:   1,
+		ID:      1,
+		Frame:   action.Frame{Width: 1000, Height: 1000},
+		Visible: action.Frame{Y: 30, Width: 1000, Height: 970},
+	}}, nil
+}
+
+func (d *transitionDesktop) ActiveSpaces() (map[uint32]int, error) { return map[uint32]int{1: 1}, nil }
+
+func (d *transitionDesktop) FullScreenDisplays() (map[uint32]bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return map[uint32]bool{1: d.fullScreen}, nil
+}
+
+func (d *transitionDesktop) Margins() (action.MarginsInfo, error) { return action.MarginsInfo{}, nil }
+
+func (d *transitionDesktop) Focus(uint32) error { return nil }
+
+func (d *transitionDesktop) Apply(frames []action.WindowFrame, _ *action.Animation) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.applies++
+
+	for _, frame := range frames {
+		for index := range d.windows {
+			if d.windows[index].Number == frame.Number {
+				d.windows[index].Frame = frame.Frame
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *transitionDesktop) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.applies
+}
+
+func (d *transitionDesktop) set(fullScreen bool, windows ...action.WindowEntry) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.fullScreen = fullScreen
+	d.windows = windows
+}
+
+// TestEngine_Run_FullScreenSwitchIsNotADrag pins the guard. While a window
+// enters or leaves full screen, macOS reports every window on the display
+// somewhere along the animation. Those frames run no pass, and the engine
+// does not remember them, so it judges the next drag against where it
+// placed the windows.
+func TestEngine_Run_FullScreenSwitchIsNotADrag(t *testing.T) {
+	t.Parallel()
+
+	tiled := []action.WindowEntry{
+		{Number: 1, PID: 10, App: "A", Frame: action.Frame{X: 0, Y: 30, Width: 500, Height: 970}},
+		{Number: 2, PID: 20, App: "B", Frame: action.Frame{X: 500, Y: 30, Width: 500, Height: 970}},
+		{
+			Number: 3,
+			PID:    30,
+			App:    "C",
+			Frame:  action.Frame{X: 1000, Y: 30, Width: 500, Height: 970},
+		},
+	}
+
+	desktop := &transitionDesktop{}
+	desktop.set(false, tiled...)
+
+	engine := New(desktop, nil, nil)
+	engine.resizeGrace = 50 * time.Millisecond
+	engine.Update(config.TilingConfig{
+		Enabled:        true,
+		RelayoutOnDrag: true,
+		DebounceMS:     10,
+		TimeoutSecs:    5,
+		Layout: `jq -c '{frames: [.windows[] | {number, frame}], ` +
+			`state: {last: .event.kind, windows: .event.windows}}'`,
+	}, "/bin/sh")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sub := make(events.Subscriber, 8)
+	done := make(chan struct{})
+
+	go func() {
+		engine.Run(ctx, sub)
+		close(done)
+	}()
+
+	waitFor := func(want int, why string) {
+		t.Helper()
+
+		deadline := time.Now().Add(3 * time.Second)
+		for desktop.count() < want && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+
+		if got := desktop.count(); got != want {
+			t.Fatalf("%s: applied %d times, want %d", why, got, want)
+		}
+	}
+
+	waitFor(1, "startup")
+	time.Sleep(engine.resizeGrace)
+
+	// Window 4 grows to the display's whole frame, menu bar included, on
+	// its way to a full-screen space of its own. macOS reports the desktop
+	// behind it part way through the animation, with every window shifted.
+	shifted := []action.WindowEntry{
+		{Number: 4, PID: 10, App: "A", Frame: action.Frame{Width: 1000, Height: 1000}},
+		{
+			Number: 1,
+			PID:    10,
+			App:    "A",
+			Frame:  action.Frame{X: -800, Y: 30, Width: 500, Height: 970},
+		},
+		{Number: 2, PID: 20, App: "B", Frame: action.Frame{X: 150, Y: 30, Width: 500, Height: 970}},
+		{Number: 3, PID: 30, App: "C", Frame: action.Frame{X: 150, Y: 30, Width: 500, Height: 970}},
+	}
+	desktop.set(false, shifted...)
+
+	sub <- events.Event{Kind: events.WindowResize, PID: 10}
+
+	waitFor(1, "a window entering full screen")
+
+	// The display shows the full-screen space now, and the frames behind
+	// it are whatever macOS says.
+	desktop.set(true, shifted[1:]...)
+
+	sub <- events.Event{Kind: events.WindowMove, PID: 20}
+
+	waitFor(1, "a display showing a full-screen space")
+
+	// Back on the desktop, the user drags window 2 rightwards. The engine
+	// did not remember the frames mid-switch, so window 2 is the one that
+	// moved.
+	dragged := append([]action.WindowEntry(nil), tiled...)
+	dragged[1].Frame.X += 300
+	desktop.set(false, dragged...)
+
+	sub <- events.Event{Kind: events.WindowMove, PID: 20}
+
+	waitFor(2, "a move by the user after the switch")
+
+	inputs, _, err := engine.Preview(ctx, Event{Kind: EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+
+	if string(inputs[0].State) != `{"last":"window_move","windows":[2]}` {
+		t.Fatalf(
+			"state = %s, want the pass to have reported window_move for window 2 alone",
+			inputs[0].State,
+		)
+	}
+
+	cancel()
+	<-done
+}


### PR DESCRIPTION
## Description

This PR stops a window entering full screen from rearranging a strip layout when `tiling.relayout_on_drag = true`.

Making a window full screen raises a resize event about 300 ms before the space switch. The engine's settle timer fires in that gap and reads the desktop while macOS is still animating the switch, so every window on the display reports a frame part way along the animation. The drag detector saw them all off their placed frames and ran a `window_move` pass for all of them. The strip layout then dropped each window into the column under its centre, which stacked the existing columns into one. The user saw it on leaving full screen, because that pass laid out the corrupted state.

The drag detector now reads the displays and the full-screen state with the windows. While a display shows a full-screen space, or a window covers a display's whole frame including the menu bar, nothing is a drag. Those frames are neither compared nor remembered, so the next real drag is judged against where the engine placed the windows. The space switch raises the event that lays the space out, as before.

No config change. `relayout_on_drag = false` was never affected.

## Related Issues

None filed.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Reproduced three times with a debug daemon on the strip layout from `examples/tiling/strip.py`, three windows in columns, then a new Safari window sent to full screen with `AXFullScreen`. The layout input captured during the switch had the full-screen window at the display's full 1920x1080 frame and the three desktop windows at x of -1620, 288 and 288. The new test `TestEngine_Run_FullScreenSwitchIsNotADrag` replays those frames and fails on the old engine.

The guard uses only reads the engine already makes. A window covering a display's whole frame is the earliest sign of the switch, since the space's type still reports as a desktop space while the animation runs.

Not verified live on the fixed binary yet. The screen was locked during the final run.
