### PR TITLE
feat(tiling): let a layout say which windows it is not managing

### DIFF
--- a/cmd/mimi/cmd/tiling.go
+++ b/cmd/mimi/cmd/tiling.go
@@ -238,10 +238,11 @@ func previewLayout(cobraCmd *cobra.Command, cfg *config.Config, inputOnly bool) 
 		}
 
 		previews[index] = previewOutput{
-			Display: inputs[index].Display.ID,
-			Space:   inputs[index].Space,
-			Frames:  frames,
-			State:   state,
+			Display:   inputs[index].Display.ID,
+			Space:     inputs[index].Space,
+			Frames:    frames,
+			State:     state,
+			Unmanaged: out.Unmanaged,
 		}
 	}
 
@@ -256,4 +257,7 @@ type previewOutput struct {
 	Space   int                  `json:"space"`
 	Frames  []action.WindowFrame `json:"frames"`
 	State   json.RawMessage      `json:"state"`
+	// Unmanaged is the windows the layout said it is leaving alone, absent
+	// when it named none, so a preview reads as the layout printed it.
+	Unmanaged []uint32 `json:"unmanaged,omitempty"`
 }

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -186,6 +186,7 @@ both, through `serve()` in `rules.py`.
 | `focused` | Index into `windows` of the focused window, or -1 when the focused window is on another display. |
 | `windows` | The focusable windows whose centres are on this display, in `focus_window` order. `number` is the window server's number, stable for the window's lifetime, and how you name a window in the output. `order` is where the window sits in the stacking order, 0 for the one in front. |
 | `state` | What you printed last time for this display and space, or `null`. |
+| `unmanaged` | The windows on this display you last said you were not managing, by number. Absent when there are none. Handed back so a layout that keeps its floats outside `state`, or one restarted mid-session, can pick the set up again. |
 
 `displays` and `windows` are exactly what `mimi query displays` and
 `mimi query windows` print, so real data is one command away.
@@ -204,6 +205,7 @@ they compare correctly but need not start at 0 or run without gaps.
   "frames": [{"number": 4242, "frame": {"x": 8, "y": 33, "width": 1424, "height": 859}}],
   "state": {"anything": "you like"},
   "focus": 4242,
+  "unmanaged": [4243],
   "before": ["osascript -e 'beep'"],
   "after": ["~/.config/mimi/warp.py 720 462"]
 }
@@ -214,8 +216,20 @@ they compare correctly but need not start at 0 or run without gaps.
 | `frames` | The windows to place. Leave a window out to leave it where it is. Print nothing, or an empty list, to change nothing. With `[tiling.animation]` on, a frame may carry `"animate": false` to move that one window at once while the rest animate, for a window with no sensible starting position. |
 | `state` | Any JSON. Handed back next run. Omit the key and the previous state is kept. Print `null` to clear it. |
 | `focus` | Optional. A window number to give keyboard focus, before the frames move. For moving focus along a layout's own structure where spatial `focus_window` cannot, such as a strip's parked columns. |
+| `unmanaged` | Optional. The windows this run was given that you are leaving alone, by number, such as the ones you float. mimi then leaves them alone too, so dragging one raises no pass and shows no drop zone. A window stays unmanaged until a later run for the same display leaves it out of this list. |
 | `before` | Optional. Command lines mimi runs through `settings.hook_shell` before the focus and the frames, all at once. mimi waits for every one and kills one past `tiling.command_timeout_secs`. A failure logs at debug and the frames still apply. See [Running commands around the frames](#running-commands-around-the-frames). |
 | `after` | Optional. Command lines mimi runs through `settings.hook_shell` once the frames have been applied, and once the animation has ended when one runs. They run in order, detached. mimi kills one past `tiling.command_timeout_secs`, drops their output and logs a failure at debug. Use it to act on the frames the layout returned, where a hook would run before them. See [Running commands around the frames](#running-commands-around-the-frames). |
+
+**Leaving a window out of `frames` is not the same as naming it in
+`unmanaged`.** Omitting a frame says only that the window does not move this
+pass, which is exactly what a temporary maximise does to the windows under the
+maximised one, and mimi keeps watching those so a drag of one still reaches
+you. Naming a window in `unmanaged` says you have no opinion about where it
+goes at all, and mimi stops watching it until you claim it again.
+
+`rules.py` does this for you. `narrow()` records the windows the float rules
+filtered out, `unmanaged_of(inp, state)` adds any the layout floated itself
+with `togglefloat`, and `write_output(..., unmanaged=...)` prints the result.
 
 ### Coordinates
 

--- a/examples/tiling/bsp.py
+++ b/examples/tiling/bsp.py
@@ -30,7 +30,7 @@ Usage: bsp.py     (the gap is tiling.gap, else the macOS tiled-window margin)
 
 import sys
 
-from rules import clamp as clamp_to
+from rules import clamp as clamp_to, unmanaged_of
 from rules import area, command, gap, maximised, serve, write_output
 
 # The gap, set from the input once it is read. The tree functions below read
@@ -308,7 +308,7 @@ def main(inp):
     state["placed"] = {
         str(number): {k: int(round(v)) for k, v in rect.items()} for number, rect in frames
     }
-    write_output(frames, state)
+    write_output(frames, state, unmanaged=unmanaged_of(inp, state))
 
 
 if __name__ == "__main__":

--- a/examples/tiling/columns.py
+++ b/examples/tiling/columns.py
@@ -11,7 +11,7 @@ stdout. Copy, edit, own. Standard library only.
 Usage: columns.py     (the gap is tiling.gap, else the macOS tiled-window margin)
 """
 
-from rules import area, gap, maximised, serve, write_output
+from rules import area, gap, maximised, serve, unmanaged_of, write_output
 
 
 def main(inp):
@@ -19,7 +19,7 @@ def main(inp):
     state = inp.get("state") or {}
     windows = inp["windows"]
     if not windows:
-        write_output([], None)
+        write_output([], None, unmanaged=unmanaged_of(inp))
         return
 
     box = area(inp, GAP)
@@ -37,7 +37,9 @@ def main(inp):
         )
         for i, w in enumerate(windows)
     ]
-    write_output(maximised(inp, state, frames, box), state)
+    write_output(
+        maximised(inp, state, frames, box), state, unmanaged=unmanaged_of(inp, state)
+    )
 
 
 if __name__ == "__main__":

--- a/examples/tiling/master-stack.py
+++ b/examples/tiling/master-stack.py
@@ -24,7 +24,7 @@ Usage: master-stack.py [ratio]     (the gap is tiling.gap, else the macOS tiled-
 
 import sys
 
-from rules import area, clamp, command, gap, maximised, serve, write_output
+from rules import area, clamp, command, gap, maximised, serve, unmanaged_of, write_output
 
 RATIO = float(sys.argv[1]) if len(sys.argv) > 1 else 0.6
 
@@ -34,7 +34,7 @@ def main(inp):
     state = inp.get("state") or {}
     windows = inp["windows"]
     if not windows:
-        write_output([], None)
+        write_output([], None, unmanaged=unmanaged_of(inp))
         return
 
     box = area(inp, GAP)
@@ -99,7 +99,9 @@ def main(inp):
         )
 
     state.update(master=master, ratio=ratio)
-    write_output(maximised(inp, state, frames, box), state)
+    write_output(
+        maximised(inp, state, frames, box), state, unmanaged=unmanaged_of(inp, state)
+    )
 
 
 if __name__ == "__main__":

--- a/examples/tiling/monocle.py
+++ b/examples/tiling/monocle.py
@@ -11,12 +11,16 @@ stdout. Copy, edit, own. Standard library only.
 Usage: monocle.py     (the gap is tiling.gap, else the macOS tiled-window margin)
 """
 
-from rules import area, gap, serve, write_output
+from rules import area, gap, serve, unmanaged_of, write_output
 
 
 def main(inp):
     box = area(inp, gap(inp))
-    write_output([(w["number"], box) for w in inp["windows"]], None)
+    write_output(
+        [(w["number"], box) for w in inp["windows"]],
+        None,
+        unmanaged=unmanaged_of(inp),
+    )
 
 
 if __name__ == "__main__":

--- a/examples/tiling/rules.py
+++ b/examples/tiling/rules.py
@@ -57,10 +57,13 @@ def narrow(inp):
     """The input with `windows` narrowed to the tileable ones and `focused`
     re-pointed at the same window, or -1 if it went. `focusFloating` is
     True when it went because the focused window floats, so a layout can
-    tell focus on a floating window from focus on nothing."""
+    tell focus on a floating window from focus on nothing. `unmanaged` is
+    the windows that were filtered out, to hand back to `write_output` so
+    mimi leaves them alone too."""
     focused_number = (
         inp["windows"][inp["focused"]]["number"] if inp["focused"] >= 0 else None
     )
+    inp["unmanaged"] = [w["number"] for w in inp["windows"] if floating(w)]
     inp["windows"] = [w for w in inp["windows"] if not floating(w)]
     numbers = [w["number"] for w in inp["windows"]]
     inp["focused"] = numbers.index(focused_number) if focused_number in numbers else -1
@@ -135,10 +138,32 @@ def _on(frame, bounds):
     return bounds["x"] <= cx < bounds["x"] + bounds["width"] and bounds["y"] <= cy < bounds["y"] + bounds["height"]
 
 
-def write_output(frames, state, focus=None):
+def unmanaged_of(inp, state=None):
+    """The windows mimi should leave alone: the ones `narrow()` filtered out
+    by the float rules, plus any the layout floated itself and keeps in
+    `state["floating"]`. Hand it to `write_output` so mimi's drag reading and
+    its drop zone agree with the layout about which windows are the layout's.
+
+    Without it mimi keeps watching a window the layout has stopped placing,
+    because not placing a window is also what a temporary maximise does to
+    the windows under it, and those it should keep watching."""
+    numbers = set(inp.get("unmanaged", []))
+    if state:
+        numbers |= set(state.get("floating", []))
+    return sorted(numbers)
+
+
+def write_output(frames, state, focus=None, unmanaged=None):
     """Print the layout output: frames in whole points, the state to get
-    back next time, and the window to focus once the frames are applied,
-    when the layout moved focus along its own structure."""
+    back next time, the window to focus once the frames are applied, when
+    the layout moved focus along its own structure, and the windows this
+    layout is not managing.
+
+    `unmanaged` is what `narrow()` filtered out, so mimi leaves those
+    windows alone too, and dragging one raises no pass and shows no drop
+    zone. Leaving a window out of `frames` says only that it does not move
+    this time, which is what a temporary maximise does to the windows under
+    it."""
     frames = [
         {"number": number, "frame": {k: int(round(v)) for k, v in frame.items()}}
         for number, frame in frames
@@ -146,6 +171,8 @@ def write_output(frames, state, focus=None):
     out = {"frames": frames, "state": state}
     if focus is not None:
         out["focus"] = focus
+    if unmanaged:
+        out["unmanaged"] = list(unmanaged)
     json.dump(out, sys.stdout)
     sys.stdout.write("\n")
 

--- a/examples/tiling/strip.py
+++ b/examples/tiling/strip.py
@@ -51,7 +51,7 @@ A layout program: reads the tiling input on stdin, prints the output on
 stdout. Copy, edit, own. Standard library only.
 """
 
-from rules import area, clamp, command, gap, maximised, serve, write_output
+from rules import area, clamp, command, gap, maximised, serve, unmanaged_of, write_output
 
 PRESETS = [1 / 3, 1 / 2, 2 / 3]
 DEFAULT = 1 / 2
@@ -226,7 +226,11 @@ def main(inp):
 
     sync(columns, windows, focused)
     if not columns:
-        write_output([], {"columns": [], "offset": 0, "floating": state.get("floating", [])})
+        write_output(
+            [],
+            {"columns": [], "offset": 0, "floating": state.get("floating", [])},
+            unmanaged=unmanaged_of(inp, state),
+        )
         return
 
     at = column_of(columns, focused)
@@ -245,7 +249,11 @@ def main(inp):
             offset += step if args[0] == "right" else -step
             offset = clamp(offset, 0, max(0, total - box["width"]))
             state.update(columns=columns, offset=offset)
-            write_output(maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box), state)
+            write_output(
+                maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box),
+                state,
+                unmanaged=unmanaged_of(inp, state),
+            )
             return
 
     if event["kind"] == "command" and at is not None:
@@ -297,7 +305,11 @@ def main(inp):
             width = col_width(column, box, GAP)
             offset = max(0, xs[at] + width / 2 - box["width"] / 2)
             state.update(columns=columns, offset=offset)
-            write_output(maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box), state)
+            write_output(
+                maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box),
+                state,
+                unmanaged=unmanaged_of(inp, state),
+            )
             return
     elif event["kind"] == "window_resize":
         placed = state.get("placed", {})
@@ -372,7 +384,7 @@ def main(inp):
     frames = maximised(inp, state, frames_for(columns, box, edge, GAP, offset), box)
     state.update(columns=columns, offset=offset)
     state["placed"] = {str(n): {k: int(round(v)) for k, v in f.items()} for n, f in frames}
-    write_output(frames, state, focus)
+    write_output(frames, state, focus, unmanaged=unmanaged_of(inp, state))
 
 
 if __name__ == "__main__":

--- a/internal/tiling/contract.go
+++ b/internal/tiling/contract.go
@@ -51,6 +51,12 @@ type Input struct {
 	Focused  int                   `json:"focused"`
 	Windows  []action.WindowEntry  `json:"windows"`
 	State    json.RawMessage       `json:"state"`
+	// Unmanaged is the windows on this display the layout last said it is
+	// not managing, by number. The engine hands the set back so that a
+	// layout restarted mid-session, or one that keeps its floats somewhere
+	// other than state, can pick it up again instead of disagreeing with
+	// the engine about which windows are its own.
+	Unmanaged []uint32 `json:"unmanaged,omitempty"`
 
 	// spaceID is which space Space names, as the window server identifies
 	// it, and it is what the engine files this input's state under. It is
@@ -84,6 +90,17 @@ type Output struct {
 	// layout uses it to act on the frames it returned, warping the cursor
 	// to the focused window say, once they are known to be applied.
 	After []string `json:"after,omitempty"`
+	// Unmanaged is the windows this run was given that the layout is
+	// leaving alone, by number, such as the ones it floats.
+	//
+	// Leaving a window out of Frames says only that it does not move this
+	// pass, which is what a layout maximizing one window over the rest
+	// does. Naming it here says the layout has no opinion about where it
+	// goes at all, so the engine stops watching it. Dragging an unmanaged
+	// window raises no pass and shows no drop zone. A window named on one
+	// run stays unmanaged until a later run for the same display leaves it
+	// out of this list.
+	Unmanaged []uint32 `json:"unmanaged,omitempty"`
 }
 
 // Event kinds the engine reports beyond the hookable ones it forwards from

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -78,6 +78,16 @@ type Engine struct {
 	// this the map would only ever grow.
 	writes    uint64
 	writtenAt map[string]uint64
+	// unmanaged is every window the layout said it is leaving alone, by
+	// number, as of the last run that was given that window. The engine
+	// watches nothing in here. It raises no pass for a drag of one and
+	// previews no drop zone over one.
+	//
+	// An entry for a window that has closed stays until the number is
+	// given to a run again, which it never is. That costs a few bytes and
+	// nothing else, because the window server counts window numbers up and
+	// does not hand one out twice.
+	unmanaged map[uint32]bool
 	// seen is every window number the last pass read, nil before the
 	// first, so a window_created pass can tell whether the window it was
 	// raised for has reached the window server's on-screen list yet.
@@ -132,6 +142,7 @@ func New(desktop Desktop, serialize Serializer, logger *zap.SugaredLogger) *Engi
 		serialize:   serialize,
 		logger:      logger,
 		states:      map[string]json.RawMessage{},
+		unmanaged:   map[uint32]bool{},
 		writtenAt:   map[string]uint64{},
 		pending:     map[string]bool{},
 		applied:     map[uint32]action.Frame{},
@@ -538,6 +549,8 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 
 		before = append(before, out.Before...)
 		after = append(after, out.After...)
+
+		e.keepUnmanaged(input, out.Unmanaged)
 	}
 
 	if len(frames) == 0 && focus == 0 && len(before) == 0 && len(after) == 0 {
@@ -587,7 +600,12 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 
 	// Whatever the apply reported, some frames may have landed: remember
 	// them all as requested, then read back where they are.
-	e.applied = make(map[uint32]action.Frame, len(frames))
+	//
+	// A window the layout still manages but did not move this pass keeps
+	// the placement it already had, so it is still watched for a drag. A
+	// layout maximizing one window over the rest returns one frame, and
+	// dragging any of the others used to raise nothing at all.
+	e.applied = e.stillPlaced(inputs)
 	for _, frame := range frames {
 		e.applied[frame.Number] = frame.Frame
 	}
@@ -711,6 +729,49 @@ func stateKey(input Input) (string, bool) {
 	}
 
 	return fmt.Sprintf("%d/%d", input.Display.ID, input.spaceID), true
+}
+
+// keepUnmanaged records which of the windows this run was given the layout is
+// leaving alone. Only those windows are reclassified, so a run for one display
+// never speaks for another's, and a window the run was not given keeps
+// whatever it was. The caller holds the lock.
+func (e *Engine) keepUnmanaged(input Input, unmanaged []uint32) {
+	for _, win := range input.Windows {
+		delete(e.unmanaged, win.Number)
+	}
+
+	for _, number := range unmanaged {
+		e.unmanaged[number] = true
+	}
+}
+
+// stillPlaced is where the engine last put every window it is still watching,
+// which is the placements it carries into the next pass.
+//
+// A window the layout has stopped managing is dropped, and so is one this pass
+// did not see at all: a window that closed, or one on a display macOS took
+// over for a full-screen space. Neither is worth comparing against a frame
+// that no longer means anything. The caller holds the lock.
+func (e *Engine) stillPlaced(inputs []Input) map[uint32]action.Frame {
+	seen := make(map[uint32]bool, len(e.applied))
+
+	for _, input := range inputs {
+		for _, win := range input.Windows {
+			seen[win.Number] = true
+		}
+	}
+
+	placed := make(map[uint32]action.Frame, len(e.applied))
+
+	for number, frame := range e.applied {
+		if e.unmanaged[number] || !seen[number] {
+			continue
+		}
+
+		placed[number] = frame
+	}
+
+	return placed
 }
 
 // maxKeptStates is how many display-and-space states the engine remembers at
@@ -955,6 +1016,12 @@ func (e *Engine) buildInputsLocked(event Event, read desktopRead) []Input {
 			continue
 		}
 
+		for _, win := range input.Windows {
+			if e.unmanaged[win.Number] {
+				input.Unmanaged = append(input.Unmanaged, win.Number)
+			}
+		}
+
 		if key, named := stateKey(input); named {
 			input.State = e.states[key]
 		}
@@ -1125,6 +1192,10 @@ func (e *Engine) draggedLocked(windows action.WindowsInfo) (string, []uint32) {
 	)
 
 	for _, win := range windows.Windows {
+		if e.unmanaged[win.Number] {
+			continue
+		}
+
 		placed, ok := e.applied[win.Number]
 		if !ok || sameFrame(placed, win.Frame) {
 			continue

--- a/internal/tiling/unmanaged_test.go
+++ b/internal/tiling/unmanaged_test.go
@@ -1,0 +1,204 @@
+//nolint:testpackage // sets the resize grace, as resize_test does
+package tiling
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/events"
+)
+
+// pairDesktop is a desktop with two windows, where every applied frame lands
+// exactly as written and a test can drag either window as the user would.
+type pairDesktop struct {
+	mu      sync.Mutex
+	frames  map[uint32]action.Frame
+	applies int
+}
+
+func newPairDesktop() *pairDesktop {
+	return &pairDesktop{frames: map[uint32]action.Frame{
+		1: {Y: 25, Width: 500, Height: 975},
+		2: {X: 500, Y: 25, Width: 500, Height: 975},
+	}}
+}
+
+func (d *pairDesktop) Windows() (action.WindowsInfo, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return action.WindowsInfo{Focused: 0, Windows: []action.WindowEntry{
+		{Number: 1, PID: 10, App: "A", Frame: d.frames[1]},
+		{Number: 2, PID: 11, App: "B", Frame: d.frames[2]},
+	}}, nil
+}
+
+// Displays reports one display whose visible frame is smaller than the whole,
+// as a real one is: the menu bar takes the top. A window filling the whole
+// display frame is how the engine recognizes a full-screen space, so a
+// maximized window has to stop short of it.
+func (d *pairDesktop) Displays() ([]action.DisplayEntry, error) {
+	return []action.DisplayEntry{{
+		Index:   1,
+		ID:      1,
+		Frame:   action.Frame{Width: 1000, Height: 1000},
+		Visible: action.Frame{Y: 25, Width: 1000, Height: 975},
+	}}, nil
+}
+
+func (d *pairDesktop) ActiveSpaces() (map[uint32]int, error) { return map[uint32]int{1: 1}, nil }
+
+func (d *pairDesktop) ActiveSpaceIDs() (map[uint32]uint64, error) {
+	return map[uint32]uint64{1: 1001}, nil
+}
+
+func (d *pairDesktop) FullScreenDisplays() (map[uint32]bool, error) {
+	return map[uint32]bool{}, nil
+}
+
+func (d *pairDesktop) Margins() (action.MarginsInfo, error) { return action.MarginsInfo{}, nil }
+
+func (d *pairDesktop) Focus(uint32) error { return nil }
+
+func (d *pairDesktop) Apply(frames []action.WindowFrame, _ *action.Animation) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.applies++
+	for _, frame := range frames {
+		d.frames[frame.Number] = frame.Frame
+	}
+
+	return nil
+}
+
+// drag moves a window sideways, as the user would.
+func (d *pairDesktop) drag(number uint32, dx float64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	frame := d.frames[number]
+	frame.X += dx
+	d.frames[number] = frame
+}
+
+func (d *pairDesktop) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.applies
+}
+
+// maximizing is a layout that places both windows on its first run and only
+// the first window on every run after it, which is what a temporary maximize
+// returns. With unmanaged set, it also says the second window is one it has
+// stopped managing.
+func maximizing(unmanaged string) string {
+	return `jq -c 'if .state == null then {frames: [` +
+		`{number: 1, frame: {x: 0, y: 25, width: 500, height: 975}},` +
+		`{number: 2, frame: {x: 500, y: 25, width: 500, height: 975}}], ` +
+		`state: {run: "first"}} else {frames: [` +
+		`{number: 1, frame: {x: 0, y: 25, width: 1000, height: 975}}]` +
+		unmanaged + `, state: {run: "later"}} end'`
+}
+
+// runPairEngine starts an engine reading drags on the desktop, waits for its
+// startup pass, and returns the events it listens to along with a check that
+// the desktop was applied to exactly want times.
+func runPairEngine(
+	t *testing.T,
+	desktop *pairDesktop,
+	layout string,
+) (events.Subscriber, func(int, string)) {
+	t.Helper()
+
+	engine := New(desktop, nil, nil)
+	engine.resizeGrace = 50 * time.Millisecond
+	engine.Update(config.TilingConfig{
+		Enabled:        true,
+		RelayoutOnDrag: true,
+		DebounceMS:     10,
+		TimeoutSecs:    5,
+		Layout:         layout,
+	}, "/bin/sh")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		engine.Wait()
+	})
+
+	sub := make(events.Subscriber, 8)
+	go engine.Run(ctx, sub)
+
+	waitFor := func(want int, why string) {
+		t.Helper()
+
+		deadline := time.Now().Add(3 * time.Second)
+		for desktop.count() < want && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		// Give a pass that should not happen the chance to happen.
+		time.Sleep(150 * time.Millisecond)
+
+		if got := desktop.count(); got != want {
+			t.Fatalf("%s: applied %d times, want %d", why, got, want)
+		}
+	}
+
+	waitFor(1, "startup")
+
+	return sub, waitFor
+}
+
+// TestEngine_Run_ReadsADragOfAWindowTheLayoutStoppedPlacing pins the case a
+// temporary maximize creates. The layout returns one frame and leaves its
+// other windows where they are, which does not mean it has given them up: a
+// drag of one still has to raise a pass, or the layout can never put it back.
+func TestEngine_Run_ReadsADragOfAWindowTheLayoutStoppedPlacing(t *testing.T) {
+	t.Parallel()
+
+	desktop := newPairDesktop()
+	sub, waitFor := runPairEngine(t, desktop, maximizing(""))
+
+	// A second pass, which maximizes the first window and returns no frame
+	// for the second.
+	sub <- events.Event{Kind: events.WindowFocus, PID: 10}
+
+	waitFor(2, "the maximizing pass")
+
+	time.Sleep(60 * time.Millisecond)
+
+	desktop.drag(2, 120)
+
+	sub <- events.Event{Kind: events.WindowMove, PID: 11}
+
+	waitFor(3, "a drag of the window the layout stopped placing")
+}
+
+// TestEngine_Run_LeavesAWindowTheLayoutGaveUpAlone pins the other half. A
+// layout that says it is no longer managing a window means it, so the engine
+// stops watching that window and a drag of it raises nothing.
+func TestEngine_Run_LeavesAWindowTheLayoutGaveUpAlone(t *testing.T) {
+	t.Parallel()
+
+	desktop := newPairDesktop()
+	sub, waitFor := runPairEngine(t, desktop, maximizing(", unmanaged: [2]"))
+
+	sub <- events.Event{Kind: events.WindowFocus, PID: 10}
+
+	waitFor(2, "the pass that gives the second window up")
+
+	time.Sleep(60 * time.Millisecond)
+
+	desktop.drag(2, 120)
+
+	sub <- events.Event{Kind: events.WindowMove, PID: 11}
+
+	waitFor(2, "a drag of the window the layout gave up")
+}


### PR DESCRIPTION
## Description

This PR fixes a drag going unnoticed after a layout stops placing a window,
and lets a layout say which windows it has genuinely given up on.

mimi decides a window was dragged by comparing where it is against where the
engine last put it, and it only remembered the windows it had just placed. So
being managed meant nothing more than "you were in the last set of frames".
That breaks the moment a layout stops placing a window on purpose. A temporary
maximise returns one frame and leaves the others where they are, and from then
on dragging any of the others raised no pass at all, so the layout could never
put them back.

The engine now keeps watching every window it is managing, whether or not that
window moved this pass. To tell the two cases apart, a layout prints the
windows it is leaving alone, such as the ones it floats, and those the engine
stops watching entirely.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A, and the visible effect is a drop zone that no longer appears over a
floating window.

## Layout contract changes

One optional key in each direction. A layout that prints neither behaves
exactly as it did.

**Output**, what a layout prints:

```json
{"frames": [...], "state": {...}, "unmanaged": [4243]}
```

| Key | Meaning |
| --- | --- |
| `unmanaged` | Optional. The windows this run was given that the layout is leaving alone, by number |

**Input**, what a layout is given:

| Key | Meaning |
| --- | --- |
| `unmanaged` | The windows on this display the layout last said it was not managing. Absent when there are none |

Leaving a window out of `frames` and naming it in `unmanaged` now mean
different things. Omitting a frame says the window does not move this pass,
and mimi keeps watching it. Naming it says the layout has no opinion about
where it goes, and mimi stops watching it until the layout claims it again.

The tiling input version does not move, since adding a field does not move it.

`mimi tiling preview` prints the key too, so a layout's output can be read
whole.

No config key, command, flag, or `mimi_*` variable changes.

## Shipped layouts

`rules.py` gains `unmanaged_of(inp, state)`, which is the windows the float
rules filtered out plus any the user floated with `togglefloat`, and
`write_output` takes it. All five layouts pass it.

This part is not optional for them. Now that mimi keeps watching a window a
layout stopped placing, a layout that floats a window without saying so would
have its floats dragged back into the tiling. Anyone running a copy of these
layouts from an earlier version keeps the old behaviour, which is the one
they have now.

## Additional Context

Checked live against a real desktop with `strip.py`, four windows, and Finder
floating by the shipped rules. Moving the Finder window from outside mimi left
it where it was put and relaid out nothing. Moving a tiled window the same way
had it placed straight back. Before this change the Finder drag behaved the
same only because Finder had never been framed at all.

Two unit tests cover the pair: a drag of a window the layout stopped placing
raises a pass, and a drag of one it gave up does not. The first fails against
the old behaviour.

One thing worth knowing while reading the engine: a window whose frame exactly
equals a display's frame is how mimi recognises a full-screen space, so a test
that maximises a window has to stop short of the display frame or no drag is
ever read. The new fake reports a visible frame smaller than the whole, as a
real display does.
