### PR TITLE
feat(tiling): run layout commands before and after the frames

### DIFF
--- a/cmd/mimi/cmd/tiling.go
+++ b/cmd/mimi/cmd/tiling.go
@@ -154,7 +154,12 @@ func (s *cliState) runTiling(cobraCmd *cobra.Command, cmd action.Command) error 
 	engine := tiling.New(tiling.LiveDesktop{}, nil, nil)
 	engine.Update(local, cfg.Settings.HookShell)
 
-	return engine.Command(cobraCmd.Context(), tiling.EventFromArgs(cmd.Tiling))
+	err = engine.Command(cobraCmd.Context(), tiling.EventFromArgs(cmd.Tiling))
+
+	// The after lines would die with this process. Wait for them.
+	engine.Wait()
+
+	return err
 }
 
 func buildTilingPreviewCommand(state *cliState) *cobra.Command {

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -193,7 +193,9 @@ both, through `serve()` in `rules.py`.
 {
   "frames": [{"number": 4242, "frame": {"x": 8, "y": 33, "width": 1424, "height": 859}}],
   "state": {"anything": "you like"},
-  "focus": 4242
+  "focus": 4242,
+  "before": ["osascript -e 'beep'"],
+  "after": ["~/.config/mimi/warp.py 720 462"]
 }
 ```
 
@@ -202,6 +204,8 @@ both, through `serve()` in `rules.py`.
 | `frames` | The windows to place. Leave a window out to leave it where it is. Print nothing, or an empty list, to change nothing. With `[tiling.animation]` on, a frame may carry `"animate": false` to move that one window at once while the rest animate, for a window with no sensible starting position. |
 | `state` | Any JSON. Handed back next run. Omit the key and the previous state is kept. Print `null` to clear it. |
 | `focus` | Optional. A window number to give keyboard focus, before the frames move. For moving focus along a layout's own structure where spatial `focus_window` cannot, such as a strip's parked columns. |
+| `before` | Optional. Command lines mimi runs through `settings.hook_shell` before the focus and the frames, in order. mimi waits for each and kills one past `tiling.timeout_secs`. A failure logs at debug and the frames still apply. See [Running commands around the frames](#running-commands-around-the-frames). |
+| `after` | Optional. Command lines mimi runs through `settings.hook_shell` once the frames have been applied, and once the animation has ended when one runs. They run in order, detached. mimi drops their output and logs a failure at debug. Use it to act on the frames the layout returned, where a hook would run before them. See [Running commands around the frames](#running-commands-around-the-frames). |
 
 ### Coordinates
 
@@ -293,6 +297,68 @@ jq -c '(.display.visible) as $v | (.windows | length) as $n
                  width: ($v.width / $n), height: $v.height}}],
      state: null}'
 ```
+
+### Running commands around the frames
+
+A hook fires on the raw event, before the engine has settled the burst and
+written the frames, so a hook that reads the focused window's frame may read
+its old one. The `before` and `after` keys run command lines from inside the
+pass instead. `before` lines run first, and the pass waits for each of them
+to finish before it writes the frames. `after` lines run once the frames
+have been applied, and the pass does not wait for them. The layout decides
+on every run whether to print either key, since it reads `event.kind`.
+Nothing runs on a pass where a key is absent or empty, and nothing runs on
+a pass the engine skips because the space changed under it.
+
+Warping the cursor to the window that gained focus, on the two events that
+mean focus moved, with the centre taken from the frame the layout is about
+to return:
+
+```python
+import os, sys
+
+def cursor_run(inp, frames):
+    if inp["event"]["kind"] not in ("window_focus", "app_activate") or inp["focused"] < 0:
+        return []
+    focused = inp["windows"][inp["focused"]]["number"]
+    for number, f in frames:
+        if number == focused:
+            x, y = f["x"] + f["width"] / 2, f["y"] + f["height"] / 2
+            return [f"{sys.executable} ~/.config/mimi/warp.py {x:.0f} {y:.0f}"]
+    return []
+
+out = {"frames": ..., "state": state}
+after = cursor_run(inp, frames)
+if after:
+    out["after"] = after
+```
+
+And `warp.py`, standard library only, taking the point in the same
+window coordinates the frames use:
+
+```python
+import ctypes, sys
+
+class CGPoint(ctypes.Structure):
+    _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double)]
+
+cg = ctypes.CDLL("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")
+cg.CGWarpMouseCursorPosition.argtypes = [CGPoint]
+x, y = (float(v) for v in sys.argv[1:3])
+cg.CGWarpMouseCursorPosition(CGPoint(x, y))
+```
+
+Each `after` line runs through `settings.hook_shell`, detached, so a slow
+command never holds a pass. mimi drops its output and logs a non-zero exit
+at debug. With `[tiling.animation]` on, the lines start once the animation
+has ended, so a command that reads a window's frame reads the final one.
+The lines run in order, one after another.
+
+A `before` line is for something that must have happened by the time the
+frames are written. An application told to leave a window alone, or a
+border hidden for the move. mimi waits for it and kills it past
+`tiling.timeout_secs`, the same bound as the layout, so keep it quick. A
+`before` line that fails does not stop the frames.
 
 ---
 

--- a/internal/tiling/contract.go
+++ b/internal/tiling/contract.go
@@ -64,6 +64,16 @@ type Output struct {
 	// its own structure, a strip's next column say, where spatial focus
 	// cannot.
 	Focus uint32 `json:"focus,omitempty"`
+	// Before is command lines the engine runs through settings.hook_shell
+	// before the focus and the frames. It waits for each, bounded by the
+	// layout's timeout, so the line has finished when the frames move.
+	Before []string `json:"before,omitempty"`
+	// After is command lines the engine runs through settings.hook_shell
+	// once the frames have been applied, and once the animation has ended
+	// when one runs. Each runs detached with its output dropped. A layout
+	// uses it to act on the frames it returned, warping the cursor to the
+	// focused window say, once they are known to be applied.
+	After []string `json:"after,omitempty"`
 }
 
 // Event kinds the engine reports beyond the hookable ones it forwards from

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os/exec"
 	"slices"
 	"sync"
 	"time"
@@ -87,6 +88,14 @@ type Engine struct {
 	// after the write, and the frame it snapped to is the one to remember.
 	resizeGrace time.Duration
 
+	// shell is what Before and After command lines run under, as
+	// settings.hook_shell, and timeout bounds each Before line.
+	shell   string
+	timeout time.Duration
+	// after counts the After command runs still going, so a one-shot
+	// engine can wait for them before its process ends.
+	after sync.WaitGroup
+
 	// wake carries the passes the engine asks of itself, on startup and on
 	// a reload that switches it on; Run drains it alongside the bus. It
 	// holds one, so an Update before Run starts is not lost.
@@ -148,6 +157,8 @@ func (e *Engine) Update(cfg config.TilingConfig, shell string) {
 	}
 
 	e.configured = true
+	e.shell = shell
+	e.timeout = time.Duration(cfg.TimeoutSecs) * time.Second
 	e.onDrag = cfg.RelayoutOnDrag
 	e.settle = time.Duration(cfg.DebounceMS) * time.Millisecond
 
@@ -358,6 +369,13 @@ func (e *Engine) Command(ctx context.Context, event Event) error {
 	return e.passLocked(ctx, event)
 }
 
+// Wait blocks until every After line a pass started has finished. The CLI
+// calls it before it exits, because the lines would die with the process.
+// The daemon never needs to.
+func (e *Engine) Wait() {
+	e.after.Wait()
+}
+
 // Close stops a resident layout. The engine is not used after it.
 func (e *Engine) Close() {
 	e.mu.Lock()
@@ -414,6 +432,8 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 	var (
 		frames []action.WindowFrame
 		focus  uint32
+		before []string
+		after  []string
 	)
 
 	for _, input := range inputs {
@@ -431,9 +451,12 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 		if out.Focus != 0 {
 			focus = out.Focus
 		}
+
+		before = append(before, out.Before...)
+		after = append(after, out.After...)
 	}
 
-	if len(frames) == 0 && focus == 0 {
+	if len(frames) == 0 && focus == 0 && len(before) == 0 && len(after) == 0 {
 		return nil
 	}
 
@@ -455,6 +478,8 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 			}
 		}
 	}
+
+	e.runBefore(ctx, before)
 
 	// Focus goes first: it is what the user pressed a key for, and it is
 	// one round trip, while the frames wait on a screen capture when they
@@ -490,6 +515,8 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 		return err
 	}
 
+	e.runAfterLocked(after, e.animationDelay(frames))
+
 	e.logger.Debugw(
 		"tiling pass applied",
 		"kind",
@@ -503,6 +530,65 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 	)
 
 	return nil
+}
+
+// animationDelay is how long after the write the frames reach where the
+// layout put them. It is the animation's length when one moved them, and
+// zero otherwise.
+func (e *Engine) animationDelay(frames []action.WindowFrame) time.Duration {
+	if e.animation == nil || len(frames) == 0 {
+		return 0
+	}
+
+	return time.Duration(e.animation.DurationMS) * time.Millisecond
+}
+
+// runBefore runs every Before line in order and waits for each, so a line
+// has finished by the time the frames move. It kills a line past the
+// layout's timeout and logs a failure without reporting it, so the frames
+// still apply.
+func (e *Engine) runBefore(ctx context.Context, lines []string) {
+	for _, line := range lines {
+		err := e.runBeforeLine(ctx, line)
+		if err != nil {
+			e.logger.Debugw("tiling before command failed", "err", err)
+		}
+	}
+}
+
+func (e *Engine) runBeforeLine(ctx context.Context, line string) error {
+	if e.timeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, e.timeout)
+		defer cancel()
+	}
+
+	return exec.CommandContext(ctx, e.shell, "-c", line).Run()
+}
+
+// runAfterLocked starts every After line once delay has passed, detached,
+// so the pass does not wait. It logs a failure without reporting it. The
+// caller holds the lock.
+func (e *Engine) runAfterLocked(lines []string, delay time.Duration) {
+	if len(lines) == 0 {
+		return
+	}
+
+	shell, logger := e.shell, e.logger
+
+	e.after.Go(func() {
+		time.Sleep(delay)
+
+		for _, line := range lines {
+			// The command outlives the pass, so the pass's context
+			// must not bound it.
+			err := exec.CommandContext(context.Background(), shell, "-c", line).Run()
+			if err != nil {
+				logger.Debugw("tiling after command failed", "err", err)
+			}
+		}
+	})
 }
 
 // stopResidentLocked ends the resident layout, if there is one. The caller

--- a/internal/tiling/engine_test.go
+++ b/internal/tiling/engine_test.go
@@ -3,6 +3,8 @@ package tiling_test
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -46,6 +48,8 @@ type fakeDesktop struct {
 	focused    []uint32
 	// calls is the order of Apply and Focus, by name.
 	calls []string
+	// onApply, when set, runs inside each Apply.
+	onApply func()
 }
 
 func (d *fakeDesktop) Focus(number uint32) error {
@@ -104,6 +108,10 @@ func (d *fakeDesktop) Apply(frames []action.WindowFrame, animation *action.Anima
 	d.animations = append(d.animations, animation)
 	d.calls = append(d.calls, "apply")
 
+	if d.onApply != nil {
+		d.onApply()
+	}
+
 	return nil
 }
 
@@ -125,6 +133,9 @@ func newDesktop() *fakeDesktop {
 		},
 	}
 }
+
+// easing is the animation curve the tests name.
+const easing = "ease-in-out"
 
 func enabled(layout string) config.TilingConfig {
 	return config.TilingConfig{Enabled: true, Layout: layout, DebounceMS: 10, TimeoutSecs: 5}
@@ -843,7 +854,7 @@ func TestEngine_Pass_AnimatesTheFramesButNotADraggedWindow(t *testing.T) {
 	desktop := newDesktop()
 	engine := tiling.New(desktop, nil, nil)
 	cfg := enabled(echoLayout)
-	cfg.Animation = config.AnimationConfig{Enabled: true, DurationMS: 120, Easing: "ease-in-out"}
+	cfg.Animation = config.AnimationConfig{Enabled: true, DurationMS: 120, Easing: easing}
 	engine.Update(cfg, shell)
 
 	err := engine.Pass(context.Background(), tiling.Event{Kind: created})
@@ -856,7 +867,7 @@ func TestEngine_Pass_AnimatesTheFramesButNotADraggedWindow(t *testing.T) {
 		t.Fatalf("Pass(window_move) error = %v, want nil", err)
 	}
 
-	want := action.Animation{DurationMS: 120, Easing: "ease-in-out"}
+	want := action.Animation{DurationMS: 120, Easing: easing}
 	for index, got := range desktop.animations {
 		if got == nil || *got != want {
 			t.Fatalf("animations[%d] = %+v, want %+v", index, got, want)
@@ -969,4 +980,98 @@ func TestEngine_Update_KeepsAResidentLayoutUnlessItChanges(t *testing.T) {
 	cfg.Layout = "true; " + countingLayout
 	engine.Update(cfg, shell)
 	pass(1)
+}
+
+// TestEngine_Pass_RunsTheCommandsTheLayoutAsksForAfterApplying pins the
+// after key: each line runs through the shell once the frames are applied,
+// and a pass that returns only commands still runs them.
+func TestEngine_Pass_RunsTheCommandsTheLayoutAsksForAfterApplying(t *testing.T) {
+	t.Parallel()
+
+	mark := filepath.Join(t.TempDir(), "ran")
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(`jq -c '{frames: [], state: null, after: ["touch `+mark+`"]}'`), shell)
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	engine.Wait()
+
+	_, statErr := os.Stat(mark)
+	if statErr != nil {
+		t.Fatalf("after command never ran: %v", statErr)
+	}
+}
+
+// TestEngine_Pass_RunsTheCommandsAfterTheAnimation pins that with
+// [tiling.animation] on, the after lines wait for the animation to end, so a
+// command that reads a window's frame sees where it stopped.
+func TestEngine_Pass_RunsTheCommandsAfterTheAnimation(t *testing.T) {
+	t.Parallel()
+
+	mark := filepath.Join(t.TempDir(), "ran")
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	cfg := enabled(
+		`jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 10, height: 10}}], state: null, after: ["touch ` + mark + `"]}'`,
+	)
+	cfg.Animation = config.AnimationConfig{Enabled: true, DurationMS: 300, Easing: easing}
+	engine.Update(cfg, shell)
+
+	start := time.Now()
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	_, statErr := os.Stat(mark)
+	if statErr == nil {
+		t.Fatal("after command ran before the animation ended")
+	}
+
+	engine.Wait()
+
+	_, statErr = os.Stat(mark)
+	if statErr != nil {
+		t.Fatalf("after command never ran: %v", statErr)
+	}
+
+	if elapsed := time.Since(start); elapsed < 300*time.Millisecond {
+		t.Fatalf("after command ran after %s, want the 300ms animation first", elapsed)
+	}
+}
+
+// TestEngine_Pass_RunsTheBeforeCommandsAndWaitsForThem pins the before
+// key: each line runs and finishes before the frames are applied.
+func TestEngine_Pass_RunsTheBeforeCommandsAndWaitsForThem(t *testing.T) {
+	t.Parallel()
+
+	mark := filepath.Join(t.TempDir(), "ran")
+	desktop := newDesktop()
+	desktop.onApply = func() {
+		_, statErr := os.Stat(mark)
+		if statErr != nil {
+			t.Errorf("frames applied before the before command finished: %v", statErr)
+		}
+	}
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(
+		enabled(
+			`jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 10, height: 10}}], state: null, before: ["sleep 0.1; touch `+mark+`"]}'`,
+		),
+		shell,
+	)
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	if len(desktop.applied) != 1 {
+		t.Fatalf("applied %d passes, want 1", len(desktop.applied))
+	}
 }


### PR DESCRIPTION
## Description

This PR lets a layout run shell commands on either side of the frames it returns, through two new optional output keys.

`before` is a list of command lines mimi runs through `settings.hook_shell` ahead of the focus and the frames. mimi waits for each and kills one past `tiling.timeout_secs`. A failure logs at debug and the frames still apply.

`after` is a list of command lines mimi runs once the frames have been applied, and once the animation has ended when `[tiling.animation]` is on. They run in order, detached from the pass, with output dropped.

A hook fires on the raw event, before the engine has settled the burst and written the frames, so a hook that reads the focused window's frame may read the old one. `after` gives a layout the moment the frames are known to be applied, for example to warp the cursor to the window that gained focus. The layout reads `event.kind` on every run, so it decides which events print either key. `docs/TILING.md` carries a worked example.

Existing layouts print neither key and are unchanged. The CLI `mimi tiling relayout` and `mimi tiling cmd` now wait for the `after` lines before exiting, since they would otherwise die with the process.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Tested live with a throwaway layout that returned every window's current frame plus a `before` line that slept 200ms and an `after` line that warped the cursor, with a 400ms animation configured. The `before` line finished before the frames were written, the `after` line started about 450ms after the write, and the cursor landed on the focused window's centre.

Three engine tests pin the contract: an `after` line runs, it waits for the animation, and a `before` line has finished when the fake desktop's apply is called.

The native animator returns as soon as the animation is dispatched, so the engine delays the `after` lines by the configured duration rather than observing the animation's end.
