### PR TITLE
fix(tiling): copy parked pictures without leaving a CoreGraphics cache

### DIFF
--- a/internal/native/animate.m
+++ b/internal/native/animate.m
@@ -575,21 +575,44 @@ static void mimiRememberStill(CGDirectDisplayID display, const MimiEntry *shows,
 	    });
 }
 
-// An image in memory of its own, or NULL.
+// An image in memory of its own, or NULL. Its rows are copied straight
+// from the source's bytes: drawing the source through a context would
+// leave a cache of it in CoreGraphics, a copy the size of the picture that
+// CoreGraphics lets go on a schedule of its own, and once per parked
+// window those added up to the daemon's footprint.
 static CGImageRef mimiCopyImage(CGImageRef image) {
 	size_t width = CGImageGetWidth(image);
 	size_t height = CGImageGetHeight(image);
-	CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-	CGContextRef context = CGBitmapContextCreate(
-	    NULL, width, height, 8, 0, space, kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
-	CGColorSpaceRelease(space);
-	if (!context) {
+	size_t rowBytes = width * 4;
+	size_t sourceRowBytes = CGImageGetBytesPerRow(image);
+	if (CGImageGetBitsPerPixel(image) != 32 || sourceRowBytes < rowBytes) {
 		return NULL;
 	}
-	CGContextSetBlendMode(context, kCGBlendModeCopy);
-	CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
-	CGImageRef copy = CGBitmapContextCreateImage(context);
-	CGContextRelease(context);
+	CFDataRef source = CGDataProviderCopyData(CGImageGetDataProvider(image));
+	if (!source) {
+		return NULL;
+	}
+	// A picture cropped from a larger one starts at its first pixel and
+	// keeps the larger one's row length, so its last row may end short.
+	const uint8_t *from = CFDataGetBytePtr(source);
+	size_t available = (size_t)CFDataGetLength(source);
+	if (available < (height - 1) * sourceRowBytes + rowBytes) {
+		CFRelease(source);
+		return NULL;
+	}
+	CFMutableDataRef data = CFDataCreateMutable(NULL, (CFIndex)(rowBytes * height));
+	CFDataSetLength(data, (CFIndex)(rowBytes * height));
+	uint8_t *to = CFDataGetMutableBytePtr(data);
+	for (size_t row = 0; row < height; row++) {
+		memcpy(to + row * rowBytes, from + row * sourceRowBytes, rowBytes);
+	}
+	CFRelease(source);
+	CGDataProviderRef provider = CGDataProviderCreateWithCFData(data);
+	CFRelease(data);
+	CGImageRef copy = CGImageCreate(
+	    width, height, 8, 32, rowBytes, CGImageGetColorSpace(image), CGImageGetBitmapInfo(image), provider, NULL, false,
+	    kCGRenderingIntentDefault);
+	CGDataProviderRelease(provider);
 	return copy;
 }
 


### PR DESCRIPTION
## Description

This PR fixes the daemon's memory climbing to around 100 MB and staying there with the tiling animation enabled, after a session of strip commands and space switches on the current release.

Since #243 each window parked off screen keeps a copy of its picture. That copy was made by drawing the capture through a bitmap context, and every such draw leaves a cache of the source inside CoreGraphics, the size of the picture, which CoreGraphics releases on a schedule of its own. Once per park, those caches were what the footprint filled with. The copy is now made by copying the picture's rows directly, so nothing is drawn and no cache is left behind.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality — N/A, native capture path without unit tests; verified live (below)
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Reproduced on a 1920x1080 display with two rounds of every strip command followed by three round trips between two spaces, each with resizes and scrolls. The current release ends that sequence at 82 to 108 MB physical footprint, and a malloc stack trace of the retained blocks shows them held by CoreGraphics' internal image cache in its purgeable zone, not by any image the daemon still references. With this change the same sequence ends at 29.5 MB, and the animation was confirmed running by watching the host window appear on screen during it.
