### PR TITLE
feat(tiling): tell a layout where each window sits in the stacking order

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -324,12 +324,14 @@ $ mimi query window
 Every focusable window on the active space, in `focus_window` cycle order.
 `focused` is the index of the focused window, or -1. `number` is the window
 server's number, stable for the window's lifetime, and what `apply_frames`
-takes. A window whose frame cannot be read is left out. **Accessibility
-permission is required.**
+takes. `order` is where the window sits in the stacking order, 0 for the one
+in front, which is a different question from the cycle order the list is in. A
+window whose frame cannot be read is left out. **Accessibility permission is
+required.**
 
 ```
 $ mimi query windows
-{"focused":0,"windows":[{"number":4242,"pid":501,"app":"Safari","bundleId":"com.apple.Safari","title":"Start Page","frame":{"x":0,"y":25,"width":1440,"height":875}}]}
+{"focused":0,"windows":[{"number":4242,"pid":501,"app":"Safari","bundleId":"com.apple.Safari","title":"Start Page","frame":{"x":0,"y":25,"width":1440,"height":875},"order":0}]}
 ```
 
 ### `mimi query displays`

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -165,7 +165,8 @@ both, through `serve()` in `rules.py`.
   "focused": 0,
   "windows": [
     {"number": 4242, "pid": 501, "app": "Safari", "bundleId": "com.apple.Safari",
-     "title": "Start Page", "frame": {"x": 0, "y": 25, "width": 1440, "height": 875}}
+     "title": "Start Page", "order": 0,
+     "frame": {"x": 0, "y": 25, "width": 1440, "height": 875}}
   ],
   "state": null
 }
@@ -183,11 +184,18 @@ both, through `serve()` in `rules.py`.
 | `gap` | Points to leave between windows and at the display's edges, resolved by mimi: `tiling.gap` when set, else the macOS tiled-window margin, else 0. |
 | `displays` | Every display, numbered as `move_window_to_display` counts them. |
 | `focused` | Index into `windows` of the focused window, or -1 when the focused window is on another display. |
-| `windows` | The focusable windows whose centres are on this display, in `focus_window` order. `number` is the window server's number, stable for the window's lifetime, and how you name a window in the output. |
+| `windows` | The focusable windows whose centres are on this display, in `focus_window` order. `number` is the window server's number, stable for the window's lifetime, and how you name a window in the output. `order` is where the window sits in the stacking order, 0 for the one in front. |
 | `state` | What you printed last time for this display and space, or `null`. |
 
 `displays` and `windows` are exactly what `mimi query displays` and
 `mimi query windows` print, so real data is one command away.
+
+The `windows` list is ordered by position, which is the order `focus_window`
+cycles through them. `order` answers a different question: which window is on
+top. The two rarely agree. Read `order` when the layout cares which of two
+overlapping windows the user can see, and ignore it otherwise. The numbers
+rank the whole desktop's windows and are then narrowed to this display's, so
+they compare correctly but need not start at 0 or run without gaps.
 
 ### Output
 

--- a/internal/action/desktop.go
+++ b/internal/action/desktop.go
@@ -23,6 +23,12 @@ type Window struct {
 	// how a window found one way is recognized when found another. It is 0
 	// when the desktop cannot read it.
 	Number uint32
+	// Order is where the window sits in the stacking order, 0 for the one in
+	// front and counting back from there, among the windows this listing
+	// reports. The window server lists windows front to back and the listing
+	// is then sorted by position, so this is read off the listing before that
+	// sort and is the only record of it left.
+	Order int
 }
 
 // AppWindow is one window of an application as the window server lists it:

--- a/internal/action/fake_desktop_test.go
+++ b/internal/action/fake_desktop_test.go
@@ -13,9 +13,13 @@ import (
 // fakeWindow is one window on the fake desktop: an identity, a frame, and the
 // failures macOS is allowed to report for it.
 type fakeWindow struct {
-	id       action.WindowID
-	pid      int
-	number   uint32
+	id     action.WindowID
+	pid    int
+	number uint32
+	// order is where the window sits in the stacking order, 0 for the one in
+	// front. Left unset it is 0 for every window, which is what a test with
+	// no interest in the stack wants.
+	order    int
 	frame    geometry.Rect
 	title    string
 	frameErr error
@@ -118,7 +122,12 @@ func (d *fakeDesktop) FocusableWindows() ([]action.Window, int, error) {
 
 	windows := make([]action.Window, len(d.windows))
 	for index, win := range d.windows {
-		windows[index] = action.Window{ID: win.id, PID: win.pid, Number: win.number}
+		windows[index] = action.Window{
+			ID:     win.id,
+			PID:    win.pid,
+			Number: win.number,
+			Order:  win.order,
+		}
 
 		if win.frameErrOnce && d.enumerations > 0 {
 			d.windows[index].frameErr = nil

--- a/internal/action/native_desktop.go
+++ b/internal/action/native_desktop.go
@@ -722,7 +722,15 @@ func (d *nativeDesktop) listOnScreen(learn bool) ([]Window, int, map[uint32]geom
 			focused = window.Number
 		}
 
-		windows = append(windows, Window{ID: entry.id, PID: entry.pid, Number: window.Number})
+		// onScreen is the window server's own front-to-back order, and the
+		// sort below replaces it with one by position, so the place in the
+		// stack is recorded here while it is still known.
+		windows = append(windows, Window{
+			ID:     entry.id,
+			PID:    entry.pid,
+			Number: window.Number,
+			Order:  len(windows),
+		})
 	}
 
 	frames := make(map[uint32]geometry.Rect, len(onScreen))

--- a/internal/action/windows_query.go
+++ b/internal/action/windows_query.go
@@ -15,6 +15,11 @@ type WindowEntry struct {
 	BundleID string `json:"bundleId"`
 	Title    string `json:"title"`
 	Frame    Frame  `json:"frame"`
+	// Order is where the window sits in the stacking order among the windows
+	// listed here: 0 for the one in front, counting back from there. The
+	// listing itself is ordered by position rather than by this, so a caller
+	// that wants the window on top reads it here.
+	Order int `json:"order"`
 }
 
 // WindowsInfo is what a windows query reports: every focusable window on the
@@ -235,6 +240,7 @@ func (e *Executor) listKnown(lister knownLister, known map[uint32]string) Window
 			BundleID: app.BundleID,
 			Title:    title,
 			Frame:    frameOf(frame),
+			Order:    win.Order,
 		})
 	}
 
@@ -282,6 +288,7 @@ func (e *Executor) listWindows(known map[uint32]string) (WindowsInfo, bool, erro
 			BundleID: app.BundleID,
 			Title:    title,
 			Frame:    frameOf(frame),
+			Order:    win.Order,
 		})
 	}
 

--- a/internal/action/windows_query_test.go
+++ b/internal/action/windows_query_test.go
@@ -25,9 +25,11 @@ func desktopWithListedWindows() *fakeDesktop {
 	desktop.windows[0].number = 4242
 	desktop.windows[0].title = "Start Page"
 	desktop.windows[0].frame = geometry.Rect{X: 0, Y: 25, W: 960, H: 1055}
+	desktop.windows[0].order = 1
 	desktop.windows[1].number = 4243
 	desktop.windows[1].title = "notes.md"
 	desktop.windows[1].frame = geometry.Rect{X: 960, Y: 25, W: 960, H: 1055}
+	desktop.windows[1].order = 0
 	desktop.appInfo = map[int]action.AppInfo{
 		100: {Name: safariName, BundleID: safariBundleID},
 		101: {Name: "TextEdit", BundleID: "com.apple.TextEdit"},
@@ -51,11 +53,13 @@ func TestExecutor_QueryWindows_ListsEveryWindowWithItsApplicationAndFrame(t *tes
 				Number: 4242, PID: 100, App: safariName, BundleID: safariBundleID,
 				Title: "Start Page",
 				Frame: action.Frame{X: 0, Y: 25, Width: 960, Height: 1055},
+				Order: 1,
 			},
 			{
 				Number: 4243, PID: 101, App: "TextEdit", BundleID: "com.apple.TextEdit",
 				Title: "notes.md",
 				Frame: action.Frame{X: 960, Y: 25, Width: 960, Height: 1055},
+				Order: 0,
 			},
 		},
 	}

--- a/internal/baseline/stacking_order_integration_test.go
+++ b/internal/baseline/stacking_order_integration_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+// The stacking order the windows query reports, checked against the live
+// window server.
+//
+// The query lists windows by position, top to bottom and then left to right,
+// because that is the order focus cycles through them. The window server lists
+// them front to back instead. Both orders are useful and they are rarely the
+// same, so the query carries the second one as each window's order while
+// listing in the first. This checks that what comes back is a real stacking
+// order rather than the positional one under another name.
+//
+// It only reads. It opens no window, moves nothing, and skips rather than
+// fails on a machine that cannot answer.
+
+package baseline_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/permissions"
+)
+
+func TestStackingOrder_NamesOneWindowInFrontAndRanksTheRest(t *testing.T) {
+	if !permissions.Check().Accessibility {
+		t.Skip("Accessibility permission is not granted; windows cannot be enumerated")
+	}
+
+	info, err := action.QueryWindows()
+	if err != nil {
+		t.Skipf("the windows could not be listed: %v", err)
+	}
+
+	if len(info.Windows) < 2 {
+		t.Skip("fewer than two windows are open, so there is no stacking order to check")
+	}
+
+	// Every window has a place in the stack, and no two share one.
+	seen := make(map[int]uint32, len(info.Windows))
+
+	for _, win := range info.Windows {
+		if win.Order < 0 || win.Order >= len(info.Windows) {
+			t.Fatalf(
+				"window %d reported stacking order %d, outside the %d windows listed",
+				win.Number, win.Order, len(info.Windows),
+			)
+		}
+
+		if other, taken := seen[win.Order]; taken {
+			t.Fatalf(
+				"windows %d and %d both report stacking order %d",
+				other, win.Number, win.Order,
+			)
+		}
+
+		seen[win.Order] = win.Number
+	}
+
+	// The window the query calls focused is the one the window server put in
+	// front, so it is the one at the head of the stack.
+	if info.Focused < 0 {
+		t.Skip("no listed window holds focus, so there is no front window to check")
+	}
+
+	if front := info.Windows[info.Focused]; front.Order != 0 {
+		t.Fatalf(
+			"the focused window %d reports stacking order %d, want 0 for the window in front",
+			front.Number, front.Order,
+		)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds each window's place in the stacking order to the windows query
and to a layout's input.

The query lists windows by position, because that is the order `focus_window`
cycles through them. The window server lists them front to back instead. The
listing already read the second order and used it to decide which window was
focused, then discarded it in the sort that produced the first. So nothing
above the window listing could tell which of two overlapping windows was on
top.

That is the piece a layout needs most before it can put windows in the same
place on purpose. A layout could already give two windows one frame, but it
had no way to learn which of them the user could actually see, or to notice
when the user brought a buried one forward with Cmd-Tab.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A, nothing on screen changes.

## Output changes

`mimi query windows` gains one field per window, and a layout's input gains
the same field, since the docs promise the input's `windows` is exactly what
that query prints.

```
$ mimi query windows | jq -c '[.windows[] | {app, order}]'
[{"app":"Safari","order":2},{"app":"Ghostty","order":1},{"app":"Notes","order":0}]
```

| Field | Meaning |
| --- | --- |
| `order` | Where the window sits in the stacking order, `0` for the one in front |

Nothing is removed or renamed and no existing field changes meaning, so a
layout or script that does not read `order` behaves exactly as before. The
tiling input version does not move, since adding a field does not move it.

The list itself is still ordered by position, not by this. The numbers rank
the whole desktop's windows and are then narrowed to one display's, so within
a layout's input they compare correctly but need not start at 0 or run without
gaps.

No config key, command, flag, or hook changes.

## Additional Context

I also looked at carrying each window's layer. It is not worth a field: the
listing already drops every window whose layer is not 0, so the value would be
0 for every window it could ever report. Accessibility subrole and whether a
window is resizable were the other candidates and are left out too, since each
costs an extra round trip into the application on the hot path and nothing
asks for them yet.

Checked live against three overlapping windows: focusing one moves it to
`order` 0 and pushes the others back, while the listing order stays
positional. There is also an integration test that reads the live window
server and checks the orders are distinct, within range, and that the focused
window is the one in front. It skips rather than fails when fewer than two
windows are open.

Unrelated, found while checking this and present on `main`: `mimi tiling
preview --input` fails with "layout exited without answering" when
`layout_mode = "resident"`. The `--input` path swaps the layout for a command
that reads and prints nothing, which is fine for a one-shot layout and never
answers in resident mode. Happy to send a one-line fix separately.
