### PR TITLE
perf(tiling): shorten a pass and bound the before and after lines

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -147,6 +147,7 @@ layout = "~/.config/mimi/tiling/columns.py"
 layout_mode = "oneshot"   # or "resident", one process kept running between passes
 debounce_ms = 100     # settle a burst of window events into one pass
 timeout_secs = 5      # kill the layout past this
+command_timeout_secs = 1     # kill a before or after line the layout returned past this
 relayout_on_drag = false     # a window the user moves or resizes runs a pass too
 # gap = 12                   # points between windows; unset follows the macOS tiled-window margin
 

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -122,7 +122,7 @@ window event ---> daemon settles the burst (debounce_ms, default 100)
   shape is logged and applies nothing. The next event tries again.
 
 The `[tiling]` keys are `enabled`, `layout`, `layout_mode`, `debounce_ms`,
-`timeout_secs`, `relayout_on_drag`, and `gap`, plus a `[tiling.animation]`
+`timeout_secs`, `command_timeout_secs`, `relayout_on_drag`, and `gap`, plus a `[tiling.animation]`
 table with `enabled`, `duration_ms`, and `easing`. Every one is reloadable.
 The reference is in [CONFIGURATION.md](CONFIGURATION.md#tiling).
 
@@ -204,8 +204,8 @@ both, through `serve()` in `rules.py`.
 | `frames` | The windows to place. Leave a window out to leave it where it is. Print nothing, or an empty list, to change nothing. With `[tiling.animation]` on, a frame may carry `"animate": false` to move that one window at once while the rest animate, for a window with no sensible starting position. |
 | `state` | Any JSON. Handed back next run. Omit the key and the previous state is kept. Print `null` to clear it. |
 | `focus` | Optional. A window number to give keyboard focus, before the frames move. For moving focus along a layout's own structure where spatial `focus_window` cannot, such as a strip's parked columns. |
-| `before` | Optional. Command lines mimi runs through `settings.hook_shell` before the focus and the frames, in order. mimi waits for each and kills one past `tiling.timeout_secs`. A failure logs at debug and the frames still apply. See [Running commands around the frames](#running-commands-around-the-frames). |
-| `after` | Optional. Command lines mimi runs through `settings.hook_shell` once the frames have been applied, and once the animation has ended when one runs. They run in order, detached. mimi drops their output and logs a failure at debug. Use it to act on the frames the layout returned, where a hook would run before them. See [Running commands around the frames](#running-commands-around-the-frames). |
+| `before` | Optional. Command lines mimi runs through `settings.hook_shell` before the focus and the frames, all at once. mimi waits for every one and kills one past `tiling.command_timeout_secs`. A failure logs at debug and the frames still apply. See [Running commands around the frames](#running-commands-around-the-frames). |
+| `after` | Optional. Command lines mimi runs through `settings.hook_shell` once the frames have been applied, and once the animation has ended when one runs. They run in order, detached. mimi kills one past `tiling.command_timeout_secs`, drops their output and logs a failure at debug. Use it to act on the frames the layout returned, where a hook would run before them. See [Running commands around the frames](#running-commands-around-the-frames). |
 
 ### Coordinates
 
@@ -352,13 +352,17 @@ Each `after` line runs through `settings.hook_shell`, detached, so a slow
 command never holds a pass. mimi drops its output and logs a non-zero exit
 at debug. With `[tiling.animation]` on, the lines start once the animation
 has ended, so a command that reads a window's frame reads the final one.
-The lines run in order, one after another.
+The lines run in order, one after another, and mimi kills one past
+`tiling.command_timeout_secs`.
 
 A `before` line is for something that must have happened by the time the
 frames are written. An application told to leave a window alone, or a
-border hidden for the move. mimi waits for it and kills it past
-`tiling.timeout_secs`, the same bound as the layout, so keep it quick. A
-`before` line that fails does not stop the frames.
+border hidden for the move. mimi starts every `before` line at once and
+waits for all of them, so the pass waits as long as the slowest line.
+Do not make one depend on another. mimi kills a line past
+`tiling.command_timeout_secs` (default 1). The bound is tighter than the
+layout's because the frames wait on it. A `before` line that fails does
+not stop the frames.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,10 +87,14 @@ type TilingConfig struct {
 	// pass given the input on stdin and read to exit, or
 	// LayoutModeResident, one process kept running that reads an input
 	// line and prints an output line per pass.
-	LayoutMode     string `json:"layoutMode"     toml:"layout_mode"`
-	DebounceMS     int    `json:"debounceMs"     toml:"debounce_ms"`
-	TimeoutSecs    int    `json:"timeoutSecs"    toml:"timeout_secs"`
-	RelayoutOnDrag bool   `json:"relayoutOnDrag" toml:"relayout_on_drag"`
+	LayoutMode  string `json:"layoutMode"  toml:"layout_mode"`
+	DebounceMS  int    `json:"debounceMs"  toml:"debounce_ms"`
+	TimeoutSecs int    `json:"timeoutSecs" toml:"timeout_secs"`
+	// CommandTimeoutSecs bounds each before and after command line a
+	// layout returns. A before line holds the frames until it finishes,
+	// so its bound is its own, and tighter than the layout's.
+	CommandTimeoutSecs int  `json:"commandTimeoutSecs" toml:"command_timeout_secs"`
+	RelayoutOnDrag     bool `json:"relayoutOnDrag"     toml:"relayout_on_drag"`
 	// Gap is the space between tiled windows and at the display's edges, in
 	// points. Left unset, the macOS tiled-window margin applies, the same
 	// setting resize_window honors; set, it replaces that setting for

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -156,6 +156,7 @@ func Load(path string) (*Config, error) {
 const (
 	defaultTilingDebounceMS      = 100
 	defaultTilingTimeoutSecs     = 5
+	defaultTilingCommandSecs     = 1
 	defaultTilingAnimationMS     = 150
 	defaultTilingAnimationEasing = "ease-out"
 )
@@ -197,6 +198,10 @@ func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 
 	if cfg.Tiling.TimeoutSecs == 0 {
 		cfg.Tiling.TimeoutSecs = defaultTilingTimeoutSecs
+	}
+
+	if cfg.Tiling.CommandTimeoutSecs == 0 {
+		cfg.Tiling.CommandTimeoutSecs = defaultTilingCommandSecs
 	}
 
 	if cfg.Tiling.LayoutMode == "" {
@@ -268,6 +273,10 @@ func validate(cfg *Config) error {
 
 	if cfg.Tiling.TimeoutSecs < 1 {
 		errs = append(errs, "tiling.timeout_secs must be >= 1")
+	}
+
+	if cfg.Tiling.CommandTimeoutSecs < 1 {
+		errs = append(errs, "tiling.command_timeout_secs must be >= 1")
 	}
 
 	if cfg.Tiling.LayoutMode != LayoutModeOneshot && cfg.Tiling.LayoutMode != LayoutModeResident {

--- a/internal/tiling/contract.go
+++ b/internal/tiling/contract.go
@@ -65,14 +65,16 @@ type Output struct {
 	// cannot.
 	Focus uint32 `json:"focus,omitempty"`
 	// Before is command lines the engine runs through settings.hook_shell
-	// before the focus and the frames. It waits for each, bounded by the
-	// layout's timeout, so the line has finished when the frames move.
+	// before the focus and the frames, all at once. It waits for every one,
+	// each bounded by tiling.command_timeout_secs, so they have finished
+	// when the frames move.
 	Before []string `json:"before,omitempty"`
 	// After is command lines the engine runs through settings.hook_shell
 	// once the frames have been applied, and once the animation has ended
-	// when one runs. Each runs detached with its output dropped. A layout
-	// uses it to act on the frames it returned, warping the cursor to the
-	// focused window say, once they are known to be applied.
+	// when one runs. They run detached from the pass, in order, each
+	// bounded by tiling.command_timeout_secs, with their output dropped. A
+	// layout uses it to act on the frames it returned, warping the cursor
+	// to the focused window say, once they are known to be applied.
 	After []string `json:"after,omitempty"`
 }
 

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -89,12 +89,13 @@ type Engine struct {
 	resizeGrace time.Duration
 
 	// shell is what Before and After command lines run under, as
-	// settings.hook_shell, and timeout bounds each Before line.
-	shell   string
-	timeout time.Duration
-	// after counts the After command runs still going, so a one-shot
-	// engine can wait for them before its process ends.
-	after sync.WaitGroup
+	// settings.hook_shell, and commandTimeout bounds each line.
+	shell          string
+	commandTimeout time.Duration
+	// background counts what a pass left running past its return, the
+	// After command runs and the read-back of where the frames landed, so
+	// a one-shot engine can wait for them before its process ends.
+	background sync.WaitGroup
 
 	// wake carries the passes the engine asks of itself, on startup and on
 	// a reload that switches it on; Run drains it alongside the bus. It
@@ -158,7 +159,7 @@ func (e *Engine) Update(cfg config.TilingConfig, shell string) {
 
 	e.configured = true
 	e.shell = shell
-	e.timeout = time.Duration(cfg.TimeoutSecs) * time.Second
+	e.commandTimeout = time.Duration(cfg.CommandTimeoutSecs) * time.Second
 	e.onDrag = cfg.RelayoutOnDrag
 	e.settle = time.Duration(cfg.DebounceMS) * time.Millisecond
 
@@ -369,11 +370,12 @@ func (e *Engine) Command(ctx context.Context, event Event) error {
 	return e.passLocked(ctx, event)
 }
 
-// Wait blocks until every After line a pass started has finished. The CLI
-// calls it before it exits, because the lines would die with the process.
-// The daemon never needs to.
+// Wait blocks until everything a pass left running has finished, its After
+// lines and the read-back of where its frames landed. The CLI calls it
+// before it exits, because the lines would die with the process. The daemon
+// never needs to.
 func (e *Engine) Wait() {
-	e.after.Wait()
+	e.background.Wait()
 }
 
 // Close stops a resident layout. The engine is not used after it.
@@ -404,18 +406,43 @@ func (e *Engine) Preview(ctx context.Context, event Event) ([]Input, []Output, e
 		)
 	}
 
-	outputs := make([]Output, 0, len(inputs))
+	outputs, err := e.reduceAll(ctx, inputs)
 
-	for _, input := range inputs {
-		out, reduceErr := e.layout.Reduce(ctx, input)
-		if reduceErr != nil {
-			return inputs, outputs, reduceErr
-		}
+	return inputs, outputs, err
+}
 
-		outputs = append(outputs, out)
+// reduceAll runs the layout on every input at once, one goroutine each,
+// and returns the outputs in input order. A one-shot layout on two displays
+// starts twice in the time of one start. A resident layout answers one
+// input at a time either way. The first failure cancels the rest, and
+// reduceAll returns it with the outputs that came back before it.
+func (e *Engine) reduceAll(ctx context.Context, inputs []Input) ([]Output, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	outputs := make([]Output, len(inputs))
+	errs := make([]error, len(inputs))
+
+	var runs sync.WaitGroup
+
+	for index, input := range inputs {
+		runs.Go(func() {
+			outputs[index], errs[index] = e.layout.Reduce(ctx, input)
+			if errs[index] != nil {
+				cancel()
+			}
+		})
 	}
 
-	return inputs, outputs, nil
+	runs.Wait()
+
+	for index, err := range errs {
+		if err != nil {
+			return outputs[:index], err
+		}
+	}
+
+	return outputs, nil
 }
 
 // passLocked is Pass under the lock.
@@ -436,11 +463,13 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 		after  []string
 	)
 
-	for _, input := range inputs {
-		out, reduceErr := e.layout.Reduce(ctx, input)
-		if reduceErr != nil {
-			return reduceErr
-		}
+	outputs, err := e.reduceAll(ctx, inputs)
+	if err != nil {
+		return err
+	}
+
+	for index, out := range outputs {
+		input := inputs[index]
 
 		if out.State != nil {
 			e.states[stateKey(input)] = out.State
@@ -509,7 +538,7 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 	}
 
 	e.appliedAt = time.Now()
-	e.rememberLocked()
+	e.rememberLater(e.appliedAt)
 
 	if err != nil {
 		return err
@@ -543,47 +572,56 @@ func (e *Engine) animationDelay(frames []action.WindowFrame) time.Duration {
 	return time.Duration(e.animation.DurationMS) * time.Millisecond
 }
 
-// runBefore runs every Before line in order and waits for each, so a line
-// has finished by the time the frames move. It kills a line past the
-// layout's timeout and logs a failure without reporting it, so the frames
+// runBefore starts every Before line at once and waits for all of them, so
+// the pass waits as long as the slowest line. It kills a line past the
+// command timeout and logs a failure without reporting it, so the frames
 // still apply.
 func (e *Engine) runBefore(ctx context.Context, lines []string) {
+	var runs sync.WaitGroup
+
 	for _, line := range lines {
-		err := e.runBeforeLine(ctx, line)
-		if err != nil {
-			e.logger.Debugw("tiling before command failed", "err", err)
-		}
+		runs.Go(func() {
+			err := runLine(ctx, e.shell, line, e.commandTimeout)
+			if err != nil {
+				e.logger.Debugw("tiling before command failed", "err", err)
+			}
+		})
 	}
+
+	runs.Wait()
 }
 
-func (e *Engine) runBeforeLine(ctx context.Context, line string) error {
-	if e.timeout > 0 {
+// runLine runs one command line through the shell and kills it past
+// timeout, when there is one.
+func runLine(ctx context.Context, shell, line string, timeout time.Duration) error {
+	if timeout > 0 {
 		var cancel context.CancelFunc
 
-		ctx, cancel = context.WithTimeout(ctx, e.timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
 
-	return exec.CommandContext(ctx, e.shell, "-c", line).Run()
+	return exec.CommandContext(ctx, shell, "-c", line).Run()
 }
 
-// runAfterLocked starts every After line once delay has passed, detached,
-// so the pass does not wait. It logs a failure without reporting it. The
-// caller holds the lock.
+// runAfterLocked starts every After line once delay has passed, in order
+// and detached, so the pass does not wait. It kills a line past the command
+// timeout and logs a failure without reporting it. The caller holds the
+// lock.
 func (e *Engine) runAfterLocked(lines []string, delay time.Duration) {
 	if len(lines) == 0 {
 		return
 	}
 
-	shell, logger := e.shell, e.logger
+	shell, timeout, logger := e.shell, e.commandTimeout, e.logger
 
-	e.after.Go(func() {
+	e.background.Go(func() {
 		time.Sleep(delay)
 
 		for _, line := range lines {
 			// The command outlives the pass, so the pass's context
 			// must not bound it.
-			err := exec.CommandContext(context.Background(), shell, "-c", line).Run()
+			err := runLine(context.Background(), shell, line, timeout)
 			if err != nil {
 				logger.Debugw("tiling after command failed", "err", err)
 			}
@@ -906,15 +944,24 @@ func (e *Engine) userDragged() (string, []uint32) {
 	return string(events.WindowMove), dragged
 }
 
-// rememberLocked reads back where the windows the engine placed actually
-// are, and keeps that. The caller holds the lock.
-func (e *Engine) rememberLocked() {
-	windows, err := e.readWindows()
-	if err != nil {
-		return
-	}
+// rememberLater reads back where the windows the engine placed actually
+// are, and keeps that. Nothing in the pass needs the answer, so the read
+// runs after the pass has returned rather than holding it, and it keeps
+// what it read only while the apply it was started for is the latest.
+func (e *Engine) rememberLater(appliedAt time.Time) {
+	e.background.Go(func() {
+		windows, err := e.readWindows()
+		if err != nil {
+			return
+		}
 
-	e.rememberFrames(windows)
+		e.mu.Lock()
+		defer e.mu.Unlock()
+
+		if e.appliedAt.Equal(appliedAt) {
+			e.rememberFrames(windows)
+		}
+	})
 }
 
 // rememberFrames keeps where the windows the engine placed are in windows.

--- a/internal/tiling/engine_test.go
+++ b/internal/tiling/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1073,5 +1074,164 @@ func TestEngine_Pass_RunsTheBeforeCommandsAndWaitsForThem(t *testing.T) {
 
 	if len(desktop.applied) != 1 {
 		t.Fatalf("applied %d passes, want 1", len(desktop.applied))
+	}
+}
+
+// commandTimeout is the before and after bound the tests run with.
+func commandTimeout(cfg config.TilingConfig, secs int) config.TilingConfig {
+	cfg.CommandTimeoutSecs = secs
+
+	return cfg
+}
+
+// TestEngine_Pass_RunsTheBeforeCommandsAtOnce pins that the before lines
+// start together. Two that each take 200ms hold the pass for one of them,
+// not both.
+func TestEngine_Pass_RunsTheBeforeCommandsAtOnce(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(
+		enabled(`jq -c '{frames: [], state: null, before: ["sleep 0.2", "sleep 0.2"]}'`),
+		shell,
+	)
+
+	start := time.Now()
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed >= 400*time.Millisecond {
+		t.Fatalf("pass took %s, want the two before lines overlapped", elapsed)
+	}
+}
+
+// TestEngine_Pass_KillsABeforeCommandPastTheCommandTimeout pins that a
+// before line runs under tiling.command_timeout_secs, not the layout's
+// timeout, and that the frames still apply once it is killed.
+func TestEngine_Pass_KillsABeforeCommandPastTheCommandTimeout(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(
+		commandTimeout(
+			enabled(
+				`jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 10, height: 10}}], state: null, before: ["sleep 5"]}'`,
+			),
+			1,
+		),
+		shell,
+	)
+
+	start := time.Now()
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed >= 3*time.Second {
+		t.Fatalf("pass took %s, want the before line killed after 1s", elapsed)
+	}
+
+	if desktop.appliedCount() != 1 {
+		t.Fatalf("applied %d passes, want 1", desktop.appliedCount())
+	}
+}
+
+// TestEngine_Wait_ReturnsWhenAnAfterCommandHangs pins that the timeout
+// covers an after line too, so a one-shot engine's Wait cannot hang on one.
+func TestEngine_Wait_ReturnsWhenAnAfterCommandHangs(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(
+		commandTimeout(enabled(`jq -c '{frames: [], state: null, after: ["sleep 5"]}'`), 1),
+		shell,
+	)
+
+	start := time.Now()
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	engine.Wait()
+
+	if elapsed := time.Since(start); elapsed >= 3*time.Second {
+		t.Fatalf("Wait() returned after %s, want the after line killed after 1s", elapsed)
+	}
+}
+
+// TestEngine_Pass_RunsTheLayoutOnEveryDisplayAtOnce pins that a one-shot
+// layout runs for both displays together, and that the engine still keeps
+// its outputs by display, so each display's state names its own id.
+func TestEngine_Pass_RunsTheLayoutOnEveryDisplayAtOnce(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	desktop.displays = []action.DisplayEntry{
+		{
+			Index:   1,
+			ID:      7,
+			Frame:   action.Frame{Width: 1000, Height: 1000},
+			Visible: action.Frame{Width: 1000, Height: 1000},
+		},
+		{
+			Index:   2,
+			ID:      8,
+			Frame:   action.Frame{X: 1000, Width: 1000, Height: 1000},
+			Visible: action.Frame{X: 1000, Width: 1000, Height: 1000},
+		},
+	}
+	desktop.windows = action.WindowsInfo{Focused: 0, Windows: []action.WindowEntry{
+		{
+			Number: 1,
+			PID:    10,
+			App:    "A",
+			Frame:  action.Frame{X: 100, Y: 100, Width: 500, Height: 500},
+		},
+		{
+			Number: 2,
+			PID:    11,
+			App:    "B",
+			Frame:  action.Frame{X: 1100, Y: 100, Width: 500, Height: 500},
+		},
+	}}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(
+		enabled(`sleep 0.2; jq -c '{frames: [], state: {display: .display.id}}'`),
+		shell,
+	)
+
+	ctx := context.Background()
+	start := time.Now()
+
+	err := engine.Pass(ctx, tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed >= 400*time.Millisecond {
+		t.Fatalf("pass took %s, want the two layout runs overlapped", elapsed)
+	}
+
+	inputs, _, err := engine.Preview(ctx, tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+
+	for _, input := range inputs {
+		want := `{"display":` + strconv.Itoa(int(input.Display.ID)) + `}`
+		if got := string(input.State); got != want {
+			t.Fatalf("display %d state = %s, want %s", input.Display.ID, got, want)
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR shortens a tiling pass and bounds the `before` and `after` command lines a layout returns.

**What changed**

- The layout runs on every display at once. A one-shot layout on two displays pays its startup once instead of twice. Outputs stay in display order.
- `before` lines start together and the pass waits for the slowest. Lines must not depend on one another, and the docs say so.
- The post-apply window read-back runs after the pass returns instead of inside it.
- New `tiling.command_timeout_secs`, default 1, bounds each `before` and `after` line. A `before` line used to hold the frames for up to `timeout_secs`. An `after` line had no bound, so a hung one kept `mimi tiling cmd` alive forever on exit. Existing configs keep working.

**Why**

The pass held the frames for work that could overlap or wait. Measured live, five windows over two displays, median of 24 passes that each moved windows:

| Pass | Before | After |
| --- | --- | --- |
| One-shot command (`ratio`, `swap`, `togglesplit`) | 91 to 94 ms | 52 to 65 ms |
| Resident command | 30 to 37 ms | 22 to 24 ms |
| Relayout after a window crossed displays, one-shot | 143 ms | 101 ms |
| Relayout after a window crossed displays, resident | 64 ms | 53 ms |

**How to test**

1. Set `layout_mode = "oneshot"` with two displays that both hold windows and run `mimi tiling cmd ratio +0.05`. The pass takes about one layout startup, not two.
2. Return `"before": ["sleep 0.2", "sleep 0.2"]` from a layout. The pass waits about 200ms, not 400ms.
3. Return `"after": ["sleep 30"]` and run `mimi tiling cmd` with no daemon. It exits after `command_timeout_secs`.

## Related Issues

None.

## Type of Change

- [x] `perf` — Performance improvement

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Resident mode remains the larger lever, at roughly a third of one-shot latency on the same workload, and is unchanged here. Calculator and Dictionary windows refuse resizing and fail a pass on both trees, which is unrelated to this change.
