### PR TITLE
fix(tiling): stop floating browser windows titled Settings

### DIFF
--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -75,8 +75,8 @@ config sets it, otherwise the macOS tiled-window margin that
 up.
 
 Windows that should never be tiled (System Settings, Finder, Activity
-Monitor, 1Password, windows titled Preferences or Settings, and anything
-smaller than 400 by 300 points) are listed in `rules.py`. Edit it to taste.
+Monitor, 1Password, and anything smaller than 400 by 300 points) are
+listed in `rules.py`. Edit it to taste.
 
 ---
 

--- a/examples/tiling/rules.py
+++ b/examples/tiling/rules.py
@@ -6,12 +6,11 @@ per line on stdout, once or for as long as stdin stays open. See README.md
 for the shapes. mimi runs a layout once per display,
 with that display's windows and a state of that display's own, so a layout
 only ever thinks about one display. This file is the one place to add a
-bundle identifier or a title pattern that should never be tiled.
+bundle identifier that should never be tiled.
 """
 
 import json
 import os
-import re
 import subprocess
 import sys
 
@@ -22,14 +21,11 @@ FLOATING_BUNDLES = {
     "com.1password.1password",
 }
 
-FLOATING_TITLES = re.compile(r"^(Preferences|Settings)$")
-
 
 def floating(win):
     """True for a window a layout should leave where it is."""
     return (
         win["bundleId"] in FLOATING_BUNDLES
-        or FLOATING_TITLES.match(win["title"]) is not None
         or (win["frame"]["width"] < 400 and win["frame"]["height"] < 300)
     )
 


### PR DESCRIPTION
## Description

This PR stops the example layout rules from floating a browser window whose active tab is called Settings.

`rules.py` floated any window titled exactly `Preferences` or `Settings`, meant for the small settings panel most apps open. Brave and Firefox name the window after the active tab, so opening their settings page retitled the whole browser window to `Settings`. The strip layout then saw the window as closed, dropped its column, and only re-added it (as a new column beside the focused one) once the tab closed.

The title rule is removed. Windows now float by bundle identifier or by size only, and the size rule (under 400 by 300 points) still catches real settings panels. Anyone who copied `rules.py` keeps their copy; the change only affects the shipped example and the docs paragraph that described it.

## Related Issues

None.

## Type of Change

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [ ] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Verified on Brave: with `brave://settings` open, `mimi query windows` reports the browser window's title as exactly `Settings`. With the rule removed, `strip.py` gives that window a column. `just test` ran the unit tier only; no Go code changed.
