### PR TITLE
feat(tiling): move a window up or down within a strip column

### DIFF
--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -332,8 +332,10 @@ alt - h         : mimi tiling cmd focus left
 alt - l         : mimi tiling cmd focus right
 alt - j         : mimi tiling cmd focus down
 alt - k         : mimi tiling cmd focus up
-alt - shift - h : mimi tiling cmd move left
-alt - shift - l : mimi tiling cmd move right
+alt + shift - h : mimi tiling cmd move left
+alt + shift - l : mimi tiling cmd move right
+alt + shift - j : mimi tiling cmd move down
+alt + shift - k : mimi tiling cmd move up
 alt - r         : mimi tiling cmd width
 alt - c         : mimi tiling cmd center
 alt - comma     : mimi tiling cmd consume

--- a/examples/tiling/strip.py
+++ b/examples/tiling/strip.py
@@ -14,7 +14,8 @@ Commands the layout answers (mimi gives them no meaning; this file does):
 
   mimi tiling cmd focus <left|right>    focus the next column that way,
                                         scrolling to it; up/down within one
-  mimi tiling cmd move <left|right>     move the focused column along the strip
+  mimi tiling cmd move <left|right>     move the focused column along the strip;
+                                        up/down swaps the window within one
   mimi tiling cmd consume                pull the focused window into the column
                                          on its left, stacked below
   mimi tiling cmd expel                  push the focused window out into a
@@ -257,9 +258,15 @@ def main(inp):
                 row = rows.index(focused)
                 focus = rows[clamp(row + (1 if args[0] == "down" else -1), 0, len(rows) - 1)]
         elif name == "move" and args:
-            to = clamp(at + (1 if args[0] == "right" else -1), 0, len(columns) - 1)
-            columns.insert(to, columns.pop(at))
-            at = to
+            if args[0] in ("left", "right"):
+                to = clamp(at + (1 if args[0] == "right" else -1), 0, len(columns) - 1)
+                columns.insert(to, columns.pop(at))
+                at = to
+            else:
+                rows = column["windows"]
+                row = rows.index(focused)
+                to = clamp(row + (1 if args[0] == "down" else -1), 0, len(rows) - 1)
+                rows[row], rows[to] = rows[to], rows[row]
         elif name == "consume" and at > 0:
             column["windows"].remove(focused)
             columns[at - 1]["windows"].append(focused)


### PR DESCRIPTION
## Description

This PR adds `move up` and `move down` to the strip layout, swapping the focused window with its neighbour in the same column.

`strip.py` already answered `focus up` and `focus down` inside a column, but `move` only understood `left` and `right`. Any other argument fell through to the horizontal branch, so `mimi tiling cmd move down` shifted the whole column left. Now `move up|down` swaps the focused window within its column, clamped at the ends, and leaves focus on that window. `move left|right` is unchanged. The skhd example in `docs/TILING.md` gains `alt - shift - j` and `alt - shift - k`.

Verified live against the daemon with a two-window column: consume, focus up, focus down, move up, move down, expel, checking frames and focus after each step.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality (example layouts have no test tier)
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
