### PR TITLE
fix(tiling): lay the desktop out when a display comes or goes

### DIFF
--- a/internal/tiling/display_change_test.go
+++ b/internal/tiling/display_change_test.go
@@ -1,0 +1,94 @@
+package tiling //nolint:testpackage // reads the states the passes kept
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+// TestEngine_Run_UnpluggingADisplayLaysOutRatherThanDrags pins that the
+// windows macOS moves when a display goes away are not taken for a drag:
+// the desktop is laid out afresh instead, so a layout that drops a window
+// where it was dropped does not pile them all where macOS put them.
+func TestEngine_Run_UnpluggingADisplayLaysOutRatherThanDrags(t *testing.T) {
+	t.Parallel()
+
+	both := []action.DisplayEntry{
+		{
+			Index:   1,
+			ID:      1,
+			Frame:   action.Frame{Width: 1000, Height: 1000},
+			Visible: action.Frame{Width: 1000, Height: 1000},
+		},
+		{
+			Index:   2,
+			ID:      2,
+			Frame:   action.Frame{X: 1000, Width: 1000, Height: 1000},
+			Visible: action.Frame{X: 1000, Width: 1000, Height: 1000},
+		},
+	}
+
+	desktop := &snappingDesktop{frame: action.Frame{X: 1000, Width: 500, Height: 500}}
+	desktop.setDisplays(both)
+
+	engine := New(desktop, nil, nil)
+	engine.resizeGrace = 50 * time.Millisecond
+	engine.Update(config.TilingConfig{
+		Enabled:        true,
+		RelayoutOnDrag: true,
+		DebounceMS:     10,
+		TimeoutSecs:    5,
+		Layout: `jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 800, height: 800}}], ` +
+			`state: {last: .event.kind}}'`,
+	}, "/bin/sh")
+
+	var held atomic.Bool
+
+	engine.SetMouse(held.Load)
+
+	ctx := t.Context()
+
+	sub := make(chan events.Event, 4)
+
+	go engine.Run(ctx, sub)
+
+	waitForCount(t, desktop, 1)
+	time.Sleep(engine.resizeGrace)
+
+	// The display goes away and macOS moves the window onto the one left.
+	desktop.setDisplays(both[:1])
+	desktop.move(-900)
+
+	sub <- events.Event{Kind: events.WindowMove, PID: 10}
+
+	waitForCount(t, desktop, 2)
+
+	kinds := engine.lastKinds(t)
+	if !strings.Contains(kinds, EventRelayout) {
+		t.Errorf("the layout was run for %q, want a %q pass", kinds, EventRelayout)
+	}
+
+	if strings.Contains(kinds, string(events.WindowMove)) {
+		t.Errorf("the layout was run for %q, want the moved window not taken for a drag", kinds)
+	}
+}
+
+// lastKinds is every event kind the layout recorded in its state, joined.
+func (e *Engine) lastKinds(t *testing.T) string {
+	t.Helper()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	kinds := make([]string, 0, len(e.states))
+	for _, state := range e.states {
+		kinds = append(kinds, string(state))
+	}
+
+	return strings.Join(kinds, " ")
+}

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os/exec"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -79,6 +80,9 @@ type Engine struct {
 
 	// onDrag is whether a window the user moved or resized runs a pass.
 	onDrag bool
+	// displays names the displays the last pass read, so the windows macOS
+	// moves when one is plugged in or unplugged are not taken for a drag.
+	displays string
 	// mouseDown reports whether the left button is held, which is when a
 	// settled drag is still going on; nil never is.
 	mouseDown func() bool
@@ -330,7 +334,7 @@ func (e *Engine) Run(ctx context.Context, sub events.Subscriber) {
 				}
 
 				kind, windows := e.userDragged()
-				if len(windows) == 0 {
+				if kind == "" {
 					continue
 				}
 
@@ -811,6 +815,10 @@ func (e *Engine) readInputsLocked(quick bool) (desktopRead, error) {
 		}
 	}
 
+	if !quick {
+		e.displays = displaySignature(read.displays)
+	}
+
 	return read, nil
 }
 
@@ -1005,6 +1013,14 @@ func (e *Engine) userDragged() (string, []uint32) {
 		return "", nil
 	}
 
+	// A display plugged in or unplugged moves every window macOS has to
+	// find a new home for, all at once and none of it the user's doing.
+	// The desktop is laid out afresh instead, which places those windows
+	// by the layout's own reckoning rather than by where they landed.
+	if e.displays != "" && displaySignature(displays) != e.displays {
+		return EventRelayout, nil
+	}
+
 	if time.Since(e.appliedAt) < e.resizeGrace {
 		e.rememberFrames(windows)
 
@@ -1012,6 +1028,19 @@ func (e *Engine) userDragged() (string, []uint32) {
 	}
 
 	return e.draggedLocked(windows)
+}
+
+// displaySignature names a set of displays by their ids and frames, so a
+// display added, removed, or moved in the arrangement reads as a change.
+func displaySignature(displays []action.DisplayEntry) string {
+	ids := make([]string, 0, len(displays))
+	for _, display := range displays {
+		ids = append(ids, fmt.Sprintf("%d:%v", display.ID, display.Frame))
+	}
+
+	slices.Sort(ids)
+
+	return strings.Join(ids, " ")
 }
 
 // draggedLocked is the windows in windows that are no longer where the

--- a/internal/tiling/resize_test.go
+++ b/internal/tiling/resize_test.go
@@ -20,6 +20,9 @@ type snappingDesktop struct {
 	frame   action.Frame
 	applies int
 	snapBy  float64
+	// displays are the displays it reports, or nil for the one display
+	// below.
+	displays []action.DisplayEntry
 }
 
 func (d *snappingDesktop) Windows() (action.WindowsInfo, error) {
@@ -32,6 +35,13 @@ func (d *snappingDesktop) Windows() (action.WindowsInfo, error) {
 }
 
 func (d *snappingDesktop) Displays() ([]action.DisplayEntry, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.displays != nil {
+		return d.displays, nil
+	}
+
 	return []action.DisplayEntry{{
 		Index:   1,
 		ID:      1,
@@ -58,6 +68,15 @@ func (d *snappingDesktop) Apply(frames []action.WindowFrame, _ *action.Animation
 	d.frame.Width -= d.snapBy
 
 	return nil
+}
+
+// setDisplays reports these displays from now on, as macOS does when one is
+// plugged in or unplugged.
+func (d *snappingDesktop) setDisplays(displays []action.DisplayEntry) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.displays = displays
 }
 
 func (d *snappingDesktop) count() int {


### PR DESCRIPTION
## Description

This PR fixes the layout collapsing into one vertical stack when a display is unplugged.

macOS moves every window the departing display leaves homeless, all at once. With `relayout_on_drag` those moves settled into a single drag, so the layout was told the user had dropped each window where macOS had just put it. A strip layout drops a window into the column under its centre, and every rehomed window now had its centre on the one display left, so they all went into the same column and stacked vertically.

Every pass now remembers the displays it read, and a settled drag whose displays are not those runs as a relayout instead of a drag. The windows are then placed by the layout's own reckoning, exactly as on any other pass. A display plugged in takes the same path. An ordinary drag is unaffected.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, no configuration or command changed
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Additional Context

The new test drives the engine with a two-display desktop, takes one display away and moves its window onto the other, then sends the move event macOS would. Without the fix the layout is run for `window_move`, which is the bug; with it the layout is run for `relayout`.

Verified live on a single display that an ordinary drag still settles as a drag: dragging a window across the strip ran a `window_move` pass and the strip moved the window into the column it was dropped on.

With `relayout_on_drag` off nothing changes: no pass runs when the display goes, as before, and the next event lays the desktop out.
