### PR TITLE
fix(tiling): keep a drag smooth while the drop zone previews it

### DIFF
--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -95,92 +95,18 @@ func (d *nativeDesktop) EnsureAccessible() error {
 // other application's. Asking the Accessibility server instead was measured
 // to wait on the application just activated.
 func (d *nativeDesktop) FocusableWindows() ([]Window, int, error) {
-	onScreen := native.WindowList(true)
-	all := native.WindowList(false)
+	windows, focused, _ := d.listOnScreen(true)
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	return windows, focused, nil
+}
 
-	d.evictLocked(all)
-
-	// The numbers the desktop has not seen, by application, each asked
-	// once for every window it has, at the same time as the others.
-	unknown := map[int]bool{}
-
-	for _, window := range onScreen {
-		if window.Layer != 0 || !window.Regular {
-			continue
-		}
-
-		if _, ok := d.entries[window.Number]; ok {
-			continue
-		}
-
-		if asked, ok := d.missing[window.Number]; ok && time.Since(asked) < missingFor {
-			continue
-		}
-
-		unknown[window.PID] = true
-	}
-
-	d.learnLocked(unknown)
-
-	windows := make([]Window, 0, len(onScreen))
-	focused := uint32(0)
-
-	for _, window := range onScreen {
-		if window.Layer != 0 || !window.Regular {
-			continue
-		}
-
-		entry, ok := d.entries[window.Number]
-		if !ok {
-			d.missing[window.Number] = time.Now()
-
-			continue
-		}
-
-		if !entry.isWindow {
-			continue
-		}
-
-		if focused == 0 {
-			focused = window.Number
-		}
-
-		windows = append(windows, Window{ID: entry.id, PID: entry.pid, Number: window.Number})
-	}
-
-	frames := map[uint32]native.Frame{}
-	for _, window := range onScreen {
-		frames[window.Number] = window.Frame
-	}
-
-	slices.SortStableFunc(windows, func(left, right Window) int {
-		leftFrame, rightFrame := frames[left.Number], frames[right.Number]
-		if leftFrame.Y != rightFrame.Y {
-			return cmp.Compare(leftFrame.Y, rightFrame.Y)
-		}
-
-		if leftFrame.X != rightFrame.X {
-			return cmp.Compare(leftFrame.X, rightFrame.X)
-		}
-
-		return cmp.Compare(left.PID, right.PID)
-	})
-
-	focusedIndex := -1
-	for index, window := range windows {
-		if window.Number == focused {
-			focusedIndex = index
-		}
-	}
-
-	d.known = windows
-	d.knownAt = time.Now()
-	d.listed = listing(onScreen)
-
-	return windows, focusedIndex, nil
+// KnownOnScreen lists the on-screen windows the desktop has learned already,
+// with their frames as the window server lists them, asking no application
+// anything: what a preview run at every step of a drag reads, since an
+// application being dragged answers Accessibility only when it gets round
+// to it. A window not learned yet is left out until the next full listing.
+func (d *nativeDesktop) KnownOnScreen() ([]Window, int, map[uint32]geometry.Rect) {
+	return d.listOnScreen(false)
 }
 
 // listing indexes a window list by number.
@@ -717,4 +643,104 @@ func (d *nativeDesktop) forget(windowID WindowID) {
 	d.framesMu.Lock()
 	delete(d.frames, windowID)
 	d.framesMu.Unlock()
+}
+
+// listOnScreen is the on-screen listing behind FocusableWindows and
+// KnownOnScreen: with learn set, applications are asked about the windows
+// the desktop has not seen; without it those windows are skipped.
+func (d *nativeDesktop) listOnScreen(learn bool) ([]Window, int, map[uint32]geometry.Rect) {
+	onScreen := native.WindowList(true)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if learn {
+		d.evictLocked(native.WindowList(false))
+
+		// The numbers the desktop has not seen, by application, each
+		// asked once for every window it has, at the same time as the
+		// others.
+		unknown := map[int]bool{}
+
+		for _, window := range onScreen {
+			if window.Layer != 0 || !window.Regular {
+				continue
+			}
+
+			if _, ok := d.entries[window.Number]; ok {
+				continue
+			}
+
+			if asked, ok := d.missing[window.Number]; ok && time.Since(asked) < missingFor {
+				continue
+			}
+
+			unknown[window.PID] = true
+		}
+
+		d.learnLocked(unknown)
+	}
+
+	windows := make([]Window, 0, len(onScreen))
+	focused := uint32(0)
+
+	for _, window := range onScreen {
+		if window.Layer != 0 || !window.Regular {
+			continue
+		}
+
+		entry, ok := d.entries[window.Number]
+		if !ok {
+			if learn {
+				d.missing[window.Number] = time.Now()
+			}
+
+			continue
+		}
+
+		if !entry.isWindow {
+			continue
+		}
+
+		if focused == 0 {
+			focused = window.Number
+		}
+
+		windows = append(windows, Window{ID: entry.id, PID: entry.pid, Number: window.Number})
+	}
+
+	frames := make(map[uint32]geometry.Rect, len(onScreen))
+	for _, window := range onScreen {
+		frame := window.Frame
+		frames[window.Number] = geometry.Rect{X: frame.X, Y: frame.Y, W: frame.W, H: frame.H}
+	}
+
+	slices.SortStableFunc(windows, func(left, right Window) int {
+		leftFrame, rightFrame := frames[left.Number], frames[right.Number]
+		if leftFrame.Y != rightFrame.Y {
+			return cmp.Compare(leftFrame.Y, rightFrame.Y)
+		}
+
+		if leftFrame.X != rightFrame.X {
+			return cmp.Compare(leftFrame.X, rightFrame.X)
+		}
+
+		return cmp.Compare(left.PID, right.PID)
+	})
+
+	focusedIndex := -1
+	for index, window := range windows {
+		if window.Number == focused {
+			focusedIndex = index
+		}
+	}
+
+	if learn {
+		d.known = windows
+		d.knownAt = time.Now()
+	}
+
+	d.listed = listing(onScreen)
+
+	return windows, focusedIndex, frames
 }

--- a/internal/action/windows_query.go
+++ b/internal/action/windows_query.go
@@ -121,6 +121,14 @@ func QueryWindows() (WindowsInfo, error) {
 	return defaultExecutor.QueryWindows()
 }
 
+// QueryWindowsWithTitles is QueryWindows with the titles in known taken
+// as they are, by window number, so only the windows not in it are asked
+// for theirs: a title is a round trip into the application, and a preview
+// run at every step of a drag has no use for a fresh one.
+func QueryWindowsWithTitles(known map[uint32]string) (WindowsInfo, error) {
+	return defaultExecutor.QueryWindowsWithTitles(known)
+}
+
 // QueryDisplays lists the connected displays of the desktop mimi is running
 // on.
 func QueryDisplays() ([]DisplayEntry, error) {
@@ -139,23 +147,79 @@ func QueryDisplays() ([]DisplayEntry, error) {
 // is more useful complete than refused. A missing title or application is
 // reported as "" and the window kept.
 func (e *Executor) QueryWindows() (WindowsInfo, error) {
+	return e.QueryWindowsWithTitles(nil)
+}
+
+// knownLister is a desktop that can list the windows it has learned with
+// their frames, asking no application anything.
+type knownLister interface {
+	KnownOnScreen() ([]Window, int, map[uint32]geometry.Rect)
+}
+
+// QueryWindowsWithTitles is QueryWindows taking the titles in known as they
+// are, by window number. On a desktop that can list its learned windows
+// without asking the applications, that is the whole listing: a window
+// without a known title is left out, since it is one the last full listing
+// did not see. Elsewhere only the windows not in known are asked.
+func (e *Executor) QueryWindowsWithTitles(known map[uint32]string) (WindowsInfo, error) {
 	err := e.desktop.EnsureAccessible()
 	if err != nil {
 		return WindowsInfo{}, err
 	}
 
-	info, retry, err := e.listWindows()
+	if lister, ok := e.desktop.(knownLister); ok && known != nil {
+		return e.listKnown(lister, known), nil
+	}
+
+	info, retry, err := e.listWindows(known)
 	if err != nil || !retry {
 		return info, err
 	}
 
-	info, _, err = e.listWindows()
+	info, _, err = e.listWindows(known)
 
 	return info, err
 }
 
+// listKnown lists the learned windows with the titles in known, from the
+// window server alone.
+func (e *Executor) listKnown(lister knownLister, known map[uint32]string) WindowsInfo {
+	windows, focused, frames := lister.KnownOnScreen()
+	info := WindowsInfo{Focused: -1, Windows: make([]WindowEntry, 0, len(windows))}
+
+	for index, win := range windows {
+		title, titled := known[win.Number]
+		if !titled {
+			continue
+		}
+
+		frame, listed := frames[win.Number]
+		if !listed {
+			continue
+		}
+
+		app, _ := e.desktop.ApplicationInfo(win.PID)
+
+		if index == focused {
+			info.Focused = len(info.Windows)
+		}
+
+		info.Windows = append(info.Windows, WindowEntry{
+			Number:   win.Number,
+			PID:      win.PID,
+			App:      app.Name,
+			BundleID: app.BundleID,
+			Title:    title,
+			Frame:    frameOf(frame),
+		})
+	}
+
+	return info
+}
+
 // listWindows is one enumeration, reporting whether a frame read failed.
-func (e *Executor) listWindows() (WindowsInfo, bool, error) {
+// Titles in known are taken as they are.
+func (e *Executor) listWindows(known map[uint32]string) (WindowsInfo, bool, error) {
 	windows, focused, err := e.desktop.FocusableWindows()
 	if err != nil {
 		return WindowsInfo{}, false, derrors.Wrapf(
@@ -176,7 +240,11 @@ func (e *Executor) listWindows() (WindowsInfo, bool, error) {
 			continue
 		}
 
-		title, _ := e.desktop.WindowTitle(win.ID)
+		title, ok := known[win.Number]
+		if !ok {
+			title, _ = e.desktop.WindowTitle(win.ID)
+		}
+
 		app, _ := e.desktop.ApplicationInfo(win.PID)
 
 		if index == focused {

--- a/internal/border/engine.go
+++ b/internal/border/engine.go
@@ -126,13 +126,16 @@ func (e *Engine) Run(ctx context.Context, sub events.Subscriber) {
 			e.Close()
 
 			return
-		case _, ok := <-sub:
+		case evt, ok := <-sub:
 			if !ok {
 				return
 			}
 
+			// A settled move or resize is a drag's, and a drag moves no
+			// focus; asking the application for its focused window would
+			// only hold it up mid-drag.
 			if e.Enabled() {
-				e.draw.Sync(true)
+				e.draw.Sync(evt.Kind != events.WindowMove && evt.Kind != events.WindowResize)
 			}
 		}
 	}

--- a/internal/tiling/desktop.go
+++ b/internal/tiling/desktop.go
@@ -9,6 +9,12 @@ type LiveDesktop struct{}
 // Windows lists the focusable windows on the active space.
 func (LiveDesktop) Windows() (action.WindowsInfo, error) { return action.QueryWindows() }
 
+// WindowsWithTitles is Windows taking the titles in known as they are, so a
+// preview run at every step of a drag asks no application for one.
+func (LiveDesktop) WindowsWithTitles(known map[uint32]string) (action.WindowsInfo, error) {
+	return action.QueryWindowsWithTitles(known)
+}
+
 // Displays lists the connected displays.
 func (LiveDesktop) Displays() ([]action.DisplayEntry, error) { return action.QueryDisplays() }
 

--- a/internal/tiling/dropzone.go
+++ b/internal/tiling/dropzone.go
@@ -2,6 +2,7 @@ package tiling
 
 import (
 	"context"
+	"time"
 
 	"github.com/y3owk1n/mimi/internal/action"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
@@ -30,24 +31,31 @@ func (e *Engine) DropPreview(ctx context.Context) (DropTarget, bool, error) {
 		return DropTarget{}, false, nil
 	}
 
-	windows, displays, fullScreen, err := e.readDesktop()
+	// One read serves both the drag and the layout's input, with the
+	// titles of the last full read: at every step of a drag, a round trip
+	// into each application for a title, the dragged one's included, is
+	// what made the drag stutter.
+	readStart := time.Now()
+
+	read, err := e.readInputsLocked(true)
 	if err != nil {
 		return DropTarget{}, false, err
 	}
 
-	if inFullScreenTransition(windows.Windows, displays, fullScreen) {
+	readFor := time.Since(readStart)
+
+	if inFullScreenTransition(read.windows.Windows, read.displays, read.fullScreen) {
 		return DropTarget{}, false, nil
 	}
 
-	kind, dragged := e.draggedLocked(windows)
+	kind, dragged := e.draggedLocked(read.windows)
 	if len(dragged) == 0 {
 		return DropTarget{}, false, nil
 	}
 
-	inputs, err := e.inputsLocked(Event{Kind: kind, Windows: dragged})
-	if err != nil {
-		return DropTarget{}, false, err
-	}
+	inputs := e.buildInputsLocked(Event{Kind: kind, Windows: dragged}, read)
+
+	layoutStart := time.Now()
 
 	outputs, err := e.reduceAll(ctx, inputs)
 	if err != nil {
@@ -57,6 +65,12 @@ func (e *Engine) DropPreview(ctx context.Context) (DropTarget, bool, error) {
 			"previewing the drop",
 		)
 	}
+
+	e.logger.Debugw("drop preview",
+		"read_ms", readFor.Milliseconds(),
+		"layout_ms", time.Since(layoutStart).Milliseconds(),
+		"windows", len(read.windows.Windows),
+	)
 
 	for _, output := range outputs {
 		for _, frame := range output.Frames {

--- a/internal/tiling/dropzone_test.go
+++ b/internal/tiling/dropzone_test.go
@@ -83,3 +83,62 @@ func TestEngine_DropPreview_NeedsRelayoutOnDrag(t *testing.T) {
 		)
 	}
 }
+
+// titledDesktop is a fake desktop that can take titles as given, and
+// counts how each listing was asked for.
+type titledDesktop struct {
+	*fakeDesktop
+
+	withTitles int
+	known      map[uint32]string
+}
+
+func (d *titledDesktop) WindowsWithTitles(known map[uint32]string) (action.WindowsInfo, error) {
+	d.withTitles++
+	d.known = known
+
+	return d.Windows()
+}
+
+func TestEngine_DropPreview_ReusesTheTitlesOfTheLastPass(t *testing.T) {
+	t.Parallel()
+
+	desktop := &titledDesktop{fakeDesktop: newDesktop()}
+	desktop.windows.Windows[0].Title = "notes.md"
+	engine := tiling.New(desktop, nil, nil)
+	cfg := enabled(echoLayout)
+	cfg.RelayoutOnDrag = true
+	engine.Update(cfg, shell)
+
+	ctx := context.Background()
+
+	err := engine.Pass(ctx, tiling.Event{Kind: tiling.EventRelayout})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	engine.Wait()
+
+	desktop.mu.Lock()
+	desktop.windows.Windows[0].Frame = action.Frame{X: 400, Y: 300, Width: 100, Height: 100}
+	desktop.mu.Unlock()
+
+	_, found, err := engine.DropPreview(ctx)
+	if err != nil || !found {
+		t.Fatalf("DropPreview() = ok %v, err %v, want the layout's answer", found, err)
+	}
+
+	if desktop.withTitles != 1 {
+		t.Errorf(
+			"the preview listed windows with given titles %d times, want once",
+			desktop.withTitles,
+		)
+	}
+
+	if desktop.known[1] != "notes.md" {
+		t.Errorf(
+			"the preview was handed titles %v, want the pass's title for window 1",
+			desktop.known,
+		)
+	}
+}

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -73,6 +73,9 @@ type Engine struct {
 	// first, so a window_created pass can tell whether the window it was
 	// raised for has reached the window server's on-screen list yet.
 	seen map[uint32]bool
+	// titles is every window's title as the last full read had it, by
+	// number, for a preview that would rather not ask the applications.
+	titles map[uint32]string
 
 	// onDrag is whether a window the user moved or resized runs a pass.
 	onDrag bool
@@ -119,6 +122,7 @@ func New(desktop Desktop, serialize Serializer, logger *zap.SugaredLogger) *Engi
 		states:      map[string]json.RawMessage{},
 		pending:     map[string]bool{},
 		applied:     map[uint32]action.Frame{},
+		titles:      map[uint32]string{},
 		resizeGrace: defaultResizeGrace,
 		wake:        make(chan Event, 1),
 	}
@@ -739,45 +743,92 @@ func (e *Engine) newWindowOf(inputs []Input, pid int) bool {
 
 // inputsLocked reads the desktop into one Input per display that has a
 // window on it and is not showing a full-screen space, in display order. The caller holds the lock.
-func (e *Engine) inputsLocked(event Event) ([]Input, error) {
-	var (
-		displays   []action.DisplayEntry
-		spaces     map[uint32]int
-		fullScreen map[uint32]bool
-		margins    action.MarginsInfo
-		windows    action.WindowsInfo
-	)
+// titledWindower is a desktop that can list windows with titles it is
+// handed rather than read, which the live one can.
+type titledWindower interface {
+	WindowsWithTitles(known map[uint32]string) (action.WindowsInfo, error)
+}
+
+// desktopRead is everything one pass reads of the desktop.
+type desktopRead struct {
+	displays   []action.DisplayEntry
+	spaces     map[uint32]int
+	fullScreen map[uint32]bool
+	margins    action.MarginsInfo
+	windows    action.WindowsInfo
+}
+
+// readInputsLocked reads what the inputs are built from. With quick set,
+// and a desktop that can, the windows keep the titles of the last full
+// read rather than asking the applications; every full read refreshes
+// them. The caller holds the lock.
+func (e *Engine) readInputsLocked(quick bool) (desktopRead, error) {
+	var read desktopRead
+
+	titled, canReuse := e.desktop.(titledWindower)
 
 	err := e.run(func() error {
 		var err error
 
-		displays, err = e.desktop.Displays()
+		read.displays, err = e.desktop.Displays()
 		if err != nil {
 			return err
 		}
 
-		spaces, err = e.desktop.ActiveSpaces()
+		read.spaces, err = e.desktop.ActiveSpaces()
 		if err != nil {
 			return err
 		}
 
-		fullScreen, err = e.desktop.FullScreenDisplays()
+		read.fullScreen, err = e.desktop.FullScreenDisplays()
 		if err != nil {
 			return err
 		}
 
-		margins, err = e.desktop.Margins()
+		read.margins, err = e.desktop.Margins()
 		if err != nil {
 			return err
 		}
 
-		windows, err = e.desktop.Windows()
+		if quick && canReuse {
+			read.windows, err = titled.WindowsWithTitles(e.titles)
+
+			return err
+		}
+
+		read.windows, err = e.desktop.Windows()
 
 		return err
 	})
 	if err != nil {
+		return desktopRead{}, err
+	}
+
+	if !quick || !canReuse {
+		e.titles = make(map[uint32]string, len(read.windows.Windows))
+		for _, win := range read.windows.Windows {
+			e.titles[win.Number] = win.Title
+		}
+	}
+
+	return read, nil
+}
+
+// inputsLocked is one input per display with windows, built from a full
+// read of the desktop. The caller holds the lock.
+func (e *Engine) inputsLocked(event Event) ([]Input, error) {
+	read, err := e.readInputsLocked(false)
+	if err != nil {
 		return nil, err
 	}
+
+	return e.buildInputsLocked(event, read), nil
+}
+
+// buildInputsLocked is one input per display with windows, from read. The
+// caller holds the lock.
+func (e *Engine) buildInputsLocked(event Event, read desktopRead) []Input {
+	displays, spaces, fullScreen, margins, windows := read.displays, read.spaces, read.fullScreen, read.margins, read.windows
 
 	focused := uint32(0)
 	if windows.Focused >= 0 && windows.Focused < len(windows.Windows) {
@@ -835,7 +886,7 @@ func (e *Engine) inputsLocked(event Event) ([]Input, error) {
 		inputs = append(inputs, input)
 	}
 
-	return inputs, nil
+	return inputs
 }
 
 // displayOf is the id of the display whose frame holds the center of frame,


### PR DESCRIPTION
## Description

This PR fixes the drag stuttering when the drop zone is on. Each preview read the desktop twice and asked every application for its window titles, asked an application about windows the desktop had not learned yet, retried every two seconds, and the borders asked the frontmost application for its focused window on every settled move event. Every one of those is a round trip into the application being dragged, which answers only when it gets round to it, and the drag stalled for half a second at a time.

The preview now reads the desktop once and lists only the windows the desktop has already learned, with frames straight from the window server and the titles kept from the last full layout pass, so it asks no application anything. A settled move or resize now syncs the borders without a refocus, since a drag moves no focus. A window the desktop has not learned yet is left out of the preview until the next full pass, which is the pass that learns it anyway.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no user-facing surface changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

Measured with a synthetic 2.5 second drag of the Notes window across the strip on a 1920x1080 display, sampling the window's position every 8 ms for the longest pause in its motion, and logging each preview's read time.

| | before | after |
|---|---|---|
| Preview read, median | 47 ms | 11 ms |
| Preview read, worst | 524 ms | 19 ms |
| Longest stall in the drag, zone on | 507 ms | 92 to 115 ms |
| Longest stall with no daemon running | 188 ms | 188 ms |

The remaining 90 to 190 ms pause happens with no daemon running at all, so it is macOS's own at the start of a drag. Each preview logs its read and layout time at debug level.
