### PR TITLE
fix(tiling): key a layout's state to the space itself, not its place in Mission Control

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,9 +33,17 @@ it on its own thread and returns the result.
 _Avoid_: IPC path, remote execution, server path
 
 **Space**:
-One Mission Control space, identified by its 1-based index in Mission Control
-ordering across every connected display.
-_Avoid_: desktop, workspace, virtual desktop
+One Mission Control space. It has two numbers and they are not
+interchangeable. Its **index** is its 1-based place in Mission Control
+ordering across every connected display. That is the number the user counts,
+the number every command and query reports, and the number `mimi action space`
+takes. Its **identifier** is the window server's own, assigned when the space
+is created and kept until it is destroyed. Adding or removing a space changes
+the index of every space after it. Nothing changes an identifier. So mimi
+reports the index and stores the identifier, and the one thing mimi stores
+per space today is the tiling engine's layout state.
+_Avoid_: desktop, workspace, virtual desktop. Never "space id" for the index,
+or "space number" for either.
 
 **Hook**:
 A shell command the daemon runs when a desktop event of a given kind occurs.

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -110,7 +110,9 @@ window event ---> daemon settles the burst (debounce_ms, default 100)
   applied together.
 - **State.** Whatever you print as `state` comes back on the next run for
   the same display and space. A layout remembers a tree or a ratio without
-  touching a file. Each display keeps one state per Mission Control space.
+  touching a file. Each display keeps one state per space, filed under the
+  space rather than its place in Mission Control, so adding or removing a
+  space never hands a layout the state it built for another one.
 - **The engine never fights you.** Its own frame writes never wake it. With
   `relayout_on_drag` it tells your drag from its own write by reading back
   where every window actually landed.

--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -155,6 +155,14 @@ type Desktop interface {
 	// space every entry is the same index.
 	ActiveSpaces() (map[uint32]int, error)
 
+	// ActiveSpaceIDs is the window server's own identifier for the space in
+	// front on every connected display, keyed by display id, leaving out a
+	// display whose space cannot be resolved. ActiveSpaces reports where a
+	// space sits in Mission Control. This reports which space it is. Adding
+	// or removing a space changes the first number and not the second, so a
+	// caller that remembers something about a space keys it by this one.
+	ActiveSpaceIDs() (map[uint32]uint64, error)
+
 	// FullScreenDisplays is the set of connected displays, by id, whose
 	// space in front is a full-screen application space. macOS lays that
 	// space out itself, for one window or a split-view pair.

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -76,6 +76,11 @@ type fakeDesktop struct {
 	// activeSpaces is the space in front per display, when a test sets it;
 	// otherwise every display shows activeSpace.
 	activeSpaces map[uint32]int
+	// activeSpaceIDs is the window server's identifier for the space in
+	// front per display, when a test sets it; otherwise one is derived from
+	// the space's index, so distinct spaces stay distinct without a test
+	// having to name ids it does not care about.
+	activeSpaceIDs map[uint32]uint64
 	// fullScreenDisplays is what FullScreenDisplays reports.
 	fullScreenDisplays map[uint32]bool
 	// enumerations counts FocusableWindows calls.
@@ -358,6 +363,31 @@ func (d *fakeDesktop) ActiveSpaces() (map[uint32]int, error) {
 	}
 
 	return spaces, nil
+}
+
+func (d *fakeDesktop) ActiveSpaceIDs() (map[uint32]uint64, error) {
+	if d.activeSpaceIDs != nil {
+		return d.activeSpaceIDs, nil
+	}
+
+	spaces, err := d.ActiveSpaces()
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make(map[uint32]uint64, len(spaces))
+	for display, index := range spaces {
+		ids[display] = fakeSpaceID(index)
+	}
+
+	return ids, nil
+}
+
+// fakeSpaceID is the identifier the fake gives the space at a Mission Control
+// index, when a test has not named one itself. It is offset so that an id is
+// never mistaken for an index in a failure message.
+func fakeSpaceID(index int) uint64 {
+	return uint64(index) + 1000
 }
 
 func (d *fakeDesktop) FocusSpace(index int) error {

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -445,6 +445,22 @@ func (d *nativeDesktop) ActiveSpaces() (map[uint32]int, error) {
 	return native.ActiveSpaceIndexes(ids), nil
 }
 
+// ActiveSpaceIDs is the window server's identifier for the space in front on
+// every display.
+func (d *nativeDesktop) ActiveSpaceIDs() (map[uint32]uint64, error) {
+	displays, err := native.Displays()
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]uint32, len(displays))
+	for index, display := range displays {
+		ids[index] = display.ID
+	}
+
+	return native.ActiveSpaceIDs(ids), nil
+}
+
 func (d *nativeDesktop) FullScreenDisplays() (map[uint32]bool, error) {
 	displays, err := native.Displays()
 	if err != nil {

--- a/internal/action/windows_query.go
+++ b/internal/action/windows_query.go
@@ -69,6 +69,12 @@ func QueryActiveSpaces() (map[uint32]int, error) {
 	return defaultExecutor.QueryActiveSpaces()
 }
 
+// QueryActiveSpaceIDs reports which space is in front on every display of the
+// desktop mimi is running on.
+func QueryActiveSpaceIDs() (map[uint32]uint64, error) {
+	return defaultExecutor.QueryActiveSpaceIDs()
+}
+
 // QueryFullScreenDisplays reports the displays of the desktop mimi is
 // running on that show a full-screen space in front.
 func QueryFullScreenDisplays() (map[uint32]bool, error) {
@@ -109,6 +115,24 @@ func (e *Executor) QueryActiveSpaces() (map[uint32]int, error) {
 		return nil, derrors.New(
 			derrors.CodeActionFailed,
 			"failed to enumerate Mission Control spaces",
+		)
+	}
+
+	return spaces, nil
+}
+
+// QueryActiveSpaceIDs reports which space is in front on every display, keyed
+// by display id, the way QueryActiveSpaces reports where that space sits.
+//
+// A display whose space cannot be resolved is left out rather than reported
+// as 0, so a caller keyed by this never takes two such displays for one.
+func (e *Executor) QueryActiveSpaceIDs() (map[uint32]uint64, error) {
+	spaces, err := e.desktop.ActiveSpaceIDs()
+	if err != nil {
+		return nil, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to resolve the active space identifiers",
 		)
 	}
 

--- a/internal/baseline/space_identity_integration_test.go
+++ b/internal/baseline/space_identity_integration_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+// What the window server says about the space in front, checked against the
+// assumption the tiling engine's state is filed under.
+//
+// A space has two numbers. One is where it sits in Mission Control, which
+// changes whenever a space is added or removed before it. The other is the
+// window server's own identifier for it, which never changes. The engine
+// reports the first to a layout and files the layout's state under the
+// second, so the two have to name the same space. This test reads both off
+// the live desktop and checks that they do.
+//
+// It only reads. It opens no window, moves nothing, and skips rather than
+// fails on a machine that cannot answer.
+
+package baseline_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/native"
+)
+
+func TestSpaceIdentity_TheIDAndTheIndexNameTheSameSpace(t *testing.T) {
+	displays, err := native.Displays()
+	if err != nil {
+		t.Skipf("the displays could not be enumerated: %v", err)
+	}
+
+	if len(displays) == 0 {
+		t.Skip("no display is connected")
+	}
+
+	ids := make([]uint32, len(displays))
+	for index, display := range displays {
+		ids[index] = display.ID
+	}
+
+	indexes := native.ActiveSpaceIndexes(ids)
+	spaceIDs := native.ActiveSpaceIDs(ids)
+
+	if len(indexes) == 0 {
+		t.Skip("no display's space could be resolved, so Mission Control may be open")
+	}
+
+	// The window server identifies every space it also places in Mission
+	// Control. The engine keys state on the identifier, so a display with a
+	// place and no identifier would keep no layout state.
+	for display, index := range indexes {
+		sid, ok := spaceIDs[display]
+		if !ok {
+			t.Fatalf(
+				"display %d shows Mission Control space %d but no space identifier, "+
+					"so the engine would keep no state for it",
+				display, index,
+			)
+		}
+
+		if sid == 0 {
+			t.Fatalf("display %d reported space identifier 0, which names nothing", display)
+		}
+	}
+
+	// The two also agree about which space that is. The identifier's own
+	// place in Mission Control is the index reported beside it.
+	places := native.SpaceIndexes()
+
+	for display, sid := range spaceIDs {
+		index, ok := indexes[display]
+		if !ok {
+			continue
+		}
+
+		if place, known := places[sid]; known && place != index {
+			t.Fatalf(
+				"display %d: space %d sits at Mission Control index %d, but the "+
+					"active-space index says %d",
+				display, sid, place, index,
+			)
+		}
+	}
+}

--- a/internal/native/space.go
+++ b/internal/native/space.go
@@ -86,6 +86,28 @@ func ActiveSpaceIndexes(displayIDs []uint32) map[uint32]int {
 	return active
 }
 
+// ActiveSpaceIDs reports the window server's own identifier for the space in
+// front on each of the given displays, leaving out a display whose space
+// cannot be resolved.
+//
+// The window server assigns the identifier when the space is created and
+// never changes it. ActiveSpaceIndexes reports where that space sits in
+// Mission Control instead, which is the number a user counts. A caller that
+// remembers something about a space keys it by the identifier, because adding
+// or removing a space changes the index of every space after it.
+func ActiveSpaceIDs(displayIDs []uint32) map[uint32]uint64 {
+	active := make(map[uint32]uint64, len(displayIDs))
+
+	for _, did := range displayIDs {
+		sid := uint64(C.MimiDisplayActiveSpaceID(C.uint32_t(did)))
+		if sid != 0 {
+			active[did] = sid
+		}
+	}
+
+	return active
+}
+
 // FullScreenDisplays reports which of the given displays show a full-screen
 // application space in front. macOS lays that window out itself, so nothing
 // else should move it.

--- a/internal/tiling/contract.go
+++ b/internal/tiling/contract.go
@@ -51,6 +51,14 @@ type Input struct {
 	Focused  int                   `json:"focused"`
 	Windows  []action.WindowEntry  `json:"windows"`
 	State    json.RawMessage       `json:"state"`
+
+	// spaceID is which space Space names, as the window server identifies
+	// it, and it is what the engine files this input's state under. It is
+	// unexported because a layout has no use for it. Space is the number
+	// the user counts, and this is the number that does not change when the
+	// user reorders their spaces in Mission Control. It is 0 when the space
+	// could not be resolved, and the engine then keeps no state at all.
+	spaceID uint64
 }
 
 // Output is what the layout prints back: the frames to apply, in the shape

--- a/internal/tiling/desktop.go
+++ b/internal/tiling/desktop.go
@@ -21,6 +21,11 @@ func (LiveDesktop) Displays() ([]action.DisplayEntry, error) { return action.Que
 // ActiveSpaces is the space in front on every display.
 func (LiveDesktop) ActiveSpaces() (map[uint32]int, error) { return action.QueryActiveSpaces() }
 
+// ActiveSpaceIDs is which space is in front on every display.
+func (LiveDesktop) ActiveSpaceIDs() (map[uint32]uint64, error) {
+	return action.QueryActiveSpaceIDs()
+}
+
 // FullScreenDisplays is the set of displays showing a full-screen space.
 func (LiveDesktop) FullScreenDisplays() (map[uint32]bool, error) {
 	return action.QueryFullScreenDisplays()

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -26,6 +26,7 @@ type Desktop interface {
 	Windows() (action.WindowsInfo, error)
 	Displays() ([]action.DisplayEntry, error)
 	ActiveSpaces() (map[uint32]int, error)
+	ActiveSpaceIDs() (map[uint32]uint64, error)
 	FullScreenDisplays() (map[uint32]bool, error)
 	Margins() (action.MarginsInfo, error)
 	Apply(frames []action.WindowFrame, animation *action.Animation) error
@@ -70,6 +71,13 @@ type Engine struct {
 	// the space in front on it (stateKey), so a space switched on one
 	// display never touches what the other remembers.
 	states map[string]json.RawMessage
+	// writes counts the state writes made, and writtenAt is the count at
+	// which each key was last written, so keepState can drop whichever
+	// space went longest without one. The window server never names a
+	// destroyed space again and never reuses its identifier, so without
+	// this the map would only ever grow.
+	writes    uint64
+	writtenAt map[string]uint64
 	// seen is every window number the last pass read, nil before the
 	// first, so a window_created pass can tell whether the window it was
 	// raised for has reached the window server's on-screen list yet.
@@ -124,6 +132,7 @@ func New(desktop Desktop, serialize Serializer, logger *zap.SugaredLogger) *Engi
 		serialize:   serialize,
 		logger:      logger,
 		states:      map[string]json.RawMessage{},
+		writtenAt:   map[string]uint64{},
 		pending:     map[string]bool{},
 		applied:     map[uint32]action.Frame{},
 		titles:      map[uint32]string{},
@@ -509,7 +518,16 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 		input := inputs[index]
 
 		if out.State != nil {
-			e.states[stateKey(input)] = out.State
+			key, named := stateKey(input)
+			if named {
+				e.keepState(key, out.State)
+			} else {
+				e.logger.Debugw(
+					"layout state dropped: the space it is for could not be named",
+					"display", input.Display.ID,
+					"space", input.Space,
+				)
+			}
 		}
 
 		frames = append(frames, out.Frames...)
@@ -678,9 +696,50 @@ func (e *Engine) stopResidentLocked() {
 	e.layout = nil
 }
 
-// stateKey names the state for one display and the space in front on it.
-func stateKey(input Input) string {
-	return fmt.Sprintf("%d/%d", input.Display.ID, input.Space)
+// stateKey names the state for one display and the space in front on it, and
+// reports whether that space could be named at all.
+//
+// The key names the space by the window server's identifier rather than by
+// its place in Mission Control. Adding or removing a space changes the place
+// of every space after it, so a key built on the place would hand a layout
+// the state it built for another space. A space the window server will not
+// identify is named by nothing, and its state is neither kept nor read, so
+// two such spaces on one display cannot be given each other's state.
+func stateKey(input Input) (string, bool) {
+	if input.spaceID == 0 {
+		return "", false
+	}
+
+	return fmt.Sprintf("%d/%d", input.Display.ID, input.spaceID), true
+}
+
+// maxKeptStates is how many display-and-space states the engine remembers at
+// once. A desktop has a handful of spaces and a few displays at most, so
+// ordinary use never reaches the bound. It is here because a user creates and
+// destroys spaces over a daemon's lifetime, and nothing else drops the state
+// of a space that is gone.
+const maxKeptStates = 64
+
+// keepState files what the layout returned for one display and space, making
+// room by dropping the state written longest ago when the map is full. The
+// caller holds the lock.
+func (e *Engine) keepState(key string, state json.RawMessage) {
+	e.writes++
+	e.states[key] = state
+	e.writtenAt[key] = e.writes
+
+	for len(e.states) > maxKeptStates {
+		oldest, oldestAt := "", uint64(0)
+
+		for candidate, at := range e.writtenAt {
+			if oldest == "" || at < oldestAt {
+				oldest, oldestAt = candidate, at
+			}
+		}
+
+		delete(e.states, oldest)
+		delete(e.writtenAt, oldest)
+	}
 }
 
 // newWindowWait is how long a window_created pass waits for the window
@@ -755,8 +814,12 @@ type titledWindower interface {
 
 // desktopRead is everything one pass reads of the desktop.
 type desktopRead struct {
-	displays   []action.DisplayEntry
-	spaces     map[uint32]int
+	displays []action.DisplayEntry
+	spaces   map[uint32]int
+	// spaceIDs is which space is in front on each display, as the window
+	// server identifies it, where spaces is only where that space sits in
+	// Mission Control. The state a pass keeps is filed under this.
+	spaceIDs   map[uint32]uint64
 	fullScreen map[uint32]bool
 	margins    action.MarginsInfo
 	windows    action.WindowsInfo
@@ -780,6 +843,11 @@ func (e *Engine) readInputsLocked(quick bool) (desktopRead, error) {
 		}
 
 		read.spaces, err = e.desktop.ActiveSpaces()
+		if err != nil {
+			return err
+		}
+
+		read.spaceIDs, err = e.desktop.ActiveSpaceIDs()
 		if err != nil {
 			return err
 		}
@@ -868,6 +936,7 @@ func (e *Engine) buildInputsLocked(event Event, read desktopRead) []Input {
 			Displays: displays,
 			Focused:  -1,
 			Windows:  []action.WindowEntry{},
+			spaceID:  read.spaceIDs[display.ID],
 		}
 
 		for _, win := range windows.Windows {
@@ -886,7 +955,10 @@ func (e *Engine) buildInputsLocked(event Event, read desktopRead) []Input {
 			continue
 		}
 
-		input.State = e.states[stateKey(input)]
+		if key, named := stateKey(input); named {
+			input.State = e.states[key]
+		}
+
 		if input.State == nil {
 			input.State = json.RawMessage("null")
 		}

--- a/internal/tiling/engine_test.go
+++ b/internal/tiling/engine_test.go
@@ -22,6 +22,8 @@ import (
 const (
 	shell   = "/bin/sh"
 	created = "window_created"
+	// noState is what a layout is handed for a space it has not run for.
+	noState = "null"
 	// echoLayout prints one frame for window 1 and records the input's
 	// event kind and previous state as its new state.
 	echoLayout = `jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 100, height: 100}}], ` +
@@ -35,6 +37,10 @@ type fakeDesktop struct {
 	windows  action.WindowsInfo
 	displays []action.DisplayEntry
 	spaces   map[uint32]int
+	// spaceIDs is which space is in front per display, when a test names
+	// one; otherwise an id is derived from the space's index, so distinct
+	// spaces stay distinct without every test naming ids.
+	spaceIDs map[uint32]uint64
 	// fullScreen is the displays FullScreenDisplays reports.
 	fullScreen map[uint32]bool
 	// late is a window Windows lists only after lateAfter reads, the way
@@ -90,6 +96,29 @@ func (d *fakeDesktop) ActiveSpaces() (map[uint32]int, error) {
 
 	return spaces, nil
 }
+
+func (d *fakeDesktop) ActiveSpaceIDs() (map[uint32]uint64, error) {
+	if d.spaceIDs != nil {
+		return d.spaceIDs, nil
+	}
+
+	ids := map[uint32]uint64{}
+	for _, display := range d.displays {
+		index := d.space
+		if d.spaces != nil {
+			index = d.spaces[display.ID]
+		}
+
+		ids[display.ID] = fakeSpaceID(index)
+	}
+
+	return ids, nil
+}
+
+// fakeSpaceID is the identifier the fake gives the space at a Mission Control
+// index, when a test has not named one itself. It is offset so an id is never
+// mistaken for an index in a failure message.
+func fakeSpaceID(index int) uint64 { return uint64(index) + 1000 }
 
 func (d *fakeDesktop) FullScreenDisplays() (map[uint32]bool, error) { return d.fullScreen, nil }
 
@@ -198,8 +227,103 @@ func TestEngine_Pass_HandsTheLayoutItsOwnStateBack(t *testing.T) {
 		t.Fatalf("Preview() on another space error = %v", err)
 	}
 
-	if string(inputs[0].State) != "null" {
+	if string(inputs[0].State) != noState {
 		t.Fatalf("state on a fresh space = %s, want null", inputs[0].State)
+	}
+}
+
+// TestEngine_Pass_KeepsStateWithTheSpaceNotItsPlaceInMissionControl pins that
+// the state a layout built belongs to the space it was built for. Adding or
+// removing a space changes the number of every space after it, so that number
+// does not identify a space. The state follows its space through such a
+// change, and another space at the same number still starts from null.
+func TestEngine_Pass_KeepsStateWithTheSpaceNotItsPlaceInMissionControl(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	desktop.spaceIDs = map[uint32]uint64{7: 5000}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(echoLayout), shell)
+
+	ctx := context.Background()
+
+	err := engine.Pass(ctx, tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	want := `{"kind":"` + created + `","was":null}`
+
+	// A space added before this one renumbers it from 2 to 5. It is the
+	// same space, so it is the same state.
+	desktop.space = 5
+
+	inputs, _, err := engine.Preview(ctx, tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() after a renumbering error = %v", err)
+	}
+
+	if got := string(inputs[0].State); got != want {
+		t.Fatalf("state after a renumbering = %s, want %s", got, want)
+	}
+
+	// Another space that happens to sit where the first one did is still
+	// another space.
+	desktop.space = 2
+	desktop.spaceIDs = map[uint32]uint64{7: 6000}
+
+	inputs, _, err = engine.Preview(ctx, tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() on another space error = %v", err)
+	}
+
+	if got := string(inputs[0].State); got != noState {
+		t.Fatalf("state on another space at the same index = %s, want null", got)
+	}
+}
+
+// TestEngine_Pass_KeepsNoStateForASpaceItCannotName pins what happens when the
+// window server will not say which space a display shows. The layout still
+// runs, and the engine keeps nothing for it, so the next space it cannot name
+// is not handed the state the last one built.
+func TestEngine_Pass_KeepsNoStateForASpaceItCannotName(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	// An empty map is a display whose space did not resolve.
+	desktop.spaceIDs = map[uint32]uint64{}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(echoLayout), shell)
+
+	ctx := context.Background()
+
+	err := engine.Pass(ctx, tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	inputs, _, err := engine.Preview(ctx, tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+
+	if got := string(inputs[0].State); got != noState {
+		t.Fatalf("state for an unnamable space = %s, want null", got)
+	}
+
+	// Another space the window server will not name either. Without an
+	// identity to tell the two apart, neither may inherit the other's.
+	desktop.space = 9
+
+	inputs, _, err = engine.Preview(ctx, tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() on a second unnamable space error = %v", err)
+	}
+
+	if got := string(inputs[0].State); got != noState {
+		t.Fatalf("state leaked to a second unnamable space = %s, want null", got)
 	}
 }
 
@@ -749,7 +873,7 @@ func TestEngine_Pass_RunsOncePerDisplayWithStateOfItsOwn(t *testing.T) {
 		t.Fatalf("Preview() error = %v", err)
 	}
 
-	if string(inputs[0].State) != want[0] || string(inputs[1].State) != "null" {
+	if string(inputs[0].State) != want[0] || string(inputs[1].State) != noState {
 		t.Fatalf("after a switch on display 8: states %s and %s; want %s and null",
 			inputs[0].State, inputs[1].State, want[0])
 	}

--- a/internal/tiling/resize_test.go
+++ b/internal/tiling/resize_test.go
@@ -51,6 +51,11 @@ func (d *snappingDesktop) Displays() ([]action.DisplayEntry, error) {
 }
 
 func (d *snappingDesktop) ActiveSpaces() (map[uint32]int, error) { return map[uint32]int{1: 1}, nil }
+
+func (d *snappingDesktop) ActiveSpaceIDs() (map[uint32]uint64, error) {
+	return map[uint32]uint64{1: 1001}, nil
+}
+
 func (d *snappingDesktop) FullScreenDisplays() (map[uint32]bool, error) {
 	return map[uint32]bool{}, nil
 }
@@ -252,6 +257,10 @@ func (d *transitionDesktop) Displays() ([]action.DisplayEntry, error) {
 }
 
 func (d *transitionDesktop) ActiveSpaces() (map[uint32]int, error) { return map[uint32]int{1: 1}, nil }
+
+func (d *transitionDesktop) ActiveSpaceIDs() (map[uint32]uint64, error) {
+	return map[uint32]uint64{1: 1001}, nil
+}
 
 func (d *transitionDesktop) FullScreenDisplays() (map[uint32]bool, error) {
 	d.mu.Lock()


### PR DESCRIPTION
## Description

This PR fixes a layout being handed the state it built for a different space.

The tiling engine remembers whatever a layout returns as `state` and hands it
back on the next pass for the same display and space. It identified that space
by its place in Mission Control. That place is not the space: adding or
removing a space shifts the number of every space after it, so after any such
change a layout could be given another space's tree, master window, or ratio.
The engine now files state under the identifier the window server assigns a
space when it is created and never changes.

What a layout is given is unchanged. The `space` field in its input is still
the 1-based Mission Control index it always was, and the identifier is
internal to the engine.

Two smaller fixes ride along. A display whose space the window server will not
identify now keeps no state, rather than sharing one key with the next
unidentifiable space on that display. And the state the engine holds had no
eviction at all, so it grew for the life of the daemon. It now holds 64
display-and-space entries and drops whichever space went longest without a
write.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A, nothing about the on-screen output changes.

## Additional Context

No config key, command, flag, hook, or `mimi_*` variable changes, and the
layout contract is untouched, so existing configs and layouts keep working
exactly as they did. The one behaviour difference a user can see is the
intended one: a layout that used to reset after reordering spaces no longer
does.

Three tests cover it. Two unit tests pin that state follows its space through
a renumbering and that an unidentifiable space leaks nothing to the next one;
both fail against the old key. One integration test reads the live window
server and checks that the index and the identifier name the same space, which
is the assumption the whole change rests on. It skips rather than fails on a
machine that cannot answer, matching the other tests in that tier.

The identifier was already being read on every pass and discarded in favour of
the index, so this costs one extra SkyLight call per display per pass and no
new private API.

Ran with the integration tier enabled and a local daemon stopped, since a
running mimi tiles the throwaway window the window baseline test opens and
fails it.
