### PR TITLE
feat(tiling): show where a dragged window would land, and wait for the drop

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -93,6 +93,15 @@ enabled = false
 duration_ms = 150
 easing = "ease-out"
 
+# While you drag a tiled window, show where the layout would put it if you
+# let go. Needs relayout_on_drag. Colours are #rrggbb or #rrggbbaa.
+[tiling.dropzone]
+enabled = false
+color = "#e2e2e330"
+outline_color = "#e2e2e3"
+outline_width = 2
+radius = 12
+
 # =============================================================================
 # Borders
 # =============================================================================

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -155,6 +155,13 @@ relayout_on_drag = false     # a window the user moves or resizes runs a pass to
 enabled = false       # move the frames into place over time instead of at once
 duration_ms = 150     # how long the move takes
 easing = "ease-out"   # linear, ease-in, ease-out or ease-in-out
+
+[tiling.dropzone]
+enabled = false            # while you drag a window, show where the layout would put it
+color = "#e2e2e330"        # the zone's fill, #rrggbb or #rrggbbaa
+outline_color = "#e2e2e3"  # its outline
+outline_width = 2          # points; 0 draws no outline
+radius = 12                # corner radius in points
 ```
 
 mimi ships no layout. `layout` is a command line, run through
@@ -257,6 +264,23 @@ slow to answer moves in fewer, larger steps, and a resize costs an
 application several times what a move does. Each animation logs how many
 windows and frames it stepped, how long it took and its slowest write at the
 native log level, which is where to look when one feels rough.
+
+### Drop zone
+
+With `[tiling.dropzone]` enabled and `relayout_on_drag` on, dragging a tiled
+window shows where the layout would put it if you let go: a translucent
+rounded frame that slides ahead of the drag as the answer changes. It is
+the layout's own answer. While the button is down, mimi runs the layout the
+way the drop will, with a `window_move` or `window_resize` event naming the
+window, no more than every 40 ms, and draws the frame it returns for that
+window. Nothing is applied and no state is kept until the drop. The zone
+goes away when the button comes up, and the settled drag then runs the
+layout for real.
+
+A layout that ignores drags shows the window's own frame. One whose answer
+depends on where the window is dropped, as the shipped `strip.py` does,
+shows the column the window would join. The zone needs Accessibility, like
+tiling, and nothing more; every key is reloadable.
 
 ---
 

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -123,7 +123,8 @@ window event ---> daemon settles the burst (debounce_ms, default 100)
 
 The `[tiling]` keys are `enabled`, `layout`, `layout_mode`, `debounce_ms`,
 `timeout_secs`, `command_timeout_secs`, `relayout_on_drag`, and `gap`, plus a `[tiling.animation]`
-table with `enabled`, `duration_ms`, and `easing`. Every one is reloadable.
+table with `enabled`, `duration_ms`, and `easing`, and a `[tiling.dropzone]`
+table that shows where a drag would land. Every one is reloadable.
 The reference is in [CONFIGURATION.md](CONFIGURATION.md#tiling).
 
 **Animation is off by default.** With `[tiling.animation]` enabled, windows
@@ -451,6 +452,10 @@ Now a drag runs your layout with the event saying what happened and
   the column it was dropped on. A stacked window dropped on empty strip or
   its own column's outer quarter gets a column of its own. Dropped higher or
   lower in its column, it takes that row.
+
+With `[tiling.dropzone]` enabled as well, the drag shows where the window
+would land before you let go, by asking your layout the same question as
+you drag. See [CONFIGURATION.md](CONFIGURATION.md#drop-zone).
 
 The engine decides which by comparing where the windows landed against where
 it last placed them, so a terminal that snaps its width to the character grid

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,6 +102,21 @@ type TilingConfig struct {
 	Gap *int `json:"gap" toml:"gap"`
 	// Animation is how the frames a layout returns move into place.
 	Animation AnimationConfig `json:"animation" toml:"animation"`
+	// Dropzone shows, while the user drags a window, where the layout would
+	// put it.
+	Dropzone DropzoneConfig `json:"dropzone" toml:"dropzone"`
+}
+
+// DropzoneConfig holds the [tiling.dropzone] section: whether, while the
+// user drags a tiled window, mimi shows where the layout would put it if
+// they let go, and how that zone is drawn. It needs relayout_on_drag, since
+// without it a drop changes nothing. Colors are #rrggbb or #rrggbbaa.
+type DropzoneConfig struct {
+	Enabled      bool    `json:"enabled"      toml:"enabled"`
+	Color        string  `json:"color"        toml:"color"`
+	OutlineColor string  `json:"outlineColor" toml:"outline_color"`
+	OutlineWidth float64 `json:"outlineWidth" toml:"outline_width"`
+	Radius       float64 `json:"radius"       toml:"radius"`
 }
 
 // AnimationConfig holds the [tiling.animation] section: whether windows

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -170,6 +170,15 @@ const (
 	maxBorderWidth             = 32.0
 )
 
+// The [tiling.dropzone] defaults: a faint fill of the border's light color
+// with a thin outline of it, rounded like a document window.
+const (
+	defaultDropzoneColor        = "#e2e2e330"
+	defaultDropzoneOutlineColor = "#e2e2e3"
+	defaultDropzoneOutlineWidth = 2.0
+	defaultDropzoneRadius       = 12.0
+)
+
 func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 	settings := &cfg.Settings
 	if settings.LogLevel == "" {
@@ -214,6 +223,22 @@ func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 
 	if cfg.Tiling.Animation.Easing == "" {
 		cfg.Tiling.Animation.Easing = defaultTilingAnimationEasing
+	}
+
+	if cfg.Tiling.Dropzone.Color == "" {
+		cfg.Tiling.Dropzone.Color = defaultDropzoneColor
+	}
+
+	if cfg.Tiling.Dropzone.OutlineColor == "" {
+		cfg.Tiling.Dropzone.OutlineColor = defaultDropzoneOutlineColor
+	}
+
+	if cfg.Tiling.Dropzone.OutlineWidth == 0 {
+		cfg.Tiling.Dropzone.OutlineWidth = defaultDropzoneOutlineWidth
+	}
+
+	if cfg.Tiling.Dropzone.Radius == 0 {
+		cfg.Tiling.Dropzone.Radius = defaultDropzoneRadius
 	}
 
 	if cfg.Border.Width == 0 {
@@ -302,6 +327,7 @@ func validate(cfg *Config) error {
 	}
 
 	errs = append(errs, validateBorder(cfg.Border)...)
+	errs = append(errs, validateDropzone(cfg.Tiling)...)
 
 	// HookKinds is a slice, so these errors come out in its declared order.
 	// The map this replaced meant validate reported the same broken config in
@@ -339,6 +365,44 @@ func validate(cfg *Config) error {
 	}
 
 	return nil
+}
+
+// validateDropzone holds the [tiling.dropzone] section to its rules: it
+// needs relayout_on_drag, its colors parse, and its sizes are sane.
+func validateDropzone(tiling TilingConfig) []string {
+	var errs []string
+
+	zone := tiling.Dropzone
+
+	if zone.Enabled && !tiling.RelayoutOnDrag {
+		errs = append(errs, "tiling.dropzone.enabled needs tiling.relayout_on_drag")
+	}
+
+	_, err := ParseColor(zone.Color)
+	if err != nil {
+		errs = append(errs, "tiling.dropzone.color must be #rrggbb or #rrggbbaa")
+	}
+
+	_, err = ParseColor(zone.OutlineColor)
+	if err != nil {
+		errs = append(errs, "tiling.dropzone.outline_color must be #rrggbb or #rrggbbaa")
+	}
+
+	if zone.OutlineWidth < 0 || zone.OutlineWidth > maxBorderWidth {
+		errs = append(
+			errs,
+			fmt.Sprintf(
+				"tiling.dropzone.outline_width must be between 0 and %d",
+				int(maxBorderWidth),
+			),
+		)
+	}
+
+	if zone.Radius < 0 {
+		errs = append(errs, "tiling.dropzone.radius must be >= 0")
+	}
+
+	return errs
 }
 
 func validateBorder(border BorderConfig) []string {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"github.com/y3owk1n/mimi/internal/action"
 	"github.com/y3owk1n/mimi/internal/border"
 	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/dropzone"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/events"
 	"github.com/y3owk1n/mimi/internal/hooks"
@@ -157,6 +158,8 @@ func runCore(
 	go pipeline.borders.Run(ctx, pipeline.borderSub)
 	go logging.WriteEventLog(ctx, pipeline.logSub, cfg.Settings.LogFile, logger)
 
+	defer pipeline.zone.Close()
+
 	cfgReloader := newReloader(
 		cfg,
 		pipeline.reg,
@@ -165,6 +168,7 @@ func runCore(
 		pipeline.router,
 		pipeline.tiler,
 		pipeline.borders,
+		pipeline.zone,
 		logger,
 	)
 
@@ -231,6 +235,7 @@ type eventPipeline struct {
 	executor  *hooks.Executor
 	tiler     *tiling.Engine
 	borders   *border.Engine
+	zone      *dropzone.Tracker
 	logSub    events.Subscriber
 	hookSub   events.Subscriber
 	tileSub   events.Subscriber
@@ -286,7 +291,17 @@ func setupEventPipeline(
 	borders := border.New(border.NativeDrawer())
 	borders.Update(borderConfigFor(cfg, accessibilityGranted))
 	borderSub := bus.SubscribeWithFilter(borderSubBufSize, borders.KindFilter())
-	router.SetRawListener(func(events.Event) { borders.Nudge() })
+
+	// The drop zone hears the same raw drags, and previews the drop with
+	// the tiling engine while the button is down.
+	tiler.SetMouse(native.LeftMouseButtonDown)
+
+	zone := dropzone.New(tiler, dropzone.NativeDrawer(), dropzone.NativeMouse(), logger)
+	zone.Update(dropzoneConfigFor(cfg, accessibilityGranted))
+	router.SetRawListener(func(events.Event) {
+		borders.Nudge()
+		zone.Nudge()
+	})
 
 	// The event log is opt-in via [settings].log_file; when present, write
 	// every event so the user can replay what happened. When disabled, the
@@ -315,6 +330,7 @@ func setupEventPipeline(
 		executor:  executor,
 		tiler:     tiler,
 		borders:   borders,
+		zone:      zone,
 		logSub:    logSub,
 		hookSub:   hookSub,
 		tileSub:   tileSub,
@@ -557,6 +573,18 @@ func borderConfigFor(cfg *config.Config, accessibilityGranted bool) config.Borde
 	}
 
 	return borderCfg
+}
+
+// dropzoneConfigFor is the [tiling.dropzone] section as the tracker gets
+// it: as written, except that without Accessibility, or with tiling off, it
+// is disabled.
+func dropzoneConfigFor(cfg *config.Config, accessibilityGranted bool) config.DropzoneConfig {
+	zoneCfg := cfg.Tiling.Dropzone
+	if !accessibilityGranted || !cfg.Tiling.Enabled {
+		zoneCfg.Enabled = false
+	}
+
+	return zoneCfg
 }
 
 // tilingConfigFor is the [tiling] section as the engine gets it: as written,

--- a/internal/daemon/reloader.go
+++ b/internal/daemon/reloader.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/y3owk1n/mimi/internal/border"
 	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/dropzone"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/hooks"
 	"github.com/y3owk1n/mimi/internal/native"
@@ -46,6 +47,7 @@ type reloader struct {
 	router    *observe.Router
 	tiler     *tiling.Engine
 	borders   *border.Engine
+	zone      *dropzone.Tracker
 	logger    *zap.SugaredLogger
 }
 
@@ -66,6 +68,7 @@ func newReloader(
 	router *observe.Router,
 	tiler *tiling.Engine,
 	borders *border.Engine,
+	zone *dropzone.Tracker,
 	logger *zap.SugaredLogger,
 ) *reloader {
 	if logger == nil {
@@ -80,6 +83,7 @@ func newReloader(
 		router:    router,
 		tiler:     tiler,
 		borders:   borders,
+		zone:      zone,
 		logger:    logger,
 	}
 }
@@ -136,6 +140,10 @@ func (rl *reloader) Apply(cfg *config.Config) (reloadChanges, error) {
 
 	if rl.borders != nil {
 		rl.borders.Update(borderConfigFor(cfg, perm.Accessibility))
+	}
+
+	if rl.zone != nil {
+		rl.zone.Update(dropzoneConfigFor(cfg, perm.Accessibility))
 	}
 
 	return reloadChanges{

--- a/internal/daemon/reloader_test.go
+++ b/internal/daemon/reloader_test.go
@@ -54,7 +54,7 @@ func newTestReloader(
 	)
 	executor := hooks.NewExecutor(reg, &initialCfg.Settings, logger)
 
-	cfgReloader := newReloader(initialCfg, reg, executor, axTracker, router, nil, nil, nil)
+	cfgReloader := newReloader(initialCfg, reg, executor, axTracker, router, nil, nil, nil, nil)
 
 	return cfgReloader, reg
 }

--- a/internal/dropzone/native.go
+++ b/internal/dropzone/native.go
@@ -1,0 +1,40 @@
+package dropzone
+
+import (
+	"github.com/y3owk1n/mimi/internal/geometry"
+	"github.com/y3owk1n/mimi/internal/native"
+)
+
+// nativeDrawer draws the zone with the window server, and nativeMouse asks
+// it for the button.
+type (
+	nativeDrawer struct{}
+	nativeMouse  struct{}
+)
+
+// NativeDrawer draws the zone on the desktop mimi runs on.
+func NativeDrawer() Drawer {
+	return nativeDrawer{}
+}
+
+// NativeMouse reads the real mouse.
+func NativeMouse() Mouse {
+	return nativeMouse{}
+}
+
+func (nativeDrawer) Show(frame geometry.Rect, style Style) {
+	native.ShowDropzone(native.DropzoneStyle{
+		Fill:    native.Color(style.Fill),
+		Outline: native.Color(style.Outline),
+		Width:   style.Width,
+		Radius:  style.Radius,
+	}, frame.X, frame.Y, frame.W, frame.H)
+}
+
+func (nativeDrawer) Hide() {
+	native.HideDropzone()
+}
+
+func (nativeMouse) LeftButtonDown() bool {
+	return native.LeftMouseButtonDown()
+}

--- a/internal/dropzone/tracker.go
+++ b/internal/dropzone/tracker.go
@@ -1,0 +1,200 @@
+// Package dropzone shows, while the user drags a tiled window, where the
+// layout would put it if they let go: a translucent rounded frame that
+// slides ahead of the drag. It is only ever as right as the layout's own
+// answer, since that is what it asks.
+package dropzone
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/geometry"
+	"github.com/y3owk1n/mimi/internal/tiling"
+)
+
+// Previewer answers where the dragged window would land now. The tiling
+// engine is the real one.
+type Previewer interface {
+	DropPreview(ctx context.Context) (tiling.DropTarget, bool, error)
+}
+
+// Drawer puts the zone on screen and takes it off.
+type Drawer interface {
+	Show(frame geometry.Rect, style Style)
+	Hide()
+}
+
+// Mouse reports whether the left button is down, which is what makes a
+// window's movement a drag.
+type Mouse interface {
+	LeftButtonDown() bool
+}
+
+// Style is how the zone is drawn.
+type Style struct {
+	Fill    config.Color
+	Outline config.Color
+	Width   float64
+	Radius  float64
+}
+
+// Tracker turns the raw moves of a drag into previews, throttled so a fast
+// drag asks the layout no more than every previewInterval, and hides the
+// zone once the button is up.
+type Tracker struct {
+	previewer Previewer
+	draw      Drawer
+	mouse     Mouse
+	logger    *zap.SugaredLogger
+
+	mu      sync.Mutex
+	enabled bool
+	style   Style
+	// previewing is whether a preview is running; nudges meanwhile are
+	// dropped, since the next nudge comes before the drag has moved far.
+	previewing bool
+	// shown is whether the zone is on screen, and so whether the watcher
+	// that hides it on release is running.
+	shown bool
+	last  time.Time
+}
+
+// previewInterval is the least time between two previews: a layout run
+// and the reads before it cost some ten milliseconds, and a drag at a
+// hundred previews a second would show nothing more.
+const previewInterval = 40 * time.Millisecond
+
+// releasePoll is how often the watcher looks for the button coming up.
+const releasePoll = 30 * time.Millisecond
+
+// New returns a tracker that is disabled until Update enables it.
+func New(previewer Previewer, draw Drawer, mouse Mouse, logger *zap.SugaredLogger) *Tracker {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
+	return &Tracker{previewer: previewer, draw: draw, mouse: mouse, logger: logger}
+}
+
+// Update applies the [tiling.dropzone] section. It is what the daemon
+// calls at startup and on every reload. Disabling takes the zone down.
+func (t *Tracker) Update(cfg config.DropzoneConfig) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.enabled = cfg.Enabled
+	t.style = styleOf(cfg)
+
+	if !cfg.Enabled && t.shown {
+		t.shown = false
+		t.draw.Hide()
+	}
+}
+
+// Nudge is called for every raw move and resize, ahead of the debounce. It
+// previews the drop when the button is down, no more than every
+// previewInterval, and hides the zone when the preview finds no drag.
+func (t *Tracker) Nudge() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.enabled || t.previewing || time.Since(t.last) < previewInterval {
+		return
+	}
+
+	if !t.mouse.LeftButtonDown() {
+		t.logger.Debugw("dropzone: window moved with the button up")
+
+		return
+	}
+
+	t.previewing = true
+	t.last = time.Now()
+
+	go t.preview()
+}
+
+// Close takes the zone down. The tracker is not used after it.
+func (t *Tracker) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.enabled = false
+	t.hideLocked()
+}
+
+// preview asks where the drag would land and draws the answer.
+func (t *Tracker) preview() {
+	target, found, err := t.previewer.DropPreview(context.Background())
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.previewing = false
+
+	if err != nil {
+		t.logger.Debugw("dropzone preview failed", "err", err)
+	}
+
+	if !t.enabled || !found || !t.mouse.LeftButtonDown() {
+		t.logger.Debugw("dropzone: nothing to show", "enabled", t.enabled, "found", found)
+		t.hideLocked()
+
+		return
+	}
+
+	t.logger.Debugw("dropzone: showing", "window", target.Number)
+
+	frame := target.Frame
+	t.draw.Show(geometry.Rect{X: frame.X, Y: frame.Y, W: frame.Width, H: frame.Height}, t.style)
+
+	if !t.shown {
+		t.shown = true
+
+		go t.watchRelease()
+	}
+}
+
+// watchRelease hides the zone once the button comes up.
+func (t *Tracker) watchRelease() {
+	for {
+		time.Sleep(releasePoll)
+
+		t.mu.Lock()
+
+		if !t.shown {
+			t.mu.Unlock()
+
+			return
+		}
+
+		if !t.mouse.LeftButtonDown() {
+			t.hideLocked()
+			t.mu.Unlock()
+
+			return
+		}
+
+		t.mu.Unlock()
+	}
+}
+
+// hideLocked takes the zone down when it is up. The caller holds the lock.
+func (t *Tracker) hideLocked() {
+	if t.shown {
+		t.shown = false
+		t.draw.Hide()
+	}
+}
+
+// styleOf is the style a validated section describes.
+func styleOf(cfg config.DropzoneConfig) Style {
+	fill, _ := config.ParseColor(cfg.Color)
+	outline, _ := config.ParseColor(cfg.OutlineColor)
+
+	return Style{Fill: fill, Outline: outline, Width: cfg.OutlineWidth, Radius: cfg.Radius}
+}

--- a/internal/dropzone/tracker_test.go
+++ b/internal/dropzone/tracker_test.go
@@ -1,0 +1,178 @@
+package dropzone_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/dropzone"
+	"github.com/y3owk1n/mimi/internal/geometry"
+	"github.com/y3owk1n/mimi/internal/tiling"
+)
+
+type fakes struct {
+	mu     sync.Mutex
+	target tiling.DropTarget
+	ok     bool
+	down   bool
+	shown  []geometry.Rect
+	hidden int
+}
+
+func (f *fakes) DropPreview(context.Context) (tiling.DropTarget, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.target, f.ok, nil
+}
+
+func (f *fakes) Show(frame geometry.Rect, _ dropzone.Style) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.shown = append(f.shown, frame)
+}
+
+func (f *fakes) Hide() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.hidden++
+}
+
+func (f *fakes) LeftButtonDown() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.down
+}
+
+func (f *fakes) release() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.down = false
+}
+
+func (f *fakes) counts() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.shown), f.hidden
+}
+
+func (f *fakes) shownCount() int {
+	shown, _ := f.counts()
+
+	return shown
+}
+
+func (f *fakes) hiddenCount() int {
+	_, hidden := f.counts()
+
+	return hidden
+}
+
+func enabledConfig() config.DropzoneConfig {
+	return config.DropzoneConfig{
+		Enabled: true, Color: "#e2e2e330", OutlineColor: "#e2e2e3", OutlineWidth: 2, Radius: 12,
+	}
+}
+
+func waitFor(t *testing.T, what string, done func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if done() {
+			return
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Fatalf("waited a second for %s", what)
+}
+
+func TestTracker_ShowsWhereTheDragWouldLandAndHidesOnRelease(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakes{
+		target: tiling.DropTarget{
+			Number: 4,
+			Frame:  action.Frame{X: 10, Y: 20, Width: 300, Height: 400},
+		},
+		ok:   true,
+		down: true,
+	}
+	tracker := dropzone.New(fake, fake, fake, nil)
+	tracker.Update(enabledConfig())
+
+	tracker.Nudge()
+	waitFor(t, "the zone to show", func() bool { return fake.shownCount() == 1 })
+
+	fake.mu.Lock()
+	got := fake.shown[0]
+	fake.mu.Unlock()
+
+	want := geometry.Rect{X: 10, Y: 20, W: 300, H: 400}
+	if got != want {
+		t.Errorf("zone shown at %+v, want the layout's frame %+v", got, want)
+	}
+
+	// A burst of nudges within the interval asks the layout once.
+	tracker.Nudge()
+	tracker.Nudge()
+
+	if shown, _ := fake.counts(); shown != 1 {
+		t.Errorf("zone shown %d times after a burst, want 1", shown)
+	}
+
+	fake.release()
+	waitFor(t, "the zone to hide", func() bool { return fake.hiddenCount() == 1 })
+}
+
+func TestTracker_DoesNothingUnlessEnabledAndTheButtonIsDown(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakes{target: tiling.DropTarget{Number: 4}, ok: true, down: true}
+	tracker := dropzone.New(fake, fake, fake, nil)
+
+	tracker.Nudge()
+	time.Sleep(20 * time.Millisecond)
+
+	if shown, _ := fake.counts(); shown != 0 {
+		t.Errorf("a disabled tracker showed the zone %d times", shown)
+	}
+
+	tracker.Update(enabledConfig())
+	fake.release()
+	tracker.Nudge()
+	time.Sleep(20 * time.Millisecond)
+
+	if shown, _ := fake.counts(); shown != 0 {
+		t.Errorf("the zone showed %d times with the button up", shown)
+	}
+}
+
+func TestTracker_HidesWhenNothingIsBeingDragged(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakes{target: tiling.DropTarget{Number: 4}, ok: true, down: true}
+	tracker := dropzone.New(fake, fake, fake, nil)
+	tracker.Update(enabledConfig())
+
+	tracker.Nudge()
+	waitFor(t, "the zone to show", func() bool { return fake.shownCount() == 1 })
+
+	fake.mu.Lock()
+	fake.ok = false
+	fake.mu.Unlock()
+
+	time.Sleep(50 * time.Millisecond)
+	tracker.Nudge()
+	waitFor(t, "the zone to hide", func() bool { return fake.hiddenCount() == 1 })
+}

--- a/internal/native/dropzone.go
+++ b/internal/native/dropzone.go
@@ -1,0 +1,37 @@
+package native
+
+/*
+#include "dropzone.h"
+*/
+import "C"
+
+// DropzoneStyle is how the drop zone is drawn: its fill, its outline and
+// how wide, and its corner radius, in points.
+type DropzoneStyle struct {
+	Fill    Color
+	Outline Color
+	Width   float64
+	Radius  float64
+}
+
+// ShowDropzone shows the drop zone over a frame, in window coordinates, or
+// slides it there when it is shown already.
+func ShowDropzone(style DropzoneStyle, left, top, width, height float64) {
+	cStyle := C.MimiDropzoneStyle{
+		fill:    cColor(style.Fill),
+		outline: cColor(style.Outline),
+		width:   C.double(style.Width),
+		radius:  C.double(style.Radius),
+	}
+	C.MimiDropzoneShow(&cStyle, C.double(left), C.double(top), C.double(width), C.double(height))
+}
+
+// HideDropzone takes the drop zone off screen.
+func HideDropzone() {
+	C.MimiDropzoneHide()
+}
+
+// LeftMouseButtonDown reports whether the left mouse button is down now.
+func LeftMouseButtonDown() bool {
+	return C.MimiLeftMouseButtonDown() != 0
+}

--- a/internal/native/dropzone.h
+++ b/internal/native/dropzone.h
@@ -1,0 +1,23 @@
+#ifndef MIMI_DROPZONE_H
+#define MIMI_DROPZONE_H
+
+#import "border.h"
+
+/// How the drop zone is drawn: the fill, the outline and its width, and the
+/// corner radius, all in points.
+typedef struct {
+	MimiColor fill;
+	MimiColor outline;
+	double width;
+	double radius;
+} MimiDropzoneStyle;
+
+/// Show the drop zone over the given frame, in window coordinates (y down
+/// from the top of the main display), or move it there when it is shown.
+void MimiDropzoneShow(const MimiDropzoneStyle *style, double x, double y, double w, double h);
+/// Take the drop zone off screen.
+void MimiDropzoneHide(void);
+/// Whether the left mouse button is down right now.
+int MimiLeftMouseButtonDown(void);
+
+#endif  // MIMI_DROPZONE_H

--- a/internal/native/dropzone.m
+++ b/internal/native/dropzone.m
@@ -1,0 +1,94 @@
+#import "dropzone.h"
+
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
+
+// The drop zone is one transparent window the size of the display the
+// dragged window is over, with a rounded layer that slides to wherever the
+// layout says the window would land. Every call goes to the main thread,
+// where the daemon runs its application loop.
+
+static NSWindow *gZone;
+static CALayer *gShape;
+
+static NSRect mimiDropzoneCocoaRect(CGRect rect) {
+	double primaryHeight = CGDisplayBounds(CGMainDisplayID()).size.height;
+	return NSMakeRect(
+	    rect.origin.x, primaryHeight - rect.origin.y - rect.size.height, rect.size.width, rect.size.height);
+}
+
+static NSWindow *mimiDropzoneWindow(void) {
+	if (gZone) {
+		return gZone;
+	}
+	NSWindow *zone = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 1, 1)
+	                                             styleMask:NSWindowStyleMaskBorderless
+	                                               backing:NSBackingStoreBuffered
+	                                                 defer:NO];
+	zone.level = NSFloatingWindowLevel;
+	zone.opaque = NO;
+	zone.backgroundColor = [NSColor clearColor];
+	zone.hasShadow = NO;
+	zone.ignoresMouseEvents = YES;
+	zone.releasedWhenClosed = NO;
+	zone.animationBehavior = NSWindowAnimationBehaviorNone;
+	zone.collectionBehavior = NSWindowCollectionBehaviorStationary | NSWindowCollectionBehaviorIgnoresCycle |
+	                          NSWindowCollectionBehaviorCanJoinAllSpaces;
+	NSView *view = zone.contentView;
+	view.wantsLayer = YES;
+	CALayer *shape = [CALayer layer];
+	shape.anchorPoint = CGPointZero;
+	[view.layer addSublayer:shape];
+	gShape = shape;
+	gZone = zone;
+	return zone;
+}
+
+void MimiDropzoneShow(const MimiDropzoneStyle *style, double x, double y, double w, double h) {
+	MimiDropzoneStyle copy = *style;
+	CGRect frame = CGRectMake(x, y, w, h);
+	dispatch_async(dispatch_get_main_queue(), ^{
+		NSWindow *zone = mimiDropzoneWindow();
+		CGDirectDisplayID display = CGMainDisplayID();
+		uint32_t count = 0;
+		CGGetDisplaysWithPoint(CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame)), 1, &display, &count);
+		CGRect bounds = CGDisplayBounds(display);
+		BOOL shown = zone.visible;
+		if (!shown || !NSEqualRects(zone.frame, mimiDropzoneCocoaRect(bounds))) {
+			[zone setFrame:mimiDropzoneCocoaRect(bounds) display:NO];
+		}
+		CGRect local = CGRectMake(
+		    frame.origin.x - bounds.origin.x,
+		    bounds.size.height - (frame.origin.y - bounds.origin.y) - frame.size.height, frame.size.width,
+		    frame.size.height);
+		[CATransaction begin];
+		// The zone jumps to the first frame and slides to the ones after.
+		[CATransaction setDisableActions:!shown];
+		gShape.frame = local;
+		gShape.cornerRadius = copy.radius;
+		gShape.borderWidth = copy.width;
+		CGColorRef fill = CGColorCreateSRGB(copy.fill.red, copy.fill.green, copy.fill.blue, copy.fill.alpha);
+		CGColorRef outline =
+		    CGColorCreateSRGB(copy.outline.red, copy.outline.green, copy.outline.blue, copy.outline.alpha);
+		gShape.backgroundColor = fill;
+		gShape.borderColor = outline;
+		CGColorRelease(fill);
+		CGColorRelease(outline);
+		[CATransaction commit];
+		if (!shown) {
+			[zone orderFrontRegardless];
+		}
+	});
+}
+
+void MimiDropzoneHide(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (gZone) {
+			[gZone orderOut:nil];
+		}
+	});
+}
+
+int MimiLeftMouseButtonDown(void) {
+	return CGEventSourceButtonState(kCGEventSourceStateCombinedSessionState, kCGMouseButtonLeft) ? 1 : 0;
+}

--- a/internal/tiling/drag_hold_test.go
+++ b/internal/tiling/drag_hold_test.go
@@ -1,0 +1,74 @@
+package tiling //nolint:testpackage // sets the resize grace, as resize_test does
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+// TestEngine_Run_WaitsForTheMouseBeforeLayingOutADrag pins that a drag
+// which settles while the button is still held runs no pass until the
+// release, however long the user pauses.
+func TestEngine_Run_WaitsForTheMouseBeforeLayingOutADrag(t *testing.T) {
+	t.Parallel()
+
+	desktop := &snappingDesktop{frame: action.Frame{Width: 500, Height: 500}}
+	engine := New(desktop, nil, nil)
+	engine.resizeGrace = 50 * time.Millisecond
+	engine.Update(config.TilingConfig{
+		Enabled:        true,
+		RelayoutOnDrag: true,
+		DebounceMS:     10,
+		TimeoutSecs:    5,
+		Layout: `jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 800, height: 800}}], ` +
+			`state: {last: .event.kind}}'`,
+	}, "/bin/sh")
+
+	var held atomic.Bool
+
+	held.Store(true)
+	engine.SetMouse(held.Load)
+
+	ctx := t.Context()
+
+	sub := make(chan events.Event, 4)
+
+	go engine.Run(ctx, sub)
+
+	// The startup pass places the window; past the grace, the user drags
+	// it and pauses with the button down.
+	waitForCount(t, desktop, 1)
+	time.Sleep(engine.resizeGrace)
+	desktop.move(300)
+
+	sub <- events.Event{Kind: events.WindowMove, PID: 10}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if applies := desktop.count(); applies != 1 {
+		t.Fatalf("the drag was laid out %d times while the button was held, want none", applies-1)
+	}
+
+	held.Store(false)
+	waitForCount(t, desktop, 2)
+}
+
+// waitForCount waits for the desktop to have been written count times.
+func waitForCount(t *testing.T, desktop *snappingDesktop, count int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if desktop.count() >= count {
+			return
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Fatalf("waited for %d applies, have %d", count, desktop.count())
+}

--- a/internal/tiling/dropzone.go
+++ b/internal/tiling/dropzone.go
@@ -1,0 +1,70 @@
+package tiling
+
+import (
+	"context"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// DropTarget is where the window the user is dragging would land if they
+// let go now: the window, by number, and the frame the layout would give
+// it.
+type DropTarget struct {
+	Number uint32
+	Frame  action.Frame
+}
+
+// DropPreview asks the layout where the window the user is dragging would
+// land if dropped where it is now. It finds the drag the way a settled one
+// is found, by the windows no longer where the engine placed them, runs the
+// layout with the event the drop would raise, and reports the frame it
+// returns for the dragged window. Nothing is applied and no state is kept.
+// It reports false when nothing is being dragged, when relayout_on_drag is
+// off, or when the layout leaves the window out.
+func (e *Engine) DropPreview(ctx context.Context) (DropTarget, bool, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if !e.enabled || !e.onDrag || e.layout == nil || len(e.applied) == 0 {
+		return DropTarget{}, false, nil
+	}
+
+	windows, displays, fullScreen, err := e.readDesktop()
+	if err != nil {
+		return DropTarget{}, false, err
+	}
+
+	if inFullScreenTransition(windows.Windows, displays, fullScreen) {
+		return DropTarget{}, false, nil
+	}
+
+	kind, dragged := e.draggedLocked(windows)
+	if len(dragged) == 0 {
+		return DropTarget{}, false, nil
+	}
+
+	inputs, err := e.inputsLocked(Event{Kind: kind, Windows: dragged})
+	if err != nil {
+		return DropTarget{}, false, err
+	}
+
+	outputs, err := e.reduceAll(ctx, inputs)
+	if err != nil {
+		return DropTarget{}, false, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"previewing the drop",
+		)
+	}
+
+	for _, output := range outputs {
+		for _, frame := range output.Frames {
+			if frame.Number == dragged[0] {
+				return DropTarget{Number: frame.Number, Frame: frame.Frame}, true, nil
+			}
+		}
+	}
+
+	return DropTarget{}, false, nil
+}

--- a/internal/tiling/dropzone_test.go
+++ b/internal/tiling/dropzone_test.go
@@ -1,0 +1,85 @@
+package tiling_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/tiling"
+)
+
+func TestEngine_DropPreview_AsksTheLayoutWhereTheDraggedWindowLands(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	cfg := enabled(echoLayout)
+	cfg.RelayoutOnDrag = true
+	engine.Update(cfg, shell)
+
+	ctx := context.Background()
+
+	_, early, err := engine.DropPreview(ctx)
+	if early || err != nil {
+		t.Fatalf("DropPreview() before any pass = ok %v, err %v, want nothing dragged", early, err)
+	}
+
+	err = engine.Pass(ctx, tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	engine.Wait()
+
+	// The user drags window 1 away from where the layout put it.
+	desktop.mu.Lock()
+	desktop.windows.Windows[0].Frame = action.Frame{X: 400, Y: 300, Width: 100, Height: 100}
+	desktop.mu.Unlock()
+
+	target, ok, err := engine.DropPreview(ctx)
+	if err != nil || !ok {
+		t.Fatalf("DropPreview() = ok %v, err %v, want the layout's answer", ok, err)
+	}
+
+	want := tiling.DropTarget{Number: 1, Frame: action.Frame{X: 0, Y: 0, Width: 100, Height: 100}}
+	if target != want {
+		t.Errorf("DropPreview() = %+v, want %+v", target, want)
+	}
+
+	// Nothing was applied or remembered: the pass that follows the drop
+	// still sees the drag.
+	_, again, _ := engine.DropPreview(ctx)
+	if !again {
+		t.Error("a preview changed what the engine remembers")
+	}
+}
+
+func TestEngine_DropPreview_NeedsRelayoutOnDrag(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(echoLayout), shell)
+
+	ctx := context.Background()
+
+	err := engine.Pass(ctx, tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	engine.Wait()
+
+	desktop.mu.Lock()
+	desktop.windows.Windows[0].Frame = action.Frame{X: 400, Y: 300, Width: 100, Height: 100}
+	desktop.mu.Unlock()
+
+	_, found, err := engine.DropPreview(ctx)
+	if found || err != nil {
+		t.Errorf(
+			"DropPreview() = ok %v, err %v, want nothing with relayout_on_drag off",
+			found,
+			err,
+		)
+	}
+}

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -76,6 +76,9 @@ type Engine struct {
 
 	// onDrag is whether a window the user moved or resized runs a pass.
 	onDrag bool
+	// mouseDown reports whether the left button is held, which is when a
+	// settled drag is still going on; nil never is.
+	mouseDown func() bool
 	// applied is where every window the engine last wrote actually landed,
 	// read back rather than as requested, keyed by window number; and
 	// appliedAt is when. Together they tell the engine's own resizes from
@@ -199,6 +202,16 @@ func (e *Engine) Update(cfg config.TilingConfig, shell string) {
 	}
 }
 
+// SetMouse names the function that reports whether the left mouse button
+// is down. A drag that settles while it is, because the user paused, waits
+// for the release rather than laying the desktop out under their hand.
+func (e *Engine) SetMouse(down func() bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.mouseDown = down
+}
+
 // Enabled reports whether a pass would run anything.
 func (e *Engine) Enabled() bool {
 	e.mu.Lock()
@@ -302,8 +315,16 @@ func (e *Engine) Run(ctx context.Context, sub events.Subscriber) {
 
 			// A drag settles into one pass, whatever mix of move and
 			// resize events it raised on the way: what it was is decided
-			// here, from where the windows ended up.
+			// here, from where the windows ended up. One the user is
+			// still holding has not settled, however long they pause,
+			// and is looked at again a little later.
 			if isDrag(pending.Kind) {
+				if e.dragHeld() {
+					arm(pending)
+
+					continue
+				}
+
 				kind, windows := e.userDragged()
 				if len(windows) == 0 {
 					continue
@@ -409,6 +430,14 @@ func (e *Engine) Preview(ctx context.Context, event Event) ([]Input, []Output, e
 	outputs, err := e.reduceAll(ctx, inputs)
 
 	return inputs, outputs, err
+}
+
+// dragHeld reports whether the user is still holding a drag.
+func (e *Engine) dragHeld() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.mouseDown != nil && e.mouseDown()
 }
 
 // reduceAll runs the layout on every input at once, one goroutine each,
@@ -931,6 +960,13 @@ func (e *Engine) userDragged() (string, []uint32) {
 		return "", nil
 	}
 
+	return e.draggedLocked(windows)
+}
+
+// draggedLocked is the windows in windows that are no longer where the
+// engine placed them, and whether, taken together, they were moved or
+// resized. The caller holds the lock.
+func (e *Engine) draggedLocked(windows action.WindowsInfo) (string, []uint32) {
 	var (
 		dragged []uint32
 		resized bool
@@ -950,6 +986,10 @@ func (e *Engine) userDragged() (string, []uint32) {
 		if sized >= moved {
 			resized = true
 		}
+	}
+
+	if len(dragged) == 0 {
+		return "", nil
 	}
 
 	if resized {


### PR DESCRIPTION
## Description

This PR adds a drop zone for drag-to-relayout, and fixes a drag being laid out before the user lets go.

With `relayout_on_drag` on, a drag that paused with the button still held settled into a pass, and the desktop rearranged under the user's hand. A settled drag now waits for the mouse release, however long the pause, and runs once.

With the new `[tiling.dropzone]` section enabled, dragging a tiled window shows where the layout would put it if you released now: a translucent rounded frame that slides ahead of the drag as the answer changes. It is the layout's own answer. While the button is down, mimi finds the drag the way a settled one is found, runs the layout with the `window_move` or `window_resize` event the drop would raise, at most every 40 ms, and draws the frame it returns for the dragged window. Nothing is applied and no state is kept until the drop, so the shipped layouts need no change to take part: `strip.py` shows the column the window would join.

## Configuration

```toml
[tiling.dropzone]
enabled = false            # while you drag a window, show where the layout would put it
color = "#e2e2e330"        # fill, #rrggbb or #rrggbbaa
outline_color = "#e2e2e3"  # outline
outline_width = 2          # points; 0 draws none
radius = 12                # corner radius in points
```

`enabled` requires `tiling.relayout_on_drag`; the loader refuses the section otherwise. Every key is reloadable. Existing configs are unaffected. The tiling input and output formats are unchanged.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Verified live with a synthetic two-second drag of the Notes window across the strip on a 1920x1080 display: the zone was on screen for the length of the drag, the layout was asked 13 times, no pass ran until the release, and the drop joined the window to the column the zone showed. With the default colours over a dark desktop the zone reads as a faint light outline; the colours are the user's to set.

## Additional Context

Each preview reads the desktop twice, once to find the drag and once to build the layout's input, which is a round trip per window each time. At the 40 ms floor and a resident layout that answers in a few milliseconds, previews landed about 100 ms apart in the live run. Reusing the first read for the input is the obvious next step if that ever matters.
