### PR TITLE
feat(config): write colours with the alpha first, as #aarrggbb

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -94,10 +94,10 @@ duration_ms = 150
 easing = "ease-out"
 
 # While you drag a tiled window, show where the layout would put it if you
-# let go. Needs relayout_on_drag. Colours are #rrggbb or #rrggbbaa.
+# let go. Needs relayout_on_drag. Colours are #rrggbb or #aarrggbb.
 [tiling.dropzone]
 enabled = false
-color = "#e2e2e330"
+color = "#30e2e2e3"
 outline_color = "#e2e2e3"
 outline_width = 2
 radius = 12
@@ -120,7 +120,7 @@ width = 4
 # follow each window's own corners (macOS 26 and later; earlier releases get
 # a document window's). Set a number to draw every ring alike; 0 is square.
 # radius = 12
-# #rrggbb or #rrggbbaa.
+# #rrggbb or #aarrggbb.
 active_color = "#e2e2e3"
 inactive_color = "#414141"
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -158,7 +158,7 @@ easing = "ease-out"   # linear, ease-in, ease-out or ease-in-out
 
 [tiling.dropzone]
 enabled = false            # while you drag a window, show where the layout would put it
-color = "#e2e2e330"        # the zone's fill, #rrggbb or #rrggbbaa
+color = "#30e2e2e3"        # the zone's fill, #rrggbb or #aarrggbb
 outline_color = "#e2e2e3"  # its outline
 outline_width = 2          # points; 0 draws no outline
 radius = 12                # corner radius in points
@@ -291,7 +291,7 @@ tiling, and nothing more; every key is reloadable.
 enabled = true
 width = 4                   # points, 1 to 32
 # radius = 12               # force one corner radius; unset follows each window's own, 0 is square
-active_color = "#e2e2e3"    # the focused window, #rrggbb or #rrggbbaa
+active_color = "#e2e2e3"    # the focused window, #rrggbb or #aarrggbb
 inactive_color = "#414141"  # every other window
 ```
 

--- a/internal/border/engine_test.go
+++ b/internal/border/engine_test.go
@@ -35,7 +35,7 @@ func enabledConfig() config.BorderConfig {
 		Enabled:       true,
 		Width:         4,
 		ActiveColor:   "#ff0000",
-		InactiveColor: "#00000080",
+		InactiveColor: "#80000000",
 	}
 }
 

--- a/internal/config/border_test.go
+++ b/internal/config/border_test.go
@@ -71,9 +71,9 @@ func TestLoad_RejectsABorderItCannotDraw(t *testing.T) {
 		"thin":     {"width = 0.5\n", widthMessage},
 		"wide":     {"width = 33\n", widthMessage},
 		"radius":   {"radius = -1\n", "border.radius must be >= 0"},
-		"active":   {"active_color = \"red\"\n", "border.active_color must be #rrggbb or #rrggbbaa"},
-		"inactive": {"inactive_color = \"#12345\"\n", "border.inactive_color must be #rrggbb or #rrggbbaa"},
-		"not hex":  {"active_color = \"#gggggg\"\n", "border.active_color must be #rrggbb or #rrggbbaa"},
+		"active":   {"active_color = \"red\"\n", "border.active_color must be #rrggbb or #aarrggbb"},
+		"inactive": {"inactive_color = \"#12345\"\n", "border.inactive_color must be #rrggbb or #aarrggbb"},
+		"not hex":  {"active_color = \"#gggggg\"\n", "border.active_color must be #rrggbb or #aarrggbb"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -106,7 +106,7 @@ func TestParseColor(t *testing.T) {
 	for text, want := range map[string]Color{
 		"#ff0000":   {Red: 1, Alpha: 1},
 		"00ff00":    {Green: 1, Alpha: 1},
-		"#0000ff80": {Blue: 1, Alpha: 128.0 / 255},
+		"#800000ff": {Blue: 1, Alpha: 128.0 / 255},
 		"#FFFFFF":   {Red: 1, Green: 1, Blue: 1, Alpha: 1},
 	} {
 		got, err := ParseColor(text)

--- a/internal/config/color.go
+++ b/internal/config/color.go
@@ -13,36 +13,46 @@ type Color struct {
 }
 
 // channelMax is the largest value a two-digit hex channel holds.
-const channelMax = 255
+const (
+	channelMax = 255
+	// rgbChannels and argbChannels are how many channels a color is
+	// written with, without and with its alpha.
+	rgbChannels  = 3
+	argbChannels = 4
+)
 
-// ParseColor reads a color written as #rrggbb or #rrggbbaa, the leading #
-// optional. The alpha is 1 when left out.
+// ParseColor reads a color written as #rrggbb or #aarrggbb, the leading #
+// optional. The alpha comes first when given, as the Android and Compose
+// conventions write it, and is 1 when left out.
 func ParseColor(text string) (Color, error) {
 	hex := strings.TrimPrefix(strings.TrimSpace(text), "#")
 	if len(hex) != 6 && len(hex) != 8 {
 		return Color{}, derrors.Newf(
 			derrors.CodeInvalidConfig,
-			"color %q must be #rrggbb or #rrggbbaa",
+			"color %q must be #rrggbb or #aarrggbb",
 			text,
 		)
 	}
 
-	var channels [4]float64
-
-	channels[3] = 1
+	// Channels in the order written, alpha first when there are four.
+	values := make([]float64, 0, argbChannels)
 
 	for index := range len(hex) / 2 {
 		value, err := strconv.ParseUint(hex[index*2:index*2+2], 16, 8)
 		if err != nil {
 			return Color{}, derrors.Newf(
 				derrors.CodeInvalidConfig,
-				"color %q must be #rrggbb or #rrggbbaa",
+				"color %q must be #rrggbb or #aarrggbb",
 				text,
 			)
 		}
 
-		channels[index] = float64(value) / channelMax
+		values = append(values, float64(value)/channelMax)
 	}
 
-	return Color{Red: channels[0], Green: channels[1], Blue: channels[2], Alpha: channels[3]}, nil
+	if len(values) == rgbChannels {
+		values = append([]float64{1}, values...)
+	}
+
+	return Color{Alpha: values[0], Red: values[1], Green: values[2], Blue: values[3]}, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,7 +110,7 @@ type TilingConfig struct {
 // DropzoneConfig holds the [tiling.dropzone] section: whether, while the
 // user drags a tiled window, mimi shows where the layout would put it if
 // they let go, and how that zone is drawn. It needs relayout_on_drag, since
-// without it a drop changes nothing. Colors are #rrggbb or #rrggbbaa.
+// without it a drop changes nothing. Colors are #rrggbb or #aarrggbb.
 type DropzoneConfig struct {
 	Enabled      bool    `json:"enabled"      toml:"enabled"`
 	Color        string  `json:"color"        toml:"color"`
@@ -132,7 +132,7 @@ type AnimationConfig struct {
 // BorderConfig holds the [border] section: whether the daemon draws a
 // border around every window on the spaces in front, how wide, the radius
 // of the window corner it follows, and the colors for the focused window
-// and for the rest. Colors are written as #rrggbb or #rrggbbaa. The whole
+// and for the rest. Colors are written as #rrggbb or #aarrggbb. The whole
 // section is reloadable; it needs Accessibility, like the window events it
 // follows.
 type BorderConfig struct {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -173,7 +173,7 @@ const (
 // The [tiling.dropzone] defaults: a faint fill of the border's light color
 // with a thin outline of it, rounded like a document window.
 const (
-	defaultDropzoneColor        = "#e2e2e330"
+	defaultDropzoneColor        = "#30e2e2e3"
 	defaultDropzoneOutlineColor = "#e2e2e3"
 	defaultDropzoneOutlineWidth = 2.0
 	defaultDropzoneRadius       = 12.0
@@ -380,12 +380,12 @@ func validateDropzone(tiling TilingConfig) []string {
 
 	_, err := ParseColor(zone.Color)
 	if err != nil {
-		errs = append(errs, "tiling.dropzone.color must be #rrggbb or #rrggbbaa")
+		errs = append(errs, "tiling.dropzone.color must be #rrggbb or #aarrggbb")
 	}
 
 	_, err = ParseColor(zone.OutlineColor)
 	if err != nil {
-		errs = append(errs, "tiling.dropzone.outline_color must be #rrggbb or #rrggbbaa")
+		errs = append(errs, "tiling.dropzone.outline_color must be #rrggbb or #aarrggbb")
 	}
 
 	if zone.OutlineWidth < 0 || zone.OutlineWidth > maxBorderWidth {
@@ -421,12 +421,12 @@ func validateBorder(border BorderConfig) []string {
 
 	_, err := ParseColor(border.ActiveColor)
 	if err != nil {
-		errs = append(errs, "border.active_color must be #rrggbb or #rrggbbaa")
+		errs = append(errs, "border.active_color must be #rrggbb or #aarrggbb")
 	}
 
 	_, err = ParseColor(border.InactiveColor)
 	if err != nil {
-		errs = append(errs, "border.inactive_color must be #rrggbb or #rrggbbaa")
+		errs = append(errs, "border.inactive_color must be #rrggbb or #aarrggbb")
 	}
 
 	return errs

--- a/internal/dropzone/tracker_test.go
+++ b/internal/dropzone/tracker_test.go
@@ -78,7 +78,7 @@ func (f *fakes) hiddenCount() int {
 
 func enabledConfig() config.DropzoneConfig {
 	return config.DropzoneConfig{
-		Enabled: true, Color: "#e2e2e330", OutlineColor: "#e2e2e3", OutlineWidth: 2, Radius: 12,
+		Enabled: true, Color: "#30e2e2e3", OutlineColor: "#e2e2e3", OutlineWidth: 2, Radius: 12,
 	}
 }
 


### PR DESCRIPTION
## Description

This PR changes how a colour with an alpha is written in the config. The eight-digit form is now `#aarrggbb`, alpha first, for every colour mimi takes: the border's `active_color` and `inactive_color`, and the drop zone's `color` and `outline_color`. The six-digit `#rrggbb` form is unchanged and still means fully opaque.

## Configuration

```toml
[border]
active_color = "#e2e2e3"      # #rrggbb, opaque
inactive_color = "#80414141"  # #aarrggbb, alpha first

[tiling.dropzone]
color = "#30e2e2e3"           # a faint fill: alpha 30 over e2e2e3
```

The defaults that carry an alpha move accordingly.

## Potential breaking change

An existing eight-digit colour reads as a different colour after this. A value written as `#rrggbbaa` keeps loading, since the format has the same length, but its first two digits are now the alpha and its last two the blue. Anyone with such a value moves the last two digits to the front: `#0000ff80` becomes `#800000ff`. Six-digit colours are unaffected.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
