### PR TITLE
feat(action): focus a window by its number

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Other options (Nix flake, build from source) → [Installation Guide](docs/INSTA
 | Cycle focus between windows      | `mimi action focus_window`                                                |
 | Cycle focus backward             | `mimi action focus_window --backward`                                     |
 | Cycle within the frontmost app   | `mimi action focus_window --same-app`                                     |
+| Focus one window by its number   | `mimi action focus_window --number 4242`                                  |
 | Jump to an app, switching space  | `mimi action focus_app Safari`                                            |
 | Focus window to the left         | `mimi action focus_window --left`                                         |
 | Focus window to the right        | `mimi action focus_window --right`                                        |

--- a/cmd/mimi/cmd/action.go
+++ b/cmd/mimi/cmd/action.go
@@ -73,6 +73,7 @@ func buildFocusWindowCommand(state *cliState) *cobra.Command {
 		focusLeft  bool
 		focusRight bool
 		sameApp    bool
+		number     uint32
 	)
 
 	cmd := &cobra.Command{
@@ -88,7 +89,14 @@ in that direction based on screen position.
 Only windows that are focusable (not minimized, not hidden) and on the
 current space are included. With --same-app, only the windows of the
 application that owns the focused window take part, whether cycling or
-moving in a direction.`,
+moving in a direction.
+
+With --number, focus goes straight to that window instead, named by the
+window server's number as mimi query windows reports it. This is the one way
+to focus a window without saying where it is on screen. A layout's before and
+after command lines need that, and so does a hotkey bound to a window you
+noted earlier. The window has to be on the current space. Use focus_app to
+reach one that is not.`,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			focusCmd, err := action.NewFocusWindowCommand(
 				backward,
@@ -97,6 +105,7 @@ moving in a direction.`,
 				focusLeft,
 				focusRight,
 				sameApp,
+				number,
 			)
 			if err != nil {
 				return err
@@ -118,6 +127,8 @@ moving in a direction.`,
 		BoolVar(&focusRight, "right", false, "Move focus to the nearest window on the right")
 	cmd.Flags().
 		BoolVar(&sameApp, "same-app", false, "Stay within the focused window's application")
+	cmd.Flags().
+		Uint32Var(&number, "number", 0, "Focus the window with this window-server number")
 
 	return cmd
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -70,6 +70,7 @@ mimi action focus_window --right
 mimi action focus_window --up
 mimi action focus_window --down
 mimi action focus_window --same-app
+mimi action focus_window --number 4242
 mimi action focus_app Safari
 mimi action space 1
 mimi action space next
@@ -98,9 +99,25 @@ move focus spatially.
 | `--left`     | Move focus to the nearest window to the left of the current one  |
 | `--right`    | Move focus to the nearest window to the right of the current one |
 | `--same-app` | Stay within the focused window's application, cycling or directional |
+| `--number <n>` | Focus the window with that window-server number |
 
 `--same-app` is the keyboard's Cmd-backtick. It combines with `--backward` or
 a direction flag, and needs a focused window to take the application from.
+
+`--number` names one window instead of saying which way to move from the
+focused one, so it combines with none of the other flags. The number is the
+one `mimi query windows` reports, stable for the window's lifetime, and the
+same number `mimi action apply_frames` and a layout's `frames` take:
+
+```bash
+mimi action focus_window --number 4242
+```
+
+This is the only way to focus a window without saying where it is on screen.
+A layout's `before` and `after` command lines need that, and so does a hotkey
+bound to a window you noted earlier. The window has to be on the current
+space. `mimi action focus_app` is the one that switches space to reach a
+window.
 
 ### `mimi action focus_app <name|bundle-id>`
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -114,6 +114,11 @@ type FocusWindowArgs struct {
 	// SameApp confines the cycle, or the directional move, to the windows of
 	// the application that owns the focused window.
 	SameApp bool `json:"sameApp"`
+	// Number names one window to focus, by the window server's number. It
+	// replaces the search rather than narrowing it. The other fields say
+	// which way to move from the focused window, and this says which window
+	// to land on. 0 names none, which is the cycling action.
+	Number uint32 `json:"number"`
 }
 
 // NewFocusWindowCommand builds focus_window's command directly from the CLI's
@@ -122,14 +127,19 @@ type FocusWindowArgs struct {
 // validateFocusWindowArgs, the same check ExecuteCommand applies to a payload
 // that arrived off the socket.
 func NewFocusWindowCommand(
-	backward, focusUp, focusDown, focusLeft, focusRight, sameApp bool,
+	backward, focusUp, focusDown, focusLeft, focusRight, sameApp bool, number uint32,
 ) (Command, error) {
 	direction, err := focusDirectionOf(focusUp, focusDown, focusLeft, focusRight)
 	if err != nil {
 		return Command{}, err
 	}
 
-	args := FocusWindowArgs{Backward: backward, Direction: direction, SameApp: sameApp}
+	args := FocusWindowArgs{
+		Backward:  backward,
+		Direction: direction,
+		SameApp:   sameApp,
+		Number:    number,
+	}
 
 	err = validateFocusWindowArgs(args)
 	if err != nil {
@@ -231,6 +241,20 @@ func focusDirectionOf(focusUp, focusDown, focusLeft, focusRight bool) (string, e
 // once wherever a payload comes from — the CLI's flags, or a socket the daemon
 // decoded a command off with nothing having checked it.
 func validateFocusWindowArgs(args FocusWindowArgs) error {
+	if args.Number != 0 {
+		// A named window is a destination, not a place to move from, so
+		// nothing that says how to move means anything beside it.
+		if args.Direction != "" || args.Backward || args.SameApp {
+			return derrors.New(
+				derrors.CodeInvalidInput,
+				"--number names the window to focus, so it cannot be combined "+
+					"with --backward, --same-app, or a direction flag",
+			)
+		}
+
+		return nil
+	}
+
 	if args.Direction == "" {
 		return nil
 	}
@@ -510,6 +534,10 @@ func (e *Executor) ExecuteCommand(cmd Command) error {
 		err := validateFocusWindowArgs(cmd.FocusWindow)
 		if err != nil {
 			return err
+		}
+
+		if cmd.FocusWindow.Number != 0 {
+			return e.FocusWindowNumber(cmd.FocusWindow.Number)
 		}
 
 		return e.FocusWindow(cmd.FocusWindow)

--- a/internal/action/command_test.go
+++ b/internal/action/command_test.go
@@ -16,7 +16,7 @@ import (
 func focusCommandFor(t *testing.T, backward, up, down, left, right bool) action.Command {
 	t.Helper()
 
-	cmd, err := action.NewFocusWindowCommand(backward, up, down, left, right, false)
+	cmd, err := action.NewFocusWindowCommand(backward, up, down, left, right, false, 0)
 	if err != nil {
 		t.Fatalf("building %s: %v", action.NameFocusWindow, err)
 	}
@@ -97,6 +97,7 @@ func TestNewFocusWindowCommand_BuildsTheTypedPayload(t *testing.T) {
 				testCase.left,
 				testCase.right,
 				false,
+				0,
 			)
 			if err != nil {
 				t.Fatalf("NewFocusWindowCommand() error = %v, want nil", err)
@@ -116,7 +117,7 @@ func TestNewFocusWindowCommand_BuildsTheTypedPayload(t *testing.T) {
 func TestNewFocusWindowCommand_RejectsMoreThanOneDirection(t *testing.T) {
 	t.Parallel()
 
-	_, err := action.NewFocusWindowCommand(false, true, true, false, false, false)
+	_, err := action.NewFocusWindowCommand(false, true, true, false, false, false, 0)
 	if err == nil {
 		t.Fatal("NewFocusWindowCommand(up, down) expected error")
 	}
@@ -126,10 +127,88 @@ func TestNewFocusWindowCommand_RejectsMoreThanOneDirection(t *testing.T) {
 	}
 }
 
+// TestExecuteCommand_FocusWindowByNumberLandsOnTheWindowNamed pins the one way
+// to focus a window without saying where it is: the number names it, and
+// neither the focused window nor the cycling order has any part in it.
+func TestExecuteCommand_FocusWindowByNumberLandsOnTheWindowNamed(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithWindows(3, 0)
+	for index := range desktop.windows {
+		desktop.windows[index].number = uint32(4242 + index)
+	}
+
+	err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
+		Name:        action.NameFocusWindow,
+		FocusWindow: action.FocusWindowArgs{Number: 4244},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteCommand(focus_window --number 4244) error = %v, want nil", err)
+	}
+
+	wantFocused(t, desktop, 3)
+}
+
+// TestExecuteCommand_FocusWindowByNumberReportsAWindowItCannotReach pins that
+// a number naming no window on the active space is an error rather than a
+// silent no-op, since a hotkey that does nothing is indistinguishable from one
+// that is not bound.
+func TestExecuteCommand_FocusWindowByNumberReportsAWindowItCannotReach(t *testing.T) {
+	t.Parallel()
+
+	desktop := desktopWithWindows(1, 0)
+	desktop.windows[0].number = 4242
+
+	err := action.NewExecutor(desktop).ExecuteCommand(action.Command{
+		Name:        action.NameFocusWindow,
+		FocusWindow: action.FocusWindowArgs{Number: 9999},
+	})
+	if err == nil {
+		t.Fatal("ExecuteCommand(focus_window --number 9999) expected an error")
+	}
+
+	if !derrors.IsCode(err, derrors.CodeActionFailed) {
+		t.Fatalf("error code = %v, want %v", derrors.GetCode(err), derrors.CodeActionFailed)
+	}
+}
+
+// TestNewFocusWindowCommand_RejectsANumberWithAnyWayToMove pins that naming a
+// window and saying which way to move from the focused one are two different
+// requests, so the constructor refuses a command that asks for both.
+func TestNewFocusWindowCommand_RejectsANumberWithAnyWayToMove(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		backward, up, sameApp bool
+	}{
+		{name: "--backward", backward: true},
+		{name: "a direction", up: true},
+		{name: "--same-app", sameApp: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := action.NewFocusWindowCommand(
+				testCase.backward, testCase.up, false, false, false, testCase.sameApp, 4242,
+			)
+			if err == nil {
+				t.Fatalf("NewFocusWindowCommand(--number with %s) expected an error", testCase.name)
+			}
+
+			if !derrors.IsCode(err, derrors.CodeInvalidInput) {
+				t.Fatalf("error code = %v, want %v", derrors.GetCode(err), derrors.CodeInvalidInput)
+			}
+		})
+	}
+}
+
 func TestNewFocusWindowCommand_RejectsBackwardWithDirection(t *testing.T) {
 	t.Parallel()
 
-	_, err := action.NewFocusWindowCommand(true, true, false, false, false, false)
+	_, err := action.NewFocusWindowCommand(true, true, false, false, false, false, 0)
 	if err == nil {
 		t.Fatal("NewFocusWindowCommand(backward, up) expected error")
 	}
@@ -581,6 +660,20 @@ func TestExecuteCommand_RejectsAPayloadNoConstructorWouldBuild(t *testing.T) {
 			cmd: action.Command{
 				Name:        action.NameFocusWindow,
 				FocusWindow: action.FocusWindowArgs{Direction: "sideways"},
+			},
+		},
+		{
+			name: "focus_window naming a window and a direction at once",
+			cmd: action.Command{
+				Name:        action.NameFocusWindow,
+				FocusWindow: action.FocusWindowArgs{Number: 4242, Direction: "up"},
+			},
+		},
+		{
+			name: "focus_window naming a window and --same-app at once",
+			cmd: action.Command{
+				Name:        action.NameFocusWindow,
+				FocusWindow: action.FocusWindowArgs{Number: 4242, SameApp: true},
 			},
 		},
 		{

--- a/internal/action/focus_same_app_test.go
+++ b/internal/action/focus_same_app_test.go
@@ -137,7 +137,7 @@ func TestExecutor_FocusWindow_SameAppNeedsAFocusedWindow(t *testing.T) {
 func TestNewFocusWindowCommand_CarriesSameApp(t *testing.T) {
 	t.Parallel()
 
-	cmd, err := action.NewFocusWindowCommand(true, false, false, false, false, true)
+	cmd, err := action.NewFocusWindowCommand(true, false, false, false, false, true, 0)
 	if err != nil {
 		t.Fatalf("NewFocusWindowCommand(backward, same-app) error = %v, want nil", err)
 	}

--- a/internal/baseline/focus_integration_test.go
+++ b/internal/baseline/focus_integration_test.go
@@ -129,6 +129,7 @@ func (h *harness) runFocus(t *testing.T, center *native.Element, dir string) bas
 		dir == dirLeft,
 		dir == dirRight,
 		false,
+		0,
 	)
 	if err != nil {
 		t.Fatalf("focus_window --%s is not a command: %v", dir, err)

--- a/internal/ipc/wire_test.go
+++ b/internal/ipc/wire_test.go
@@ -46,6 +46,7 @@ func everyPayloadSet() []payloadCase {
 					Backward:  true,
 					Direction: "right",
 					SameApp:   true,
+					Number:    4242,
 				},
 			},
 		},
@@ -195,17 +196,25 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 		{
 			name: "mimi action focus_window --backward",
 			build: func() (action.Command, error) {
-				return action.NewFocusWindowCommand(true, false, false, false, false, false)
+				return action.NewFocusWindowCommand(true, false, false, false, false, false, 0)
 			},
 			want: `{"version":7,"command":{"name":"focus_window",` +
-				`"focusWindow":{"backward":true,"direction":"","sameApp":false}}}`,
+				`"focusWindow":{"backward":true,"direction":"","sameApp":false,"number":0}}}`,
 		},
 		{
 			name: "mimi action focus_window",
 			build: func() (action.Command, error) {
-				return action.NewFocusWindowCommand(false, false, false, false, false, false)
+				return action.NewFocusWindowCommand(false, false, false, false, false, false, 0)
 			},
 			want: `{"version":7,"command":{"name":"focus_window"}}`,
+		},
+		{
+			name: "mimi action focus_window --number 4242",
+			build: func() (action.Command, error) {
+				return action.NewFocusWindowCommand(false, false, false, false, false, false, 4242)
+			},
+			want: `{"version":7,"command":{"name":"focus_window",` +
+				`"focusWindow":{"backward":false,"direction":"","sameApp":false,"number":4242}}}`,
 		},
 		{
 			name: "mimi action space 3",


### PR DESCRIPTION
## Description

This PR adds a way to focus a specific window from the command line.

Every existing way to focus a window says where to move from the one that
already has focus: cycle forward, cycle back, or step up, down, left, or
right. None of them can name a window. That gap shows up in two places. A
layout can ask the engine to focus a window through its output, but the
`before` and `after` command lines it returns run as shell commands and had no
way to do the same. And a hotkey that should go to a window you noted earlier
had nothing to bind to.

`mimi action focus_window` now takes `--number`. The window has to be on the
active space, and a number naming no window there fails with a message saying
so, rather than doing nothing quietly.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A, focus moves but nothing about the output on screen changes.

## Command changes

One new flag on an existing command. Nothing is removed or renamed, and no
existing invocation behaves differently.

```bash
mimi action focus_window --number 4242
```

| Flag | Default | Meaning |
| --- | --- | --- |
| `--number <n>` | `0`, meaning unset | Focus the window with that window-server number |

The number is the one `mimi query windows` reports, stable for the window's
lifetime, and the same number `mimi action apply_frames` and a layout's
`frames` already take.

`--number` names a window rather than a direction to move in, so it combines
with none of `--backward`, `--same-app`, `--up`, `--down`, `--left`, or
`--right`. Passing it with any of them is rejected as invalid input on both
the direct and the daemon path, before anything is focused.

No config key, hook, or `mimi_*` variable changes.

## Additional Context

The executor already had the code to focus a window by number, because the
tiling engine uses it for the `focus` key a layout returns. This wires that to
the command line and adds the payload validation the daemon path needs, since
a payload arriving over the socket has had nothing check it.

Checked live on both paths: with a daemon running the command goes over the
socket, and with none it runs in the CLI process, and both focus the named
window and reject the same malformed invocations in the same words.
