### PR TITLE
feat(tiling): show the state the daemon holds, and let one space start over

### DIFF
--- a/cmd/mimi/cmd/interrupt_audit_test.go
+++ b/cmd/mimi/cmd/interrupt_audit_test.go
@@ -138,6 +138,12 @@ var interruptAudit = []auditEntry{
 			"awaited; otherwise as tiling preview, and then the frames are applied"),
 	audited("tiling cmd", interruptRunsOn,
 		"as tiling relayout"),
+	audited("tiling state", interruptRunsOn,
+		"one request written to the daemon and one reply awaited, then one line "+
+			"of output; with no daemon it reports an empty state and returns"),
+	audited("tiling reset", interruptRunsOn,
+		"as tiling state; the daemon clears what it holds either way, since the "+
+			"interrupt reaches this process and not that one"),
 	audited("services install", interruptStopsTheWork,
 		"Service.Install threads the context through every launchctl call "+
 			"and checks it again before the plist is written, so a canceled "+

--- a/cmd/mimi/cmd/tiling.go
+++ b/cmd/mimi/cmd/tiling.go
@@ -31,13 +31,18 @@ Available subcommands:
   preview   run the layout once against the desktop and print what it would apply
   relayout  run the layout once and apply it
   cmd       send a named command to the layout, for it to give meaning to
+  state     print the state the running daemon is holding for each space
+  reset     forget that state, so the next pass starts the layout over
 
 Examples:
   mimi tiling preview
   mimi tiling preview --input
   mimi tiling relayout
   mimi tiling cmd swap
-  mimi tiling cmd ratio +0.05`,
+  mimi tiling cmd ratio +0.05
+  mimi tiling state
+  mimi tiling reset
+  mimi tiling reset --all`,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			cobraCmd.SilenceUsage = false
 
@@ -51,6 +56,76 @@ Examples:
 	cmd.AddCommand(buildTilingPreviewCommand(state))
 	cmd.AddCommand(buildTilingRelayoutCommand(state))
 	cmd.AddCommand(buildTilingCmdCommand(state))
+	cmd.AddCommand(buildTilingStateCommand(state))
+	cmd.AddCommand(buildTilingResetCommand(state))
+
+	return cmd
+}
+
+func buildTilingStateCommand(state *cliState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "state",
+		Short: "Print the layout state the running daemon holds",
+		Long: `Print, as one line of JSON, what the daemon's tiling engine is remembering:
+one entry per display and space it has run the layout for, with the state the
+layout last returned there, and the windows the layout said it is not managing.
+
+  {"spaces":[{"display":1,"spaceId":5,"space":2,"state":{...}}],"unmanaged":[]}
+
+Each space is named twice. spaceId is the window server's own identifier for
+it, which is what the engine files the state under and what never changes.
+space is where that space sits in Mission Control right now, or 0 when it is
+not the space in front on any display.
+
+This is a read of the daemon's memory, not of the desktop, so it needs a
+running daemon. Without one it reports nothing, because a layout run from the
+CLI is given a null state and keeps none. mimi tiling preview is the one that
+works either way.`,
+		Args: cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			tilingCmd, err := action.NewTilingCommand(action.TilingState, "", nil)
+			if err != nil {
+				return err
+			}
+
+			return state.printTiling(cobraCmd, tilingCmd, tiling.State{
+				Spaces:    []tiling.SpaceState{},
+				Unmanaged: []uint32{},
+			})
+		},
+	}
+}
+
+func buildTilingResetCommand(state *cliState) *cobra.Command {
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Forget the layout state the running daemon holds",
+		Long: `Forget what the layout returned for the space in front on each display, so
+the next pass there starts it from a null state. With --all, forget every
+space the daemon remembers instead.
+
+This is the way out of a layout whose state has gone wrong: a tree that no
+longer matches the windows, a master that is not there. Restarting the daemon
+does the same thing to every display at once, which is rarely what is wanted.
+
+It prints how many spaces it forgot. Nothing is laid out by this; the next
+event runs the layout, or mimi tiling relayout does it now. It needs a running
+daemon, since a CLI holds no state to forget.`,
+		Args: cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			tilingCmd, err := action.NewTilingResetCommand(all)
+			if err != nil {
+				return err
+			}
+
+			return state.printTiling(cobraCmd, tilingCmd, map[string]int{"dropped": 0})
+		},
+	}
+
+	cmd.Flags().
+		BoolVar(&all, "all", false, "Forget every space, not just the one in front on each display")
 
 	return cmd
 }
@@ -113,6 +188,55 @@ Examples:
 	cmd.Flags().SetInterspersed(false)
 
 	return cmd
+}
+
+// printTiling sends a tiling command that answers with something, and prints
+// what came back as one line of JSON.
+//
+// There is no falling back to an engine of this process's own, as runTiling
+// does. These commands read and clear state the daemon holds, and an engine
+// built here holds none, so falling back would print an empty answer as
+// though it were the truth. With no daemon it prints empty instead, which is
+// what empty means, and says on stderr that there was nothing to ask.
+func (s *cliState) printTiling(cobraCmd *cobra.Command, cmd action.Command, empty any) error {
+	socketPath := ipc.ResolveSocketPath(s.configPath)
+
+	data, err := ipc.TryExecuteData(socketPath, cmd)
+	if err != nil {
+		if !derrors.IsCode(err, derrors.CodeDaemonUnavailable) &&
+			!derrors.IsCode(err, derrors.CodeProtocolMismatch) {
+			return err
+		}
+
+		_, _ = fmt.Fprintln(
+			cobraCmd.ErrOrStderr(),
+			"mimi: no daemon is holding any tiling state, so there is none to report.",
+		)
+
+		return printJSON(cobraCmd, empty)
+	}
+
+	return printRawJSON(cobraCmd, data)
+}
+
+// printJSON writes one line of JSON for a value built here.
+func printJSON(cobraCmd *cobra.Command, value any) error {
+	err := json.NewEncoder(cobraCmd.OutOrStdout()).Encode(value)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeSerializationFailed, "encoding the answer")
+	}
+
+	return nil
+}
+
+// printRawJSON writes the JSON the daemon answered with, as it sent it.
+func printRawJSON(cobraCmd *cobra.Command, data json.RawMessage) error {
+	_, err := fmt.Fprintf(cobraCmd.OutOrStdout(), "%s\n", data)
+	if err != nil {
+		return derrors.Wrapf(err, derrors.CodeSerializationFailed, "writing the answer")
+	}
+
+	return nil
 }
 
 // runTiling sends a tiling command to the daemon, whose engine holds the

--- a/cmd/mimi/cmd/tiling_test.go
+++ b/cmd/mimi/cmd/tiling_test.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"os"
 	"path/filepath"
@@ -42,10 +43,10 @@ func TestTilingCommands_ReachTheDaemonAsATilingAction(t *testing.T) {
 	server := ipc.NewServer(socketPath)
 
 	received := make(chan action.Command, 1)
-	server.HandleDirect(action.NameTiling, func(cmd action.Command) error {
+	server.HandleDirect(action.NameTiling, func(cmd action.Command) (json.RawMessage, error) {
 		received <- cmd
 
-		return nil
+		return nil, nil
 	})
 
 	ctx := t.Context()
@@ -107,10 +108,10 @@ func TestTilingCmd_PassesADashArgumentToTheLayout(t *testing.T) {
 	server := ipc.NewServer(socketPath)
 
 	received := make(chan action.Command, 1)
-	server.HandleDirect(action.NameTiling, func(cmd action.Command) error {
+	server.HandleDirect(action.NameTiling, func(cmd action.Command) (json.RawMessage, error) {
 		received <- cmd
 
-		return nil
+		return nil, nil
 	})
 
 	ctx := t.Context()

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -401,6 +401,44 @@ mimi tiling cmd swap
 mimi tiling cmd ratio +0.05
 ```
 
+### `mimi tiling state`
+
+Print, as one line of JSON, what the running daemon's engine is remembering:
+one entry per display and space it has run the layout for, with the state the
+layout last returned there, and the windows the layout said it is not managing.
+
+```
+$ mimi tiling state | jq -c
+{"spaces":[{"display":1,"spaceId":5,"space":2,"state":{"ratio":0.6}}],"unmanaged":[4243]}
+```
+
+Each space is named twice. `spaceId` is the window server's own identifier for
+it, which is what the engine files state under and what never changes. `space`
+is where that space sits in Mission Control right now, or `0` when it is not in
+front on any display.
+
+This reads the daemon's memory, not the desktop, so it needs a running daemon.
+With none it prints an empty state and says so on stderr, because a layout run
+from the CLI is given a null state and keeps none. Needs no Accessibility
+permission of its own.
+
+### `mimi tiling reset [--all]`
+
+Forget what the layout returned for the space in front on each display, so the
+next pass there starts it from a null state. With `--all`, forget every space
+the daemon remembers. Prints how many spaces it forgot.
+
+```bash
+mimi tiling reset
+mimi tiling reset --all
+```
+
+This is the way out of a layout whose state has gone wrong, a tree that no
+longer matches the windows say. Restarting the daemon does the same to every
+display at once, which is rarely what is wanted. Nothing is laid out by this.
+The next event runs the layout, or `mimi tiling relayout` does it now. Needs a
+running daemon.
+
 ---
 
 ## Hook Daemon

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -550,26 +550,32 @@ Work down this list.
 3. **Does the layout run by hand?** `mimi tiling preview` runs it the way the
    daemon would and shows its stderr. A missing `python3`, a syntax error, or
    a wrong shebang all show up here.
-4. **Read the daemon log.** With `log_level = "debug"` every pass logs
+4. **Ask the daemon what it is holding.** `mimi tiling state` prints the
+   state the engine kept for each display and space, and the windows your
+   layout said it is not managing. When a tree no longer matches the windows,
+   `mimi tiling reset` forgets the space in front and the next pass starts
+   your layout over, without restarting the daemon and losing every other
+   space with it.
+5. **Read the daemon log.** With `log_level = "debug"` every pass logs
    `tiling pass applied` with the event kind, display count, and frame count.
    A failing pass logs `tiling pass failed` with the reason. A slow layout
    logs `layout timed out`. Raise `timeout_secs`.
-5. **Is the window one mimi tiles?** `mimi query windows` lists exactly what
+6. **Is the window one mimi tiles?** `mimi query windows` lists exactly what
    a layout is given: standard windows of regular applications on the current
    space. Sheets, popovers, and minimized windows are not there. The pass
    skips a display showing a full-screen space even though its window is
    listed. If it is listed but not tiled, check `rules.py`.
-6. **A window that will not take its frame.** Some applications enforce a
+7. **A window that will not take its frame.** Some applications enforce a
    minimum size or snap to a grid, and land a little off what was asked. The
    next input shows where things actually are, which is why the shipped
    layouts read ratios off actual frames rather than assuming.
-7. **An app that opens windows but never tiles.** Applications slow to start
+8. **An app that opens windows but never tiles.** Applications slow to start
    refuse the daemon's observer for a moment after launch. The daemon retries
    for several seconds and runs your layout the moment it gets in. If it
    gives up it logs `AX observer install gave up` naming the app. Its windows
    are then tiled only when another event runs a pass, or by
    `mimi tiling relayout`.
-8. **It tiles, then un-tiles, then tiles.** A layout that reads a drag and
+9. **It tiles, then un-tiles, then tiles.** A layout that reads a drag and
    emits a different frame every time will loop with an application that
    refuses that frame. Read the actual frame back from the input and treat a
    difference of a few points as "already there".

--- a/docs/adr/0005-engine-state-is-read-over-the-socket.md
+++ b/docs/adr/0005-engine-state-is-read-over-the-socket.md
@@ -1,0 +1,60 @@
+# The tiling engine's state is read over the socket, and is not a query
+
+**Status:** accepted
+
+`mimi tiling state` prints what the daemon's tiling engine is remembering for
+each display and space, and `mimi tiling reset` makes it forget. Both are
+reads or writes of the daemon's own memory rather than of the desktop, so
+neither can run the way the other reads do. We decided they travel the Unix
+socket as the `tiling` action already does, and that they are not queries.
+
+`CONTEXT.md` defines a **Query** as a read that "always runs on the direct
+path and never travels the socket", and `docs/ARCHITECTURE.md` gives the
+reason: a query has no side effect to serialize with the daemon's actions, so
+routing it over the socket would cost a wire change and buy nothing. That
+reasoning does not reach this state, because this state exists only inside the
+daemon.
+
+## Considered options
+
+- **`mimi query tiling`, on the direct path like every other query.**
+  Rejected: there is nothing to read. A CLI process with no daemon builds a
+  throwaway engine whose state map is empty, so the command would print an
+  empty answer that looks exactly like a daemon holding nothing. The two
+  cases are the ones a user most needs told apart.
+- **`mimi query tiling`, but routed over the socket.** Rejected: it would
+  make "query" mean two different things depending on which query it was, and
+  the definition that says otherwise is load-bearing. Someone reading
+  `internal/action/query.go` should not have to check each function for
+  whether it is the exception.
+- **A subcommand of `tiling`, over the socket (chosen).** The `tiling`
+  action already travels the socket and already reaches the engine through
+  `ipc.Server.HandleDirect`, because the engine holds the layout's state and
+  queues its own desktop work. A read of that same state belongs on the same
+  path, under the same command family, and needs no new concept.
+
+## Consequences
+
+- **The response envelope carries data now.** `ipc.Response` gained a `data`
+  field, and a direct handler answers with `(json.RawMessage, error)` rather
+  than an error alone. This is additive, so `ipc.ProtocolVersion` does not
+  move: an older daemon ignores a field it does not know, and an older CLI
+  ignores one it is not looking for. Every action that drives the desktop
+  still answers with success or failure and nothing else.
+- **There is no fall back to a local engine.** `runTiling` falls back to an
+  engine of the CLI's own when no daemon answers, because running the layout
+  once is still useful. `printTiling` does not, because an engine built here
+  has never run a pass and holds nothing. With no daemon it prints an empty
+  answer and says on stderr that there was nothing to ask, which is the
+  distinction the direct path could not make.
+- **`mimi tiling preview` is still the one that works either way.** It runs
+  the layout rather than reading the engine, so it needs no daemon. It also
+  cannot answer the question `state` answers: a preview always runs with a
+  null state, so it shows what a fresh space would do and never what the
+  daemon is actually holding.
+- **A space is named twice in the output.** The engine files state under the
+  window server's identifier for a space, which never changes, and the user
+  counts spaces by their place in Mission Control, which does. Reporting only
+  the identifier would be unreadable and reporting only the place would be
+  ambiguous, so both are printed, and the place is 0 for a space that is not
+  in front on any display.

--- a/internal/action/tiling_command.go
+++ b/internal/action/tiling_command.go
@@ -6,11 +6,14 @@ import (
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 )
 
-// The two kinds of tiling command a user sends: a plain relayout, and a named
-// command the layout program gives meaning to.
+// The kinds of tiling command a user sends: a plain relayout, a named command
+// the layout program gives meaning to, a read of the state the engine holds,
+// and a clearing of it.
 const (
 	TilingRelayout = "relayout"
 	TilingCommand  = "command"
+	TilingState    = "state"
+	TilingReset    = "reset"
 )
 
 // TilingArgs is the tiling action's typed payload: what kind of command it
@@ -21,14 +24,25 @@ type TilingArgs struct {
 	Kind string   `json:"kind"`
 	Name string   `json:"name"`
 	Args []string `json:"args"`
+	// All widens a reset from the space in front on each display to every
+	// space the engine remembers. It means nothing to the other kinds.
+	All bool `json:"all"`
 }
 
 // NewTilingCommand builds the tiling action's command, rejecting a payload
 // the daemon would refuse: a kind that is neither relayout nor command, or a
 // command with no name.
 func NewTilingCommand(kind, name string, args []string) (Command, error) {
-	payload := TilingArgs{Kind: kind, Name: strings.TrimSpace(name), Args: args}
+	return newTilingCommand(TilingArgs{Kind: kind, Name: strings.TrimSpace(name), Args: args})
+}
 
+// NewTilingResetCommand builds the tiling action's command for a reset, which
+// is the one kind with a flag of its own.
+func NewTilingResetCommand(all bool) (Command, error) {
+	return newTilingCommand(TilingArgs{Kind: TilingReset, All: all})
+}
+
+func newTilingCommand(payload TilingArgs) (Command, error) {
 	err := validateTilingArgs(payload)
 	if err != nil {
 		return Command{}, err
@@ -41,21 +55,30 @@ func NewTilingCommand(kind, name string, args []string) (Command, error) {
 // paths.
 func validateTilingArgs(args TilingArgs) error {
 	switch args.Kind {
-	case TilingRelayout:
+	case TilingRelayout, TilingState, TilingReset:
 		if args.Name != "" || len(args.Args) > 0 {
-			return derrors.New(
+			return derrors.Newf(
 				derrors.CodeInvalidInput,
-				"a relayout takes no command name or arguments",
+				"a %s takes no command name or arguments",
+				args.Kind,
 			)
+		}
+
+		if args.All && args.Kind != TilingReset {
+			return derrors.Newf(derrors.CodeInvalidInput, "a %s is never for all spaces", args.Kind)
 		}
 	case TilingCommand:
 		if args.Name == "" {
 			return derrors.New(derrors.CodeInvalidInput, "tiling command name is required")
 		}
+
+		if args.All {
+			return derrors.New(derrors.CodeInvalidInput, "a command is never for all spaces")
+		}
 	default:
 		return derrors.Newf(
 			derrors.CodeInvalidInput,
-			"unknown tiling command kind %q (supported: relayout, command)",
+			"unknown tiling command kind %q (supported: relayout, command, state, reset)",
 			args.Kind,
 		)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -148,9 +149,12 @@ func runCore(
 
 	// A tiling command from the CLI reaches the engine here, off the action
 	// worker: the engine puts its own desktop work on that worker.
-	ipcServer.HandleDirect(action.NameTiling, func(cmd action.Command) error {
-		return pipeline.tiler.Command(ctx, tiling.EventFromArgs(cmd.Tiling))
-	})
+	ipcServer.HandleDirect(
+		action.NameTiling,
+		func(cmd action.Command) (json.RawMessage, error) {
+			return tilingAnswer(ctx, pipeline.tiler, cmd.Tiling)
+		},
+	)
 
 	go pipeline.router.Run(ctx)
 	go pipeline.executor.Run(ctx, pipeline.hookSub)
@@ -618,5 +622,32 @@ func getObserverConfig(cfg *config.Config) native.ObserverConfig {
 		// on config.HookKinds.
 		AppLifecycle: hasWindowEvents(cfg) || hasAppEvents(cfg),
 		Workspace:    hasWorkspaceEvents(cfg),
+	}
+}
+
+// tilingAnswer runs one tiling command against the engine and returns what it
+// answered with, which is nothing for the kinds that only do something.
+//
+// The reads live here rather than in internal/action because the state they
+// report is the daemon's own. An engine in a CLI process holds none, so there
+// is nothing for a direct path to answer with (see
+// docs/adr/0005-engine-state-is-read-over-the-socket.md).
+func tilingAnswer(
+	ctx context.Context,
+	tiler *tiling.Engine,
+	args action.TilingArgs,
+) (json.RawMessage, error) {
+	switch args.Kind {
+	case action.TilingState:
+		return json.Marshal(tiler.State())
+	case action.TilingReset:
+		dropped, err := tiler.Reset(args.All)
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(map[string]int{"dropped": dropped})
+	default:
+		return nil, tiler.Command(ctx, tiling.EventFromArgs(args))
 	}
 }

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -3,6 +3,7 @@ package ipc
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"os"
@@ -22,15 +23,28 @@ const dialTimeout = 100 * time.Millisecond
 // not reachable so callers can fall back to direct execution against the same
 // typed cmd.
 func TryExecute(socketPath string, cmd action.Command) error {
+	_, err := TryExecuteData(socketPath, cmd)
+
+	return err
+}
+
+// TryExecuteData is TryExecute for the actions that answer with something,
+// returning what the daemon read alongside the error. It is the same request
+// on the same socket; only the reply is looked at further.
+//
+// There is no direct-path counterpart, and there cannot be: the actions that
+// use this answer with state the daemon holds, so a CLI with no daemon to ask
+// has nothing to report.
+func TryExecuteData(socketPath string, cmd action.Command) (json.RawMessage, error) {
 	socketPath = paths.ExpandHome(socketPath)
 
 	_, err := os.Stat(socketPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return derrors.New(derrors.CodeDaemonUnavailable, "daemon socket not found")
+			return nil, derrors.New(derrors.CodeDaemonUnavailable, "daemon socket not found")
 		}
 
-		return derrors.Wrapf(err, derrors.CodeIPCFailed, "checking daemon socket")
+		return nil, derrors.Wrapf(err, derrors.CodeIPCFailed, "checking daemon socket")
 	}
 
 	dialer := net.Dialer{Timeout: dialTimeout}
@@ -39,10 +53,10 @@ func TryExecute(socketPath string, cmd action.Command) error {
 	if err != nil {
 		var netErr net.Error
 		if errors.As(err, &netErr) && netErr.Timeout() {
-			return derrors.New(derrors.CodeDaemonUnavailable, "daemon socket timed out")
+			return nil, derrors.New(derrors.CodeDaemonUnavailable, "daemon socket timed out")
 		}
 
-		return derrors.New(derrors.CodeDaemonUnavailable, "daemon not reachable")
+		return nil, derrors.New(derrors.CodeDaemonUnavailable, "daemon not reachable")
 	}
 
 	defer func() { _ = conn.Close() }()
@@ -51,15 +65,20 @@ func TryExecute(socketPath string, cmd action.Command) error {
 
 	err = writeRequest(conn, Request{Version: ProtocolVersion, Command: cmd})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	resp, err := readResponse(reader)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return errorFromResponse(resp)
+	err = errorFromResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
 }
 
 // ResolveSocketPath returns the configured socket path when --config is set,

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -32,10 +32,15 @@ type Request struct {
 }
 
 // Response is a JSON-encoded action result sent back to the client.
+//
+// Data is what the action read, for the few that answer with something rather
+// than only doing something. It is absent for the rest, which is every action
+// that drives the desktop: those report success or a failure and nothing more.
 type Response struct {
-	OK      bool   `json:"ok"`
-	Code    string `json:"code,omitempty"`
-	Message string `json:"message,omitempty"`
+	OK      bool            `json:"ok"`
+	Code    string          `json:"code,omitempty"`
+	Message string          `json:"message,omitempty"`
+	Data    json.RawMessage `json:"data,omitempty"`
 }
 
 func writeRequest(writer io.Writer, req Request) error {

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -3,6 +3,7 @@ package ipc
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -38,7 +39,7 @@ type Server struct {
 	// instead of the action worker: the ones whose handler drives the desktop
 	// through Serialize itself, and would deadlock waiting for the worker it
 	// was running on.
-	direct       map[action.Name]func(cmd action.Command) error
+	direct       map[action.Name]func(cmd action.Command) (json.RawMessage, error)
 	directMu     sync.RWMutex
 	once         sync.Once
 	shutdownOnce sync.Once
@@ -56,13 +57,16 @@ func NewServer(path string) *Server {
 		actionCh:       make(chan actionJob),
 		enqueueTimeout: actionEnqueueTimeout,
 		execute:        action.ExecuteCommand,
-		direct:         map[action.Name]func(cmd action.Command) error{},
+		direct:         map[action.Name]func(cmd action.Command) (json.RawMessage, error){},
 	}
 }
 
 // HandleDirect routes every request for name to fn, run on the connection's
 // goroutine rather than the action worker. fn may call Serialize.
-func (s *Server) HandleDirect(name action.Name, fn func(cmd action.Command) error) {
+func (s *Server) HandleDirect(
+	name action.Name,
+	fn func(cmd action.Command) (json.RawMessage, error),
+) {
 	s.directMu.Lock()
 	defer s.directMu.Unlock()
 
@@ -145,7 +149,9 @@ func (s *Server) Serialize(fn func() error) error {
 }
 
 // directHandler is the direct handler for name, if one is registered.
-func (s *Server) directHandler(name action.Name) (func(cmd action.Command) error, bool) {
+func (s *Server) directHandler(
+	name action.Name,
+) (func(cmd action.Command) (json.RawMessage, error), bool) {
 	s.directMu.RLock()
 	defer s.directMu.RUnlock()
 
@@ -185,7 +191,14 @@ func (s *Server) handleConn(conn net.Conn) {
 	}
 
 	if handle, ok := s.directHandler(req.Command.Name); ok {
-		_ = writeResponse(conn, responseFromError(handle(req.Command)))
+		data, handleErr := handle(req.Command)
+
+		resp := responseFromError(handleErr)
+		if handleErr == nil {
+			resp.Data = data
+		}
+
+		_ = writeResponse(conn, resp)
 
 		return
 	}

--- a/internal/ipc/wire_test.go
+++ b/internal/ipc/wire_test.go
@@ -265,7 +265,7 @@ func TestRequest_EncodesTheGoldenBytes(t *testing.T) {
 				return action.NewTilingCommand(action.TilingCommand, "swap", []string{"left"})
 			},
 			want: `{"version":7,"command":{"name":"tiling",` +
-				`"tiling":{"kind":"command","name":"swap","args":["left"]}}}`,
+				`"tiling":{"kind":"command","name":"swap","args":["left"],"all":false}}}`,
 		},
 		{
 			name: "mimi action resize_window left-half --width 800 --anchor cc --no-margin",

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -728,7 +728,13 @@ func stateKey(input Input) (string, bool) {
 		return "", false
 	}
 
-	return fmt.Sprintf("%d/%d", input.Display.ID, input.spaceID), true
+	return stateKeyOf(input.Display.ID, input.spaceID), true
+}
+
+// stateKeyOf is the key naming one display and one space, which is the one
+// place the shape of a state key is decided. splitStateKey reads it back.
+func stateKeyOf(display uint32, spaceID uint64) string {
+	return fmt.Sprintf("%d/%d", display, spaceID)
 }
 
 // keepUnmanaged records which of the windows this run was given the layout is

--- a/internal/tiling/state.go
+++ b/internal/tiling/state.go
@@ -1,0 +1,175 @@
+package tiling
+
+import (
+	"cmp"
+	"encoding/json"
+	"slices"
+	"strconv"
+	"strings"
+
+	derrors "github.com/y3owk1n/mimi/internal/errors"
+)
+
+// SpaceState is what the engine remembers for one display and one space: the
+// state the layout last returned there, and enough about the space to say
+// which one it is.
+//
+// Display and SpaceID name the space the way the engine files it. Space is
+// the same space's place in Mission Control at the time of the read, which is
+// what the user counts and what the layout was told. Both are reported
+// because only the first is an identity and only the second is recognizable.
+type SpaceState struct {
+	Display uint32 `json:"display"`
+	SpaceID uint64 `json:"spaceId"`
+	// Space is 0 when that space is not in front on any display now, which
+	// is every space but the ones the user is looking at.
+	Space int             `json:"space"`
+	State json.RawMessage `json:"state"`
+}
+
+// State is everything the engine remembers. Spaces is one entry per display
+// and space it has run a layout for, ordered by display and then by space so
+// that two reads of an unchanged desktop print the same bytes.
+//
+// This is a read of the daemon's own memory rather than of the desktop, which
+// is why it is not a query and why a CLI with no daemon to ask has nothing to
+// report.
+type State struct {
+	Spaces []SpaceState `json:"spaces"`
+	// Unmanaged is every window the layout said it is leaving alone, by
+	// number. The engine keeps one set for the desktop rather than one per
+	// space, because a window number names a window wherever it is.
+	Unmanaged []uint32 `json:"unmanaged"`
+}
+
+// State is what the engine is holding right now.
+func (e *Engine) State() State {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	held := State{
+		Spaces:    make([]SpaceState, 0, len(e.states)),
+		Unmanaged: make([]uint32, 0, len(e.unmanaged)),
+	}
+
+	inFront := e.spacesInFront()
+
+	for key, state := range e.states {
+		display, sid, ok := splitStateKey(key)
+		if !ok {
+			continue
+		}
+
+		held.Spaces = append(held.Spaces, SpaceState{
+			Display: display,
+			SpaceID: sid,
+			Space:   inFront[sid],
+			State:   state,
+		})
+	}
+
+	slices.SortFunc(held.Spaces, func(left, right SpaceState) int {
+		if left.Display != right.Display {
+			return cmp.Compare(left.Display, right.Display)
+		}
+
+		return cmp.Compare(left.SpaceID, right.SpaceID)
+	})
+
+	for number := range e.unmanaged {
+		held.Unmanaged = append(held.Unmanaged, number)
+	}
+
+	slices.Sort(held.Unmanaged)
+
+	return held
+}
+
+// Reset forgets what the layout returned for the space in front on every
+// display, so the next pass there starts from null, and reports how many
+// entries it dropped. With all set it forgets every space instead.
+//
+// This is the way out of a layout that has tied its own state in a knot.
+// Without it the only way was restarting the daemon, which threw away every
+// display's state rather than the one that had gone wrong.
+func (e *Engine) Reset(all bool) (int, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if all {
+		dropped := len(e.states)
+
+		clear(e.states)
+		clear(e.writtenAt)
+
+		return dropped, nil
+	}
+
+	ids, err := e.desktop.ActiveSpaceIDs()
+	if err != nil {
+		return 0, derrors.Wrapf(
+			err,
+			derrors.CodeActionFailed,
+			"failed to resolve which space to reset",
+		)
+	}
+
+	dropped := 0
+
+	for display, sid := range ids {
+		key := stateKeyOf(display, sid)
+		if _, held := e.states[key]; !held {
+			continue
+		}
+
+		delete(e.states, key)
+		delete(e.writtenAt, key)
+
+		dropped++
+	}
+
+	return dropped, nil
+}
+
+// spacesInFront is where each space that is in front on some display sits in
+// Mission Control, by identifier. A space that is not in front anywhere is
+// absent, and so is every space when the desktop will not say, which costs
+// the read those numbers and nothing else. The caller holds the lock.
+func (e *Engine) spacesInFront() map[uint64]int {
+	ids, err := e.desktop.ActiveSpaceIDs()
+	if err != nil {
+		return nil
+	}
+
+	spaces, err := e.desktop.ActiveSpaces()
+	if err != nil {
+		return nil
+	}
+
+	inFront := make(map[uint64]int, len(ids))
+	for display, sid := range ids {
+		inFront[sid] = spaces[display]
+	}
+
+	return inFront
+}
+
+// splitStateKey reads back the display and the space a state key names.
+func splitStateKey(key string) (uint32, uint64, bool) {
+	left, right, ok := strings.Cut(key, "/")
+	if !ok {
+		return 0, 0, false
+	}
+
+	display, err := strconv.ParseUint(left, 10, 32)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	sid, err := strconv.ParseUint(right, 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return uint32(display), sid, true
+}

--- a/internal/tiling/state_test.go
+++ b/internal/tiling/state_test.go
@@ -1,0 +1,192 @@
+package tiling_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/tiling"
+)
+
+// TestEngine_State_ReportsWhatEachSpaceIsHolding pins what the state read
+// answers with: one entry per display and space the layout has run for, naming
+// that space both ways, and the windows the layout is not managing.
+func TestEngine_State_ReportsWhatEachSpaceIsHolding(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	desktop.spaceIDs = map[uint32]uint64{7: 5000}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(`jq -c '{frames: [], state: {kept: true}, unmanaged: [1]}'`), shell)
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	held := engine.State()
+
+	if len(held.Spaces) != 1 {
+		t.Fatalf("State() held %d spaces, want 1: %+v", len(held.Spaces), held.Spaces)
+	}
+
+	space := held.Spaces[0]
+	if space.Display != 7 || space.SpaceID != 5000 {
+		t.Fatalf("State() named display %d space %d, want 7 and 5000", space.Display, space.SpaceID)
+	}
+
+	// The space is in front, so it is also reported by the number the user
+	// counts it by.
+	if space.Space != 2 {
+		t.Fatalf("State() reported Mission Control index %d, want 2", space.Space)
+	}
+
+	if got := string(space.State); got != `{"kept":true}` {
+		t.Fatalf("State() held %s, want {\"kept\":true}", got)
+	}
+
+	if len(held.Unmanaged) != 1 || held.Unmanaged[0] != 1 {
+		t.Fatalf("State() unmanaged = %v, want [1]", held.Unmanaged)
+	}
+}
+
+// TestEngine_State_IsEmptyBeforeAnyPass pins that a read before the layout has
+// run answers with nothing rather than failing, which is what a CLI with no
+// daemon behind it prints.
+func TestEngine_State_IsEmptyBeforeAnyPass(t *testing.T) {
+	t.Parallel()
+
+	engine := tiling.New(newDesktop(), nil, nil)
+
+	if held := engine.State(); len(held.Spaces) != 0 || len(held.Unmanaged) != 0 {
+		t.Fatalf("State() before any pass = %+v, want nothing held", held)
+	}
+}
+
+// TestEngine_Reset_StartsTheSpaceInFrontOver pins the way out of a layout
+// whose state has gone wrong: the space in front is forgotten and starts from
+// null, and the other space the engine remembers is left alone.
+func TestEngine_Reset_StartsTheSpaceInFrontOver(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	desktop.spaceIDs = map[uint32]uint64{7: 5000}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(echoLayout), shell)
+
+	ctx := context.Background()
+
+	err := engine.Pass(ctx, tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	// A second space on the same display, so the reset has something it
+	// should not touch.
+	desktop.space = 3
+	desktop.spaceIDs = map[uint32]uint64{7: 6000}
+
+	err = engine.Pass(ctx, tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() on the second space error = %v", err)
+	}
+
+	if held := engine.State(); len(held.Spaces) != 2 {
+		t.Fatalf("State() held %d spaces before the reset, want 2", len(held.Spaces))
+	}
+
+	dropped, err := engine.Reset(false)
+	if err != nil {
+		t.Fatalf("Reset() error = %v", err)
+	}
+
+	if dropped != 1 {
+		t.Fatalf("Reset() dropped %d spaces, want 1", dropped)
+	}
+
+	// The space in front starts over.
+	inputs, _, err := engine.Preview(ctx, tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+
+	if got := string(inputs[0].State); got != noState {
+		t.Fatalf("state on the reset space = %s, want null", got)
+	}
+
+	// The other one is where it was.
+	desktop.space = 2
+	desktop.spaceIDs = map[uint32]uint64{7: 5000}
+
+	inputs, _, err = engine.Preview(ctx, tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() on the untouched space error = %v", err)
+	}
+
+	if string(inputs[0].State) == noState {
+		t.Fatal("the space that was not in front was reset too")
+	}
+}
+
+// TestEngine_Reset_All pins that --all forgets every space rather than the
+// ones in front.
+func TestEngine_Reset_All(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	desktop.spaceIDs = map[uint32]uint64{7: 5000}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(echoLayout), shell)
+
+	ctx := context.Background()
+
+	for _, space := range []struct {
+		index int
+		id    uint64
+	}{{2, 5000}, {3, 6000}} {
+		desktop.space = space.index
+		desktop.spaceIDs = map[uint32]uint64{7: space.id}
+
+		err := engine.Pass(ctx, tiling.Event{Kind: created})
+		if err != nil {
+			t.Fatalf("Pass() on space %d error = %v", space.index, err)
+		}
+	}
+
+	dropped, err := engine.Reset(true)
+	if err != nil {
+		t.Fatalf("Reset(all) error = %v", err)
+	}
+
+	if dropped != 2 {
+		t.Fatalf("Reset(all) dropped %d spaces, want 2", dropped)
+	}
+
+	if held := engine.State(); len(held.Spaces) != 0 {
+		t.Fatalf("State() after Reset(all) held %+v, want nothing", held.Spaces)
+	}
+}
+
+// TestEngine_State_LeavesOutASpaceItCannotName pins that a space the window
+// server would not identify, whose state is never kept, is never reported
+// either.
+func TestEngine_State_LeavesOutASpaceItCannotName(t *testing.T) {
+	t.Parallel()
+
+	desktop := newDesktop()
+	desktop.spaceIDs = map[uint32]uint64{}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(echoLayout), shell)
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	if held := engine.State(); len(held.Spaces) != 0 {
+		t.Fatalf("State() held %+v for an unnamable space, want nothing", held.Spaces)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds two commands for looking at, and clearing, the layout state the
running daemon holds.

The engine remembers whatever a layout returns for each display and space, and
until now nothing could see it. `mimi tiling preview` looks like the command
for the job, but it builds a throwaway engine with a null state, so it shows
what a fresh space would do and never what the daemon is actually holding.

`mimi tiling state` prints what the engine holds. `mimi tiling reset` makes it
forget the space in front on each display, or every space with `--all`, so the
next pass starts the layout over. Before this, the only way out of a layout
whose state had gone wrong was restarting the daemon, which threw away every
display's state rather than the one that had gone bad.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A, both print JSON and neither moves a window.

## Command changes

Two new subcommands under `mimi tiling`. Nothing existing changes.

```bash
mimi tiling state
mimi tiling reset
mimi tiling reset --all
```

| Command | Flag | What it does |
| --- | --- | --- |
| `mimi tiling state` | none | Prints one line of JSON: what the engine holds per display and space, and the windows the layout said it is not managing |
| `mimi tiling reset` | none | Forgets the space in front on each display. Prints how many it forgot |
| `mimi tiling reset` | `--all` | Forgets every space the daemon remembers |

```
$ mimi tiling state | jq -c
{"spaces":[{"display":3,"spaceId":1,"space":1,"state":{"columns":[...],"offset":0}}],"unmanaged":[]}
```

Each space is named twice. `spaceId` is the window server's identifier, which
is what the engine files state under and what never changes. `space` is that
space's place in Mission Control right now, or `0` when it is not in front on
any display.

Both need a running daemon. With none they print an empty answer and say so on
stderr. No config key, hook, or `mimi_*` variable changes.

## Why these are not queries

`CONTEXT.md` defines a query as a read that always runs on the direct path and
never travels the socket. This state exists only inside the daemon, so a
direct-path read would print an empty answer that looks exactly like a daemon
holding nothing, and those are the two cases a user most needs told apart.
They ship as `tiling` subcommands on the socket the `tiling` action already
uses. Reasoning and the rejected alternatives are in
`docs/adr/0005-engine-state-is-read-over-the-socket.md`.

Deliberately, neither falls back to an engine of the CLI's own the way
`mimi tiling relayout` does, for the same reason.

## Potentially breaking

Nothing user-facing. One internal shape changed: `ipc.Response` gained a
`data` field and a direct handler now answers with `(json.RawMessage, error)`
rather than an error alone. Both are additive on the wire, so
`ipc.ProtocolVersion` stays at 7. An older daemon ignores a field it does not
know and an older CLI ignores one it is not looking for, so a CLI and daemon
from different builds behave as they did.

## Additional Context

Checked live against a real daemon running `strip.py`: `state` reported the
layout's own keys for the space in front, `reset` dropped one space and left
the state empty, a `relayout` rebuilt it, and `--all` cleared it again. With
the daemon stopped, both print empty and the notice goes to stderr, so piping
to `jq` still works.

Five unit tests cover the engine side: what a read reports, that it is empty
before any pass, that a reset takes the space in front and leaves another
alone, that `--all` takes everything, and that a space the window server will
not identify is never reported (its state is never kept either, from the
earlier space-identity change).
