### PR TITLE
feat(tiling): animate through Accessibility without capturing the screen

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -155,6 +155,7 @@ relayout_on_drag = false     # a window the user moves or resizes runs a pass to
 enabled = false       # move the frames into place over time instead of at once
 duration_ms = 150     # how long the move takes
 easing = "ease-out"   # linear, ease-in, ease-out or ease-in-out
+driver = "capture"    # capture (needs Screen Recording) or accessibility
 ```
 
 mimi ships no layout. `layout` is a command line, run through
@@ -243,7 +244,17 @@ screen slides in. A window the user just dragged moves at once, and a layout
 can opt a window out with `animate: false` on its frame. The focus a layout
 asks for lands before its frames move.
 
-**Animation requires Screen Recording permission.** macOS lets a process
+**Two drivers move the windows.** The `capture` driver, the default, is
+described below and needs Screen Recording. The `accessibility` driver
+needs nothing more than tiling itself: it moves the real windows through
+their applications, a frame every ten milliseconds along the curve, every
+application on a thread of its own, with the enhanced accessibility
+interface off for the duration so that applications do not animate each
+step themselves. Its smoothness is each application's to give: a window
+whose application is slow to answer moves in fewer, larger steps, and a
+resize costs an application several times what a move does.
+
+**The capture driver requires Screen Recording permission.** macOS lets a process
 move another application's window, but not fade, transform or reorder it.
 So mimi takes a picture of each window and of the rest of the screen, moves
 the real windows to their frames at once behind that still, and has the

--- a/internal/action/apply_frames.go
+++ b/internal/action/apply_frames.go
@@ -5,8 +5,10 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
 )
 
 // WindowFrame is one entry of apply_frames' payload: a window, by the number
@@ -21,10 +23,12 @@ type WindowFrame struct {
 }
 
 // Animation is how apply_frames moves the windows when it is asked to: over
-// how long, in milliseconds, and along which curve, named as in Easings.
+// how long, in milliseconds, along which curve, named as in Easings, and by
+// which driver, named as in Drivers; "" is the capture driver.
 type Animation struct {
 	DurationMS int    `json:"durationMs"`
 	Easing     string `json:"easing"`
+	Driver     string `json:"driver,omitempty"`
 }
 
 // Easings are the curves an Animation names, in the order native numbers
@@ -41,6 +45,34 @@ const MaxAnimationMS = 1000
 type ApplyFramesArgs struct {
 	Frames    []WindowFrame `json:"frames"`
 	Animation *Animation    `json:"animation,omitempty"`
+}
+
+// FrameStepper is what a Desktop offers when it can move windows a step at
+// a time through their applications, which is how the accessibility driver
+// animates. A desktop that cannot moves the frames at once.
+type FrameStepper interface {
+	// StepWindowFrame writes one step of a window's frame. Unlike
+	// SetWindowFrame it leaves the desktop's listing alone: a step is one
+	// of a hundred a second.
+	StepWindowFrame(id WindowID, frame geometry.Rect) error
+	// FinishSteps runs once the last window has landed, with what the
+	// steps cost.
+	FinishSteps(report StepReport)
+	// SetEnhancedUI turns an application's enhanced accessibility interface
+	// on or off, under which some applications animate every move they are
+	// given. It reports whether the setting was on, and ok false when the
+	// application has no such setting.
+	SetEnhancedUI(pid int, enabled bool) (was bool, ok bool)
+}
+
+// StepReport is what a stepped animation cost: how many windows moved, how
+// many frames were written over all of them, how long the whole took, and
+// the slowest single write.
+type StepReport struct {
+	Windows int
+	Frames  int
+	Elapsed time.Duration
+	Slowest time.Duration
 }
 
 // FrameAnimator is what a Desktop offers when it can animate frames. A
@@ -138,6 +170,14 @@ func validateAnimation(animation Animation) error {
 		)
 	}
 
+	if animation.Driver != "" && !slices.Contains(Drivers, animation.Driver) {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"animation.driver must be one of %s",
+			strings.Join(Drivers, ", "),
+		)
+	}
+
 	return nil
 }
 
@@ -196,6 +236,16 @@ func (e *Executor) ApplyFrames(args ApplyFramesArgs) error {
 		byNumber[win.Number] = win.ID
 	}
 
+	// The accessibility driver writes the frames itself, a step at a time,
+	// and returns when the windows have landed.
+	if args.Animation != nil && args.Animation.Driver == DriverAccessibility {
+		if stepper, ok := e.desktop.(FrameStepper); ok {
+			failures, _ := e.stepFrames(stepper, args.Frames, windows, *args.Animation)
+
+			return framesError(failures, len(args.Frames))
+		}
+	}
+
 	// The animation is prepared before the first write and started after
 	// the last, so the writes happen while the animation hides them. A
 	// desktop that cannot animate, or an animation that cannot begin, moves
@@ -229,17 +279,23 @@ func (e *Executor) ApplyFrames(args ApplyFramesArgs) error {
 		animator.StartFrameAnimation(dropped)
 	}
 
-	if len(failures) > 0 {
-		return derrors.Newf(
-			derrors.CodeActionFailed,
-			"%d of %d frames not applied: %s",
-			len(failures),
-			len(args.Frames),
-			strings.Join(failures, "; "),
-		)
+	return framesError(failures, len(args.Frames))
+}
+
+// framesError is apply_frames' error for the frames that did not land, nil
+// when every one did.
+func framesError(failures []string, total int) error {
+	if len(failures) == 0 {
+		return nil
 	}
 
-	return nil
+	return derrors.Newf(
+		derrors.CodeActionFailed,
+		"%d of %d frames not applied: %s",
+		len(failures),
+		total,
+		strings.Join(failures, "; "),
+	)
 }
 
 // windowsNamed is the focusable windows, from the desktop's recent
@@ -327,6 +383,13 @@ func (e *Executor) writeFrames(frames []WindowFrame, windows []Window) ([]string
 
 	writers.Wait()
 
+	return collectFailures(frames, messages, errs)
+}
+
+// collectFailures turns the per-frame messages and errors of a write into
+// the failures to report, in payload order, and the windows whose frames did
+// not land.
+func collectFailures(frames []WindowFrame, messages []string, errs []error) ([]string, []uint32) {
 	var (
 		failures []string
 		dropped  []uint32

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -130,6 +130,11 @@ func (d *fakeDesktop) KnownWindows() []action.Window {
 }
 
 func (d *fakeDesktop) WindowFrame(windowID action.WindowID) (geometry.Rect, error) {
+	// The accessibility driver reads frames from one application's thread
+	// while another's writes.
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	index, err := d.indexOf(windowID)
 	if err != nil {
 		return geometry.Rect{}, err

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -367,6 +367,43 @@ func (d *nativeDesktop) SetWindowFrame(windowID WindowID, frame geometry.Rect) e
 	})
 }
 
+// StepWindowFrame writes one step of a window's frame, moving it alone when
+// the application last had it at the size asked for, as SetWindowFrame does,
+// without taking the window server's list again after every step.
+func (d *nativeDesktop) StepWindowFrame(windowID WindowID, frame geometry.Rect) error {
+	return d.withWindow(windowID, func(element *native.Element) error {
+		last, known := d.rememberedSize(windowID)
+		if known && sameLength(last.W, frame.W) && sameLength(last.H, frame.H) {
+			err := element.SetPosition(frame.X, frame.Y)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := element.SetFrame(frame.X, frame.Y, frame.W, frame.H)
+			if err != nil {
+				return err
+			}
+		}
+
+		d.rememberFrame(windowID, frame)
+
+		return nil
+	})
+}
+
+// FinishSteps takes the window server's list once the windows have landed,
+// and logs what the steps cost.
+func (d *nativeDesktop) FinishSteps(report StepReport) {
+	d.relist()
+	native.LogAnimationSteps(report.Windows, report.Frames, report.Elapsed, report.Slowest)
+}
+
+// SetEnhancedUI turns an application's enhanced accessibility interface on
+// or off, reporting whether it was on.
+func (d *nativeDesktop) SetEnhancedUI(pid int, enabled bool) (bool, bool) {
+	return native.SetEnhancedUserInterface(pid, enabled)
+}
+
 // samePoint is how far two lengths may differ and still be the same as
 // macOS stores them, in whole points.
 const samePoint = 0.5

--- a/internal/action/step_frames.go
+++ b/internal/action/step_frames.go
@@ -1,0 +1,249 @@
+package action
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// DriverCapture and DriverAccessibility name how an Animation moves the
+// windows. The capture driver takes a picture of the screen and slides
+// pictures of the windows, which needs Screen Recording. The accessibility
+// driver moves the real windows through their applications, a step at a
+// time, and needs nothing beyond Accessibility.
+const (
+	DriverCapture       = "capture"
+	DriverAccessibility = "accessibility"
+)
+
+// Drivers are the animation drivers, in the order the config documents them.
+var Drivers = []string{DriverCapture, DriverAccessibility}
+
+// stepInterval is how often the accessibility driver writes a frame: a
+// hundred a second, as the window managers that animate this way do.
+const stepInterval = 10 * time.Millisecond
+
+// stepFrames moves the windows to their frames through their applications,
+// a step every stepInterval along the animation's curve, every application
+// on a thread of its own, and reports the failures the way writeFrames does.
+// It returns once the last window has landed. A frame the payload leaves
+// out of the animation is written at once, before the rest start.
+func (e *Executor) stepFrames(
+	stepper FrameStepper,
+	frames []WindowFrame,
+	windows []Window,
+	animation Animation,
+) ([]string, []uint32) {
+	byNumber := make(map[uint32]Window, len(windows))
+	for _, win := range windows {
+		byNumber[win.Number] = win
+	}
+
+	messages := make([]string, len(frames))
+	errs := make([]error, len(frames))
+	groups := make(map[int][]int)
+
+	for index, entry := range frames {
+		win, ok := byNumber[entry.Number]
+		if !ok {
+			messages[index] = fmt.Sprintf("window %d is not on the active space", entry.Number)
+
+			continue
+		}
+
+		if entry.Animate != nil && !*entry.Animate {
+			errs[index] = e.desktop.SetWindowFrame(win.ID, rectOfFrame(entry.Frame))
+
+			continue
+		}
+
+		groups[win.PID] = append(groups[win.PID], index)
+	}
+
+	var (
+		steppers sync.WaitGroup
+		reportMu sync.Mutex
+		report   StepReport
+	)
+
+	duration := time.Duration(animation.DurationMS) * time.Millisecond
+	began := time.Now()
+
+	for pid, indexes := range groups {
+		steppers.Add(1)
+
+		go func(pid int, indexes []int) {
+			defer steppers.Done()
+
+			written, slowest := e.stepApplication(
+				stepper,
+				pid,
+				indexes,
+				frames,
+				byNumber,
+				errs,
+				duration,
+				animation.Easing,
+			)
+
+			reportMu.Lock()
+			defer reportMu.Unlock()
+
+			report.Windows += len(indexes)
+			report.Frames += written
+			report.Slowest = max(report.Slowest, slowest)
+		}(pid, indexes)
+	}
+
+	steppers.Wait()
+
+	report.Elapsed = time.Since(began)
+	stepper.FinishSteps(report)
+
+	return collectFailures(frames, messages, errs)
+}
+
+// stepping is one window on its way: where it started, where it goes, and
+// the last frame written, so a step that lands where the last did is not
+// written again.
+type stepping struct {
+	index  int
+	id     WindowID
+	start  geometry.Rect
+	finish geometry.Rect
+	last   geometry.Rect
+}
+
+// stepApplication steps one application's windows, together, since an
+// application answers its accessibility calls one at a time. It reports how
+// many frames it wrote and the slowest write.
+func (e *Executor) stepApplication(
+	stepper FrameStepper,
+	pid int,
+	indexes []int,
+	frames []WindowFrame,
+	byNumber map[uint32]Window,
+	errs []error,
+	duration time.Duration,
+	easing string,
+) (int, time.Duration) {
+	// Under the enhanced interface some applications animate every move
+	// they are given, which fights the steps.
+	if was, ok := stepper.SetEnhancedUI(pid, false); ok && was {
+		defer stepper.SetEnhancedUI(pid, true)
+	}
+
+	moving := make([]*stepping, 0, len(indexes))
+
+	for _, index := range indexes {
+		entry := frames[index]
+		win := byNumber[entry.Number]
+
+		start, err := e.desktop.WindowFrame(win.ID)
+		if err != nil {
+			errs[index] = err
+
+			continue
+		}
+
+		moving = append(moving, &stepping{
+			index:  index,
+			id:     win.ID,
+			start:  start,
+			finish: rectOfFrame(entry.Frame),
+			last:   start,
+		})
+	}
+
+	var (
+		written int
+		slowest time.Duration
+	)
+
+	began := time.Now()
+
+	for tick := 1; len(moving) > 0; tick++ {
+		progress := 1.0
+		if duration > 0 {
+			progress = math.Min(1, float64(time.Since(began))/float64(duration))
+		}
+
+		eased := ease(easing, progress)
+		landed := progress >= 1
+
+		remaining := moving[:0]
+
+		for _, window := range moving {
+			frame := window.finish
+			if !landed {
+				frame = between(window.start, window.finish, eased)
+			}
+
+			if frame != window.last {
+				wrote := time.Now()
+				err := stepper.StepWindowFrame(window.id, frame)
+				slowest = max(slowest, time.Since(wrote))
+				written++
+
+				if err != nil {
+					errs[window.index] = err
+
+					continue
+				}
+
+				window.last = frame
+			}
+
+			if !landed {
+				remaining = append(remaining, window)
+			}
+		}
+
+		moving = remaining
+
+		time.Sleep(time.Until(began.Add(time.Duration(tick) * stepInterval)))
+	}
+
+	return written, slowest
+}
+
+// between is the frame progress of the way from start to finish, in whole
+// points, as the window server places windows.
+func between(start, finish geometry.Rect, progress float64) geometry.Rect {
+	along := func(from, to float64) float64 {
+		return math.Round(from + (to-from)*progress)
+	}
+
+	return geometry.Rect{
+		X: along(start.X, finish.X),
+		Y: along(start.Y, finish.Y),
+		W: along(start.W, finish.W),
+		H: along(start.H, finish.H),
+	}
+}
+
+// ease maps progress through the animation's time onto progress along its
+// way, by the curve the Easings name.
+func ease(name string, progress float64) float64 {
+	switch name {
+	case "ease-in":
+		return progress * progress
+	case "ease-out":
+		return 1 - (1-progress)*(1-progress)
+	case "ease-in-out":
+		const halfway = 0.5
+
+		if progress < halfway {
+			return progress * progress / halfway
+		}
+
+		tail := 1 - progress
+
+		return 1 - tail*tail/halfway
+	default:
+		return progress
+	}
+}

--- a/internal/action/step_frames_test.go
+++ b/internal/action/step_frames_test.go
@@ -1,0 +1,213 @@
+package action_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+	"github.com/y3owk1n/mimi/internal/geometry"
+)
+
+// steppingDesktop is a fake desktop that can step frames: it records every
+// step per window and how the enhanced interface was switched.
+type steppingDesktop struct {
+	*fakeDesktop
+
+	mu       sync.Mutex
+	steps    map[action.WindowID][]geometry.Rect
+	enhanced []bool
+	report   action.StepReport
+	finished int
+}
+
+func newSteppingDesktop() *steppingDesktop {
+	return &steppingDesktop{
+		fakeDesktop: desktopWithListedWindows(),
+		steps:       map[action.WindowID][]geometry.Rect{},
+	}
+}
+
+func (d *steppingDesktop) StepWindowFrame(id action.WindowID, frame geometry.Rect) error {
+	d.mu.Lock()
+	d.steps[id] = append(d.steps[id], frame)
+	d.mu.Unlock()
+
+	return d.SetWindowFrame(id, frame)
+}
+
+func (d *steppingDesktop) FinishSteps(report action.StepReport) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.report = report
+	d.finished++
+}
+
+func (d *steppingDesktop) SetEnhancedUI(_ int, enabled bool) (bool, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.enhanced = append(d.enhanced, enabled)
+
+	return true, true
+}
+
+func TestExecutor_ApplyFrames_AccessibilityDriverStepsEveryWindowHome(t *testing.T) {
+	t.Parallel()
+
+	desktop := newSteppingDesktop()
+	desktop.windows = append(desktop.windows, fakeWindow{id: 3, pid: 101, number: 4244})
+	still := false
+	animation := action.Animation{
+		DurationMS: 40,
+		Easing:     "ease-out",
+		Driver:     action.DriverAccessibility,
+	}
+	targets := []action.WindowFrame{
+		{Number: 4242, Frame: action.Frame{X: 300, Y: 25, Width: 640, Height: 1055}},
+		{Number: 4243, Frame: action.Frame{X: 940, Y: 25, Width: 640, Height: 1055}},
+		{Number: 4244, Frame: action.Frame{Width: 100, Height: 100}, Animate: &still},
+	}
+
+	err := action.NewExecutor(desktop).
+		ExecuteCommand(animatedApplyFramesCommand(&animation, targets...))
+	if err != nil {
+		t.Fatalf("ExecuteCommand(apply_frames) error = %v, want nil", err)
+	}
+
+	for index, win := range desktop.windows {
+		want := rectOf(targets[index].Frame)
+		if win.frame != want {
+			t.Errorf("window %d landed at %+v, want %+v", win.number, win.frame, want)
+		}
+	}
+
+	if len(desktop.steps[1]) < 2 || len(desktop.steps[2]) < 2 {
+		t.Errorf(
+			"windows moved in %d and %d steps, want several each",
+			len(desktop.steps[1]),
+			len(desktop.steps[2]),
+		)
+	}
+
+	if len(desktop.steps[3]) != 0 {
+		t.Errorf("the window left out of the animation was stepped %d times", len(desktop.steps[3]))
+	}
+
+	for windowID, steps := range desktop.steps {
+		finish := desktop.windows[windowID-1].frame
+		for index := 1; index < len(steps); index++ {
+			if remaining(steps[index], finish) > remaining(steps[index-1], finish) {
+				t.Errorf(
+					"window %d stepped backwards from %+v to %+v",
+					windowID,
+					steps[index-1],
+					steps[index],
+				)
+			}
+		}
+	}
+
+	if desktop.finished != 1 || desktop.report.Windows != 2 || desktop.report.Frames < 4 {
+		t.Errorf(
+			"finished %d times with report %+v, want once for 2 windows and several frames",
+			desktop.finished,
+			desktop.report,
+		)
+	}
+
+	// Two applications: each has its interface switched off, then back on.
+	switchedOff, switchedOn := 0, 0
+	for _, enabled := range desktop.enhanced {
+		if enabled {
+			switchedOn++
+		} else {
+			switchedOff++
+		}
+	}
+
+	if switchedOff != 2 || switchedOn != 2 {
+		t.Errorf(
+			"enhanced interface switched off %d and on %d times, want 2 and 2",
+			switchedOff,
+			switchedOn,
+		)
+	}
+}
+
+func TestExecutor_ApplyFrames_AccessibilityDriverReportsTheWindowThatRefused(t *testing.T) {
+	t.Parallel()
+
+	desktop := newSteppingDesktop()
+	desktop.windows[1].setFrameErr = derrors.New(derrors.CodeAccessibilityFailed, "refused")
+	animation := action.Animation{
+		DurationMS: 20,
+		Easing:     "linear",
+		Driver:     action.DriverAccessibility,
+	}
+
+	err := action.NewExecutor(desktop).ExecuteCommand(animatedApplyFramesCommand(
+		&animation,
+		action.WindowFrame{
+			Number: 4242,
+			Frame:  action.Frame{X: 10, Y: 25, Width: 960, Height: 1055},
+		},
+		action.WindowFrame{
+			Number: 4243,
+			Frame:  action.Frame{X: 970, Y: 25, Width: 960, Height: 1055},
+		},
+	))
+	if !derrors.IsCode(err, derrors.CodeActionFailed) {
+		t.Fatalf(
+			"ExecuteCommand(apply_frames) error = %v, want CodeActionFailed for the refused frame",
+			err,
+		)
+	}
+
+	if desktop.windows[0].frame.X != 10 {
+		t.Errorf("the window that answered landed at %+v, want x 10", desktop.windows[0].frame)
+	}
+}
+
+func TestApplyFrames_RejectsAnUnknownDriver(t *testing.T) {
+	t.Parallel()
+
+	animation := action.Animation{DurationMS: 20, Easing: "linear", Driver: "telepathy"}
+
+	err := action.NewExecutor(desktopWithListedWindows()).ExecuteCommand(animatedApplyFramesCommand(
+		&animation,
+		action.WindowFrame{
+			Number: 4242,
+			Frame:  action.Frame{X: 10, Y: 25, Width: 960, Height: 1055},
+		},
+	))
+	if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+		t.Fatalf("ExecuteCommand(apply_frames) error = %v, want CodeInvalidInput", err)
+	}
+}
+
+// remaining is how far a frame still has to go to finish, along every edge.
+func remaining(frame, finish geometry.Rect) float64 {
+	abs := func(value float64) float64 {
+		if value < 0 {
+			return -value
+		}
+
+		return value
+	}
+
+	return abs(
+		finish.X-frame.X,
+	) + abs(
+		finish.Y-frame.Y,
+	) + abs(
+		finish.W-frame.W,
+	) + abs(
+		finish.H-frame.H,
+	)
+}
+
+func rectOf(frame action.Frame) geometry.Rect {
+	return geometry.Rect{X: frame.X, Y: frame.Y, W: frame.Width, H: frame.Height}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
 
@@ -106,12 +107,22 @@ type TilingConfig struct {
 
 // AnimationConfig holds the [tiling.animation] section: whether windows
 // move to the frames a layout returns over time rather than at once, over
-// how long, and along which curve. Off, the daemon neither captures the
-// screen nor asks for the Screen Recording permission that takes.
+// how long, along which curve, and by which driver. The capture driver
+// slides pictures of the windows over a still of the screen and needs
+// Screen Recording; the accessibility driver moves the real windows
+// through their applications a step at a time and needs nothing more.
+// Off, the daemon neither captures the screen nor asks for the permission.
 type AnimationConfig struct {
 	Enabled    bool   `json:"enabled"    toml:"enabled"`
 	DurationMS int    `json:"durationMs" toml:"duration_ms"`
 	Easing     string `json:"easing"     toml:"easing"`
+	Driver     string `json:"driver"     toml:"driver"`
+}
+
+// UsesCapture reports whether the animation, as configured, captures the
+// screen, which is what needs Screen Recording.
+func (a AnimationConfig) UsesCapture() bool {
+	return a.Enabled && a.Driver != action.DriverAccessibility
 }
 
 // BorderConfig holds the [border] section: whether the daemon draws a

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -216,6 +216,10 @@ func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 		cfg.Tiling.Animation.Easing = defaultTilingAnimationEasing
 	}
 
+	if cfg.Tiling.Animation.Driver == "" {
+		cfg.Tiling.Animation.Driver = action.DriverCapture
+	}
+
 	if cfg.Border.Width == 0 {
 		cfg.Border.Width = defaultBorderWidth
 	}
@@ -291,6 +295,13 @@ func validate(cfg *Config) error {
 				"tiling.animation.duration_ms must be between 1 and %d",
 				action.MaxAnimationMS,
 			),
+		)
+	}
+
+	if !slices.Contains(action.Drivers, cfg.Tiling.Animation.Driver) {
+		errs = append(
+			errs,
+			"tiling.animation.driver must be one of "+strings.Join(action.Drivers, ", "),
 		)
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -564,15 +564,15 @@ func borderConfigFor(cfg *config.Config, accessibilityGranted bool) config.Borde
 }
 
 // promptScreenCapture shows the Screen Recording alert once, at startup,
-// when the tiling animation is enabled and macOS has not granted the
-// permission. A config that leaves the animation off never prompts. It
+// when the tiling animation captures the screen and macOS has not granted
+// the permission. A config that leaves the animation off never prompts. It
 // reports false when mimi must quit for a grant to take effect.
 func promptScreenCapture(
 	cfg *config.Config,
 	accessibilityGranted bool,
 	logger *zap.SugaredLogger,
 ) bool {
-	if !accessibilityGranted || !cfg.Tiling.Enabled || !cfg.Tiling.Animation.Enabled ||
+	if !accessibilityGranted || !cfg.Tiling.Enabled || !cfg.Tiling.Animation.UsesCapture() ||
 		permissions.ScreenCaptureGranted() {
 		return true
 	}
@@ -600,7 +600,8 @@ func tilingConfigFor(
 		tilingCfg.Enabled = false
 	}
 
-	if tilingCfg.Enabled && tilingCfg.Animation.Enabled && !permissions.ScreenCaptureGranted() {
+	if tilingCfg.Enabled && tilingCfg.Animation.UsesCapture() &&
+		!permissions.ScreenCaptureGranted() {
 		logger.Warn(
 			"screen recording permission not granted, tiling animation disabled. " +
 				"Grant it in System Settings > Privacy & Security > Screen & System Audio Recording, then restart mimi",

--- a/internal/native/application.go
+++ b/internal/native/application.go
@@ -165,3 +165,18 @@ func SpaceIndexes() map[uint64]int {
 
 	return indexes
 }
+
+// SetEnhancedUserInterface turns an application's enhanced accessibility
+// interface on or off, under which some applications animate every move
+// they are given. It reports whether the setting was on, and ok false when
+// the application has no such setting.
+func SetEnhancedUserInterface(pid int, enabled bool) (bool, bool) {
+	on := 0
+	if enabled {
+		on = 1
+	}
+
+	result := int(C.MimiSetEnhancedUserInterface(C.int(pid), C.int(on)))
+
+	return result == 1, result >= 0
+}

--- a/internal/native/application.m
+++ b/internal/native/application.m
@@ -144,6 +144,25 @@ CFArrayRef MimiCopyRealWindowsOnSpaces(CFArrayRef spaceIDs, CFArrayRef *radii) {
 	return CFBridgingRetain(real);
 }
 
+int MimiSetEnhancedUserInterface(int pid, int enabled) {
+	@autoreleasepool {
+		AXUIElementRef app = AXUIElementCreateApplication((pid_t)pid);
+		if (!app)
+			return -1;
+		CFStringRef attribute = CFSTR("AXEnhancedUserInterface");
+		CFTypeRef value = NULL;
+		int was = -1;
+		if (AXUIElementCopyAttributeValue(app, attribute, &value) == kAXErrorSuccess && value) {
+			was = (CFGetTypeID(value) == CFBooleanGetTypeID() && CFBooleanGetValue(value)) ? 1 : 0;
+			CFRelease(value);
+		}
+		if (was >= 0 && was != enabled)
+			AXUIElementSetAttributeValue(app, attribute, enabled ? kCFBooleanTrue : kCFBooleanFalse);
+		CFRelease(app);
+		return was;
+	}
+}
+
 void MimiWindowCornerRadii(const uint32_t *numbers, int count, double *radii) {
 	for (int i = 0; i < count; i++)
 		radii[i] = -1;

--- a/internal/native/mimi.h
+++ b/internal/native/mimi.h
@@ -58,6 +58,10 @@ CFArrayRef MimiCopyRealWindowsOnSpaces(CFArrayRef spaceIDs, CFArrayRef *radii);
 /// or -1 where the window server does not say (before macOS 26) or the
 /// window is gone.
 void MimiWindowCornerRadii(const uint32_t *numbers, int count, double *radii);
+/// Turn an application's AXEnhancedUserInterface on or off, under which some
+/// applications animate every move they are given. Returns whether it was
+/// on, or -1 when the application has no such setting.
+int MimiSetEnhancedUserInterface(int pid, int enabled);
 /// Copy an application's real, unminimized windows on every space, front to
 /// back. Sets *count; the caller frees the array. Auxiliary windows (popovers,
 /// sheets, tab previews) are left out.
@@ -87,6 +91,9 @@ double *MimiCopyScreenFrames(int *count);
 double *MimiGetWindowFrame(void *window);
 int MimiSetWindowFrame(void *window, double x, double y, double w, double h);
 int MimiSetWindowPosition(void *window, double x, double y);
+/// Log what a stepped animation cost: how many windows and frames, over how
+/// long, and the slowest single write, all in milliseconds.
+void MimiLogAnimationSteps(int windows, int frames, double elapsedMS, double slowestMS);
 
 /// Doubles per window in MimiCopyWindowList's result: number, x, y, width,
 /// height, whether the window server named it, owner pid, layer, and whether

--- a/internal/native/window.go
+++ b/internal/native/window.go
@@ -7,6 +7,7 @@ package native
 import "C"
 
 import (
+	"time"
 	"unsafe"
 
 	derrors "github.com/y3owk1n/mimi/internal/errors"
@@ -501,4 +502,15 @@ func TiledWindowMarginSize() float64 {
 // MissionControlActive reports whether Mission Control is currently open.
 func MissionControlActive() bool {
 	return bool(C.MimiIsMissionControlActive())
+}
+
+// LogAnimationSteps logs what a stepped animation cost: how many windows
+// and frames, over how long, and the slowest single write.
+func LogAnimationSteps(windows, frames int, elapsed, slowest time.Duration) {
+	C.MimiLogAnimationSteps(
+		C.int(windows),
+		C.int(frames),
+		C.double(float64(elapsed)/float64(time.Millisecond)),
+		C.double(float64(slowest)/float64(time.Millisecond)),
+	)
 }

--- a/internal/native/window.m
+++ b/internal/native/window.m
@@ -652,6 +652,12 @@ void **MimiCopyApplicationWindowElements(int pid, int *count, unsigned int **num
 	}
 }
 
+void MimiLogAnimationSteps(int windows, int frames, double elapsedMS, double slowestMS) {
+	MIMI_LOG(
+	    "animation: stepped %d windows through %d frames in %.0f ms, slowest write %.1f ms", windows, frames, elapsedMS,
+	    slowestMS);
+}
+
 int MimiSetWindowPosition(void *window, double x, double y) {
 	if (!window)
 		return 0;

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -154,6 +154,7 @@ func (e *Engine) Update(cfg config.TilingConfig, shell string) {
 		e.animation = &action.Animation{
 			DurationMS: cfg.Animation.DurationMS,
 			Easing:     cfg.Animation.Easing,
+			Driver:     cfg.Animation.Driver,
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR adds a second way to animate tiling that captures nothing and needs no Screen Recording permission. The `accessibility` driver moves the real windows through their applications, a frame every ten milliseconds along the configured easing, each application on its own thread, with the enhanced accessibility interface switched off for the duration so applications do not animate each step themselves. Windows parked off screen by a strip layout slide in the same way, since the layouts leave a sliver of them on the display.

The `capture` driver stays the default, so existing configs behave as before. With `driver = "accessibility"` the daemon never captures the screen and never asks for the permission. Smoothness under this driver is each application's to give: a slow application moves in fewer, larger steps, and a resize costs an application several times what a move does.

## Configuration

```toml
[tiling.animation]
enabled = true
duration_ms = 100
easing = "ease-out"
driver = "capture"    # capture (needs Screen Recording) or accessibility
```

`driver` defaults to `capture`; an existing config keeps working unchanged. The `apply_frames` action's `animation` object accepts the same `driver` field, absent meaning capture.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Both drivers were run through the identical sequence on a 1920x1080 display with Safari, Ghostty and Notes on a strip: two rounds of every strip command, then three round trips between two spaces with resizes and scrolls on each, 97 animations of 100 ms in about 50 seconds.

| | capture | accessibility |
|---|---|---|
| Daemon footprint at the end | 52 MB (peak 65) | 21 MB (peak 21.5) |
| Daemon CPU over the run | 2.7 s | 3.5 s |
| Safari / Ghostty / Notes CPU over the run | 2.3 / 1.9 / 1.0 s | 3.7 / 3.5 / 2.1 s |
| Animation length, configured 100 ms | display refresh, by Core Animation | p50 111 ms, p90 113 ms, max 179 ms |
| Frames per window per animation | every display refresh | 5.3 written on average, identical steps skipped |
| Slowest single window write | n/a | 39 ms |
| Permission | Screen Recording | none beyond Accessibility |

The applications spend roughly twice the CPU under the accessibility driver because they lay out and repaint at every step; the capture driver moves pictures on the render server instead. Each stepped animation logs its window and frame counts, length and slowest write at the native log level so the numbers can be reproduced.
