### PR TITLE
feat(tiling): stack windows in one place and mark how many are there

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,6 +89,17 @@ never travels the socket.
 _Avoid_: action (an action changes the desktop), get, info, status (that is the
 daemon's health report)
 
+**Stack**:
+Windows a layout put in one frame, so that only one of them is seen at a time.
+mimi changes no z-order to arrange this and cannot: macOS will not raise one
+application's window above another's without also focusing it. So the member
+seen is the one with keyboard focus, and the layout names a stack only so that
+the indicator can say how many windows are in that place.
+_Avoid_: group, tab, pile. And note the older informal use in `strip.py` and
+`master-stack.py`, where "stacked" means the rows of a column or the column
+beside the master: those are windows with frames of their own, which is the
+opposite of this.
+
 **Display**:
 One connected screen, identified by its 1-based index counting left to right
 and then top to bottom across every display. A display holds spaces; a space

--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -102,6 +102,19 @@ outline_color = "#e2e2e3"
 outline_width = 2
 radius = 12
 
+# A layout can put several windows in one frame, so that only the one with
+# keyboard focus is seen. Nothing on screen says the others are there, so this
+# draws a bar along the top of that frame with one segment per window, the one
+# the layout means to be seen in active_color. It marks only what a layout
+# names, so it costs nothing with a layout that stacks nothing.
+# Colours are #rrggbb or #aarrggbb.
+[tiling.stackbar]
+enabled = false
+color = "#60e2e2e3"
+active_color = "#e2e2e3"
+height = 4
+radius = 2
+
 # =============================================================================
 # Borders
 # =============================================================================

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -282,6 +282,37 @@ depends on where the window is dropped, as the shipped `strip.py` does,
 shows the column the window would join. The zone needs Accessibility, like
 tiling, and nothing more; every key is reloadable.
 
+### Stack indicator
+
+```toml
+[tiling.stackbar]
+enabled = true
+color = "#60e2e2e3"
+active_color = "#e2e2e3"
+height = 4
+radius = 2
+```
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Mark the stacks a layout names |
+| `color` | `#60e2e2e3` | The colour of a window in the stack |
+| `active_color` | `#e2e2e3` | The colour of the one the layout means to be seen |
+| `height` | `4` | How tall the bar is, in points, up to 40 |
+| `radius` | `2` | The corner radius of each segment, in points |
+
+A layout can put several windows in one frame, so that only the one with
+keyboard focus is seen. Nothing on screen says the others are there, which is
+what this draws: a bar along the top of that frame with one segment per
+window, the active one in its own colour.
+
+It marks only what a layout names in its output's `stacks` key, so a layout
+that names none has nothing marked and the setting costs nothing.
+`examples/tiling/stacked.py` is the one that names them; `docs/TILING.md` has
+the contract. Colours are `#rrggbb` or `#aarrggbb`, alpha first. It needs
+Accessibility and tiling enabled, like the drop zone, and every key is
+reloadable.
+
 ---
 
 ## Borders

--- a/docs/TILING.md
+++ b/docs/TILING.md
@@ -12,6 +12,7 @@ keeps the timing, the state, and the hard parts of driving macOS.
 - [Writing your own layout](#writing-your-own-layout)
 - [Commands and hotkeys](#commands-and-hotkeys)
 - [Drags and the temporary maximise](#drags-and-the-temporary-maximise)
+- [Stacking windows in one place](#stacking-windows-in-one-place)
 - [More than one display](#more-than-one-display)
 - [Trying a layout without turning it on](#trying-a-layout-without-turning-it-on)
 - [When nothing happens](#when-nothing-happens)
@@ -63,10 +64,11 @@ The layouts shipped, all Python with the standard library only:
 
 | Layout | Shape | Commands it answers |
 | --- | --- | --- |
-| `monocle.py` | Every window fills the display. Move between them with focus. No state, no commands. The one to copy when starting your own. | none |
+| `monocle.py` | Every window fills the display. Move between them with focus. No state, no commands. Names them all as one stack, so `[tiling.stackbar]` marks how many there are. The one to copy when starting your own. | none |
 | `columns.py` | Equal-width columns. | `togglemax` |
 | `master-stack.py [ratio]` | One master on the left, the rest stacked on the right. Remembers the master and the ratio. | `swap`, `ratio <delta>`, `togglemax` |
 | `bsp.py` | Dwindle BSP, as Hyprland tiles by default. A new window splits the focused one, closing hands the area back. | `swap <dir>`, `togglesplit`, `ratio <delta>`, `togglefloat`, `togglemax` |
+| `stacked.py` | Equal columns, where a column holds one window or several in one place with only the focused one seen, as yabai stacks and niri tabs. | `stack`, `unstack`, `next`, `prev`, `togglemax` |
 | `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. | `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction\|prev\|+d\|-d]`, `center`, `scroll <dir> [fraction]`, `togglefloat`, `togglemax` |
 
 None of them takes a gap. The gap comes from mimi: `tiling.gap` when the
@@ -125,8 +127,9 @@ window event ---> daemon settles the burst (debounce_ms, default 100)
 
 The `[tiling]` keys are `enabled`, `layout`, `layout_mode`, `debounce_ms`,
 `timeout_secs`, `command_timeout_secs`, `relayout_on_drag`, and `gap`, plus a `[tiling.animation]`
-table with `enabled`, `duration_ms`, and `easing`, and a `[tiling.dropzone]`
-table that shows where a drag would land. Every one is reloadable.
+table with `enabled`, `duration_ms`, and `easing`, a `[tiling.dropzone]`
+table that shows where a drag would land, and a `[tiling.stackbar]` table that
+marks the windows a layout stacked. Every one is reloadable.
 The reference is in [CONFIGURATION.md](CONFIGURATION.md#tiling).
 
 **Animation is off by default.** With `[tiling.animation]` enabled, windows
@@ -187,6 +190,7 @@ both, through `serve()` in `rules.py`.
 | `windows` | The focusable windows whose centres are on this display, in `focus_window` order. `number` is the window server's number, stable for the window's lifetime, and how you name a window in the output. `order` is where the window sits in the stacking order, 0 for the one in front. |
 | `state` | What you printed last time for this display and space, or `null`. |
 | `unmanaged` | The windows on this display you last said you were not managing, by number. Absent when there are none. Handed back so a layout that keeps its floats outside `state`, or one restarted mid-session, can pick the set up again. |
+| `stacks` | The stacks you last named on this display, handed back for the same reason. Absent when there are none. |
 
 `displays` and `windows` are exactly what `mimi query displays` and
 `mimi query windows` print, so real data is one command away.
@@ -206,6 +210,7 @@ they compare correctly but need not start at 0 or run without gaps.
   "state": {"anything": "you like"},
   "focus": 4242,
   "unmanaged": [4243],
+  "stacks": [{"windows": [4242, 4244], "active": 4242}],
   "before": ["osascript -e 'beep'"],
   "after": ["~/.config/mimi/warp.py 720 462"]
 }
@@ -217,6 +222,7 @@ they compare correctly but need not start at 0 or run without gaps.
 | `state` | Any JSON. Handed back next run. Omit the key and the previous state is kept. Print `null` to clear it. |
 | `focus` | Optional. A window number to give keyboard focus, before the frames move. For moving focus along a layout's own structure where spatial `focus_window` cannot, such as a strip's parked columns. |
 | `unmanaged` | Optional. The windows this run was given that you are leaving alone, by number, such as the ones you float. mimi then leaves them alone too, so dragging one raises no pass and shows no drop zone. A window stays unmanaged until a later run for the same display leaves it out of this list. |
+| `stacks` | Optional. The sets of windows you put in one place, as `[{"windows": [n, ...], "active": n}]`. mimi marks each with a small bar, one segment per window, with the `active` one in its own colour. Every member needs its own frame in `frames`; a stack naming a window without one, or naming fewer than two, is dropped and the frames still apply. |
 | `before` | Optional. Command lines mimi runs through `settings.hook_shell` before the focus and the frames, all at once. mimi waits for every one and kills one past `tiling.command_timeout_secs`. A failure logs at debug and the frames still apply. See [Running commands around the frames](#running-commands-around-the-frames). |
 | `after` | Optional. Command lines mimi runs through `settings.hook_shell` once the frames have been applied, and once the animation has ended when one runs. They run in order, detached. mimi kills one past `tiling.command_timeout_secs`, drops their output and logs a failure at debug. Use it to act on the frames the layout returned, where a hook would run before them. See [Running commands around the frames](#running-commands-around-the-frames). |
 
@@ -493,6 +499,45 @@ frames and state underneath are untouched. It ends on a second `togglemax`,
 when the window closes, or when you focus another tiled window. It is one
 call from `rules.py`, `maximised(inp, state, frames, area)`, made last on the
 frames a layout computed. Add it to your own layout with that one line.
+
+---
+
+## Stacking windows in one place
+
+Give two windows the same frame and only one of them is seen. That is the
+whole mechanism, and every layout can already do it. What mimi adds is the
+`stacks` key, which says *this* is a stack rather than an accident, so a small
+bar is drawn on it: one segment per window, the active one in its own colour.
+Without that a column of four windows looks exactly like a column of one.
+
+```toml
+[tiling.stackbar]
+enabled = true
+```
+
+**The window seen is the one with keyboard focus.** mimi changes no z-order of
+its own, and not by choice: macOS offers no way to raise one application's
+window above another's without also focusing it. Every private call that
+claims to, `SLSOrderWindow` included, refuses on a window belonging to another
+application unless mimi is running with the scripting addition, which needs
+SIP disabled. So a layout moves between the windows in a stack with the
+`focus` key, exactly as it moves focus anywhere else.
+
+`active` is the member you mean to be seen, which is what the bar marks. It is
+your own reckoning, not a reading of the desktop, and the two can differ:
+Cmd-Tab puts a buried member in front without telling your layout. The next
+input says which window really is in front, through `focused` and each
+window's `order`, so a layout that cares can reconcile.
+
+`stacked.py` is the shipped example: equal columns where a column holds one
+window or several, answering `stack`, `unstack`, `next` and `prev`.
+
+```
+alt - s         : mimi tiling cmd stack
+alt + shift - s : mimi tiling cmd unstack
+alt - n         : mimi tiling cmd next
+alt - p         : mimi tiling cmd prev
+```
 
 ---
 

--- a/docs/adr/0006-a-stack-is-windows-sharing-a-frame-with-focus-on-top.md
+++ b/docs/adr/0006-a-stack-is-windows-sharing-a-frame-with-focus-on-top.md
@@ -1,0 +1,77 @@
+# A stack is windows sharing one frame, and the one seen is the one with focus
+
+**Status:** accepted
+
+A layout can put several windows in one place so that only one is seen at a
+time, the way yabai stacks and niri tabs. We decided that mimi changes no
+z-order to arrange this, that the window seen is whichever holds keyboard
+focus, and that a layout names its stacks only so mimi can mark them.
+
+## The measurement that decided it
+
+The obvious design is for the engine to raise the member the layout names,
+leaving focus wherever the user left it. It cannot, and this was tested rather
+than assumed.
+
+`SLSOrderWindow(cid, wid, mode, relativeTo)` is the private SkyLight call that
+orders one window against another. mimi already links it and already uses it,
+on its own border overlay (`internal/native/border.m`). Run against a window
+belonging to another application, from mimi's own connection, every form of it
+fails:
+
+| Call | Result |
+| --- | --- |
+| order the front window below the second | `kCGErrorFailure` (1000), no change |
+| order the second window above the front | `kCGErrorFailure` (1000), no change |
+| order either relative to nothing | `kCGErrorFailure` (1000), no change |
+| `SLSSetWindowLevel` on a foreign window | returned 0, no change |
+
+The window server accepts these only from a connection with the scripting
+addition loaded, which needs SIP disabled. mimi's whole premise is that it
+does not ask for that.
+
+The only raise mimi has is `MimiRaiseWindowNumber`
+(`internal/native/application.m`), which goes through `MimiActivateWindow` and
+so performs `activateWithOptions:`, sets `kAXMain` and `kAXFocused`, and only
+then `kAXRaiseAction`. There is no way to reach the last step alone.
+
+## Considered options
+
+- **The engine raises the active member after the frames.** Rejected on the
+  measurement above: the only raise available also takes focus, so a stack on
+  a display the user was not looking at would steal their keyboard every pass.
+- **Minimise the members that are not active.** Rejected: a minimised window
+  leaves the window list mimi and every layout read, so the stack would
+  dissolve on the next pass, and the Dock animates every change.
+- **Move the inactive members off screen.** Rejected: it works, and it makes a
+  mess of everything else. Those windows would be on another display as far as
+  the layout is concerned, Mission Control would show them adrift, and an
+  application that saves its frame would reopen off screen.
+- **Same frame, focus decides, and mark it (chosen).** Identical geometry
+  means the window in front covers the rest exactly. Focus already moves the
+  front window to the front, which the window server reports as each window's
+  `order`. Nothing needs a private call that does not work.
+
+## Consequences
+
+- **A layout switches members with the `focus` key it already had.** There is
+  no new verb for moving within a stack, because moving focus is the whole
+  mechanism. `stacked.py` answers `next` and `prev` by returning `focus`.
+- **`active` is the layout's own reckoning, not a reading of the desktop.**
+  The two can differ the moment the user presses Cmd-Tab, which surfaces a
+  buried member without telling the layout. The input reports what is really
+  in front, through `focused` and each window's `order`, so a layout that
+  cares can reconcile on the next pass. mimi does not reconcile for it, since
+  which of the two is right is the layout's business.
+- **The indicator is the feature.** Windows sharing a frame was always
+  possible and always invisible. `[tiling.stackbar]` draws one segment per
+  member along the top of the shared frame, so a stack of four does not look
+  like a window of one. A layout that names no stack has nothing marked.
+- **The engine refuses a stack it cannot draw.** Fewer than two windows is
+  every window in every layout, and a member with no frame in the same output
+  would put a mark where nothing is. Either is dropped with a debug line, and
+  the frames still apply, which is the containment the rest of the engine
+  uses.
+- **A real `mimi action lower_window` stays impossible.** The same measurement
+  rules it out, so the z-order verb considered alongside this is not a matter
+  of implementing it, and will not become one unless macOS changes.

--- a/examples/tiling/README.md
+++ b/examples/tiling/README.md
@@ -23,11 +23,12 @@ per pass.
 
 | File | What it does |
 | --- | --- |
-| `monocle.py` | Every window fills the display; move between them with focus. The smallest layout there is, and the one to copy when starting your own. |
+| `monocle.py` | Every window fills the display; move between them with focus. Names them all as one stack, so `[tiling.stackbar]` says how many are there. The smallest layout there is, and the one to copy when starting your own. |
 | `columns.py` | Equal-width columns. No state, no commands. |
 | `master-stack.py [ratio]` | One master on the left, the rest stacked on the right. Remembers the master and ratio in `state`, answers `swap` and `ratio +0.05`, reads a drag of the split from either side, and makes a stack window dropped on the master the master. |
 | `strip.py` | Scrollable strip, as niri tiles: columns on a strip wider than the display, focus scrolls it, neighbours peek in at the edges. Answers `focus <dir>`, `move <dir>`, `consume`, `expel`, `width [fraction|prev|+d|-d]`, `center`, `scroll <dir> [fraction]`, `togglefloat`, `togglemax`; a dragged edge sets a column's width and a window dropped on a column joins it, a stacked window dropped on empty strip or a column's outer quarter gets a column of its own, and one dropped higher or lower in its column takes that row. `PRIORITY` fixes where listed apps open. |
 | `bsp.py` | Dwindle BSP, as Hyprland tiles by default: a new window splits the focused one, closing hands the area back, any dragged edge resizes its split, a window dropped on another swaps with it. Answers `swap <dir>`, `togglesplit`, `ratio <delta>`, `togglefloat`. |
+| `stacked.py` | Equal columns where a column holds one window or several in one place, as yabai stacks and niri tabs, with only the focused one seen and a bar marking how many are there. Answers `stack`, `unstack`, `next`, `prev`, `togglemax`. Needs `[tiling.stackbar]` enabled to draw the mark. |
 | `rules.py` | What the others share: the float rules (edit the bundle ids and title patterns here), the area to fill, `serve()`, which reads the input and runs the layout in either mode, `write_output`, and the temporary maximise every layout answers as `togglemax`. |
 
 Run any of them with nothing on stdin and it lays the desktop out once by

--- a/examples/tiling/monocle.py
+++ b/examples/tiling/monocle.py
@@ -5,6 +5,12 @@ Windows sit on top of one another and you move between them with focus
 (mimi action focus_window, or an app switcher). The smallest layout there
 is, and the one to copy when starting your own: no state, no commands.
 
+Every window being in the same place is exactly what a stack is, so this
+names one, and with [tiling.stackbar] enabled mimi marks it: one segment per
+window with the focused one lit. That is the one thing monocle otherwise
+cannot tell you, since a display with six windows on it looks like a display
+with one.
+
 A layout program: reads the tiling input on stdin, prints the output on
 stdout. Copy, edit, own. Standard library only.
 
@@ -16,10 +22,18 @@ from rules import area, gap, serve, unmanaged_of, write_output
 
 def main(inp):
     box = area(inp, gap(inp))
+    numbers = [w["number"] for w in inp["windows"]]
+    focused = inp["windows"][inp["focused"]]["number"] if inp["focused"] >= 0 else None
+
+    # Two or more windows in one place is a stack. mimi drops a stack of
+    # one, so there is nothing to check here.
+    stacks = [{"windows": numbers, "active": focused or numbers[0]}] if numbers else []
+
     write_output(
-        [(w["number"], box) for w in inp["windows"]],
+        [(number, box) for number in numbers],
         None,
         unmanaged=unmanaged_of(inp),
+        stacks=stacks,
     )
 
 

--- a/examples/tiling/rules.py
+++ b/examples/tiling/rules.py
@@ -153,7 +153,7 @@ def unmanaged_of(inp, state=None):
     return sorted(numbers)
 
 
-def write_output(frames, state, focus=None, unmanaged=None):
+def write_output(frames, state, focus=None, unmanaged=None, stacks=None):
     """Print the layout output: frames in whole points, the state to get
     back next time, the window to focus once the frames are applied, when
     the layout moved focus along its own structure, and the windows this
@@ -163,7 +163,13 @@ def write_output(frames, state, focus=None, unmanaged=None):
     windows alone too, and dragging one raises no pass and shows no drop
     zone. Leaving a window out of `frames` says only that it does not move
     this time, which is what a temporary maximise does to the windows under
-    it."""
+    it.
+
+    `stacks` names the sets of windows this layout put in one place, as
+    [{"windows": [...], "active": n}], so mimi marks each with a bar saying
+    how many windows are there. Every member needs a frame of its own in
+    `frames`, and giving them the same frame is what makes a stack. See
+    stacked.py."""
     frames = [
         {"number": number, "frame": {k: int(round(v)) for k, v in frame.items()}}
         for number, frame in frames
@@ -173,6 +179,10 @@ def write_output(frames, state, focus=None, unmanaged=None):
         out["focus"] = focus
     if unmanaged:
         out["unmanaged"] = list(unmanaged)
+    if stacks:
+        out["stacks"] = [
+            {"windows": list(s["windows"]), "active": s["active"]} for s in stacks
+        ]
     json.dump(out, sys.stdout)
     sys.stdout.write("\n")
 

--- a/examples/tiling/stacked.py
+++ b/examples/tiling/stacked.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Columns that hold more than one window, as yabai stacks and niri tabs.
+
+Windows are laid out in equal columns left to right. A column holds one
+window or several, and windows in the same column share one frame, so only
+the one with keyboard focus is seen. mimi marks such a column with a small
+bar, one segment per window, so a column of four does not look like a column
+of one.
+
+  mimi tiling cmd stack          put the focused window into the column to
+                                 its left, or the one to its right when it
+                                 is already leftmost
+  mimi tiling cmd unstack        give the focused window a column of its own
+  mimi tiling cmd next           focus the next window in this column
+  mimi tiling cmd prev           focus the previous one
+  mimi tiling cmd togglemax      the temporary maximise every layout answers
+
+There is no z-order here on purpose. macOS gives no way to raise one
+application's window above another's without also focusing it, so the window
+seen in a column is the one with focus, and `next` moves focus rather than
+raising anything. `mimi query windows` reports each window's `order`, which
+is how this layout knows which member is really on top.
+"""
+
+from rules import area, command, gap, maximised, serve, unmanaged_of, write_output
+
+
+def columns_of(state, numbers):
+    """The remembered columns, with windows that went dropped and windows
+    that appeared added as columns of their own, in the order they arrive."""
+    columns = [[n for n in column if n in numbers] for column in state.get("columns", [])]
+    columns = [column for column in columns if column]
+
+    known = {n for column in columns for n in column}
+    for number in numbers:
+        if number not in known:
+            columns.append([number])
+
+    return columns
+
+
+def find(columns, number):
+    """Where a window sits, as (column index, row index), or (None, None)."""
+    for index, column in enumerate(columns):
+        if number in column:
+            return index, column.index(number)
+    return None, None
+
+
+def main(inp):
+    GAP = gap(inp)
+    state = inp.get("state") or {}
+    box = area(inp, GAP)
+    numbers = [w["number"] for w in inp["windows"]]
+    focused = inp["windows"][inp["focused"]]["number"] if inp["focused"] >= 0 else None
+
+    columns = columns_of(state, numbers)
+    if not columns:
+        write_output([], {"columns": []}, unmanaged=unmanaged_of(inp, state))
+        return
+
+    at, _ = find(columns, focused)
+    focus = None
+
+    if command(inp, "stack") is not None and at is not None and len(columns) > 1:
+        into = at - 1 if at > 0 else 1
+        columns[into].append(focused)
+        columns[at].remove(focused)
+        columns = [column for column in columns if column]
+    elif command(inp, "unstack") is not None and at is not None and len(columns[at]) > 1:
+        columns[at].remove(focused)
+        columns.insert(at + 1, [focused])
+    else:
+        # `command` answers with an empty list for a command that takes no
+        # arguments, so each one is asked about on its own: `a or b` would
+        # read that empty list as "no".
+        step = 0
+        if command(inp, "next") is not None:
+            step = 1
+        elif command(inp, "prev") is not None:
+            step = -1
+
+        if step and at is not None and len(columns[at]) > 1:
+            column = columns[at]
+            focus = column[(column.index(focused) + step) % len(column)]
+
+    # Every window in a column gets the column's frame. The one with focus
+    # is the one seen; the rest are behind it, which is what the stack key
+    # tells mimi to mark.
+    width = (box["width"] - GAP * (len(columns) - 1)) / len(columns)
+    frames = []
+    stacks = []
+
+    for index, column in enumerate(columns):
+        frame = {
+            "x": box["x"] + index * (width + GAP),
+            "y": box["y"],
+            "width": width,
+            "height": box["height"],
+        }
+        for number in column:
+            frames.append((number, dict(frame)))
+
+        if len(column) > 1:
+            seen = focus if focus in column else (focused if focused in column else column[0])
+            stacks.append({"windows": list(column), "active": seen})
+
+    state["columns"] = columns
+    out = maximised(inp, state, frames, box)
+
+    write_output(out, state, focus, unmanaged=unmanaged_of(inp, state), stacks=stacks)
+
+
+if __name__ == "__main__":
+    serve(main)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,22 @@ type TilingConfig struct {
 	// Dropzone shows, while the user drags a window, where the layout would
 	// put it.
 	Dropzone DropzoneConfig `json:"dropzone" toml:"dropzone"`
+	// Stackbar marks the places where a layout stacked several windows, so
+	// the ones hidden behind the top one can be seen to be there.
+	Stackbar StackbarConfig `json:"stackbar" toml:"stackbar"`
+}
+
+// StackbarConfig holds the [tiling.stackbar] section: whether mimi marks the
+// stacks a layout names, and how that mark is drawn. Windows in a stack share
+// one frame, so without a mark there is nothing to say how many are there.
+// Colors are #rrggbb or #aarrggbb.
+type StackbarConfig struct {
+	Enabled bool   `json:"enabled" toml:"enabled"`
+	Color   string `json:"color"   toml:"color"`
+	// ActiveColor marks the member the layout means to be seen.
+	ActiveColor string  `json:"activeColor" toml:"active_color"`
+	Height      float64 `json:"height"      toml:"height"`
+	Radius      float64 `json:"radius"      toml:"radius"`
 }
 
 // DropzoneConfig holds the [tiling.dropzone] section: whether, while the

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -177,6 +177,10 @@ const (
 	defaultDropzoneOutlineColor = "#e2e2e3"
 	defaultDropzoneOutlineWidth = 2.0
 	defaultDropzoneRadius       = 12.0
+	defaultStackbarColor        = "#60e2e2e3"
+	defaultStackbarActiveColor  = "#e2e2e3"
+	defaultStackbarHeight       = 4.0
+	defaultStackbarRadius       = 2.0
 )
 
 func applyDefaults(cfg *Config, systrayEnabledSet bool) {
@@ -239,6 +243,22 @@ func applyDefaults(cfg *Config, systrayEnabledSet bool) {
 
 	if cfg.Tiling.Dropzone.Radius == 0 {
 		cfg.Tiling.Dropzone.Radius = defaultDropzoneRadius
+	}
+
+	if cfg.Tiling.Stackbar.Color == "" {
+		cfg.Tiling.Stackbar.Color = defaultStackbarColor
+	}
+
+	if cfg.Tiling.Stackbar.ActiveColor == "" {
+		cfg.Tiling.Stackbar.ActiveColor = defaultStackbarActiveColor
+	}
+
+	if cfg.Tiling.Stackbar.Height == 0 {
+		cfg.Tiling.Stackbar.Height = defaultStackbarHeight
+	}
+
+	if cfg.Tiling.Stackbar.Radius == 0 {
+		cfg.Tiling.Stackbar.Radius = defaultStackbarRadius
 	}
 
 	if cfg.Border.Width == 0 {
@@ -328,6 +348,7 @@ func validate(cfg *Config) error {
 
 	errs = append(errs, validateBorder(cfg.Border)...)
 	errs = append(errs, validateDropzone(cfg.Tiling)...)
+	errs = append(errs, validateStackbar(cfg.Tiling)...)
 
 	// HookKinds is a slice, so these errors come out in its declared order.
 	// The map this replaced meant validate reported the same broken config in
@@ -404,6 +425,42 @@ func validateDropzone(tiling TilingConfig) []string {
 
 	return errs
 }
+
+// validateStackbar holds the [tiling.stackbar] section to its rules: its
+// colors parse and its sizes are sane. It needs nothing else switched on,
+// since a layout that names no stack simply has nothing marked.
+func validateStackbar(tiling TilingConfig) []string {
+	var errs []string
+
+	bar := tiling.Stackbar
+
+	_, err := ParseColor(bar.Color)
+	if err != nil {
+		errs = append(errs, "tiling.stackbar.color must be #rrggbb or #aarrggbb")
+	}
+
+	_, err = ParseColor(bar.ActiveColor)
+	if err != nil {
+		errs = append(errs, "tiling.stackbar.active_color must be #rrggbb or #aarrggbb")
+	}
+
+	if bar.Height <= 0 || bar.Height > maxStackbarHeight {
+		errs = append(
+			errs,
+			fmt.Sprintf("tiling.stackbar.height must be between 0 and %d", int(maxStackbarHeight)),
+		)
+	}
+
+	if bar.Radius < 0 {
+		errs = append(errs, "tiling.stackbar.radius must be >= 0")
+	}
+
+	return errs
+}
+
+// maxStackbarHeight is as tall as the indicator may be drawn. Past this it
+// stops marking a stack and starts covering its windows.
+const maxStackbarHeight = 40.0
 
 func validateBorder(border BorderConfig) []string {
 	var errs []string

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/y3owk1n/mimi/internal/observe"
 	"github.com/y3owk1n/mimi/internal/paths"
 	"github.com/y3owk1n/mimi/internal/permissions"
+	"github.com/y3owk1n/mimi/internal/stackbar"
 	"github.com/y3owk1n/mimi/internal/systray"
 	"github.com/y3owk1n/mimi/internal/tiling"
 )
@@ -173,6 +174,7 @@ func runCore(
 		pipeline.tiler,
 		pipeline.borders,
 		pipeline.zone,
+		pipeline.bars,
 		logger,
 	)
 
@@ -240,6 +242,7 @@ type eventPipeline struct {
 	tiler     *tiling.Engine
 	borders   *border.Engine
 	zone      *dropzone.Tracker
+	bars      *stackbar.Tracker
 	logSub    events.Subscriber
 	hookSub   events.Subscriber
 	tileSub   events.Subscriber
@@ -307,6 +310,12 @@ func setupEventPipeline(
 		zone.Nudge()
 	})
 
+	// The stack indicator is drawn from the stacks a pass ends with, so the
+	// engine tells it rather than the bus.
+	bars := stackbar.New(stackbar.NativeDrawer(), logger)
+	bars.Update(stackbarConfigFor(cfg, accessibilityGranted))
+	tiler.SetStacks(bars.Sync)
+
 	// The event log is opt-in via [settings].log_file; when present, write
 	// every event so the user can replay what happened. When disabled, the
 	// always-false filter prevents the bus from sending into a channel
@@ -335,6 +344,7 @@ func setupEventPipeline(
 		tiler:     tiler,
 		borders:   borders,
 		zone:      zone,
+		bars:      bars,
 		logSub:    logSub,
 		hookSub:   hookSub,
 		tileSub:   tileSub,
@@ -589,6 +599,18 @@ func dropzoneConfigFor(cfg *config.Config, accessibilityGranted bool) config.Dro
 	}
 
 	return zoneCfg
+}
+
+// stackbarConfigFor is the [tiling.stackbar] section as the indicator gets
+// it: as written, except that without Accessibility, or with tiling off,
+// there are no stacks to mark and it is disabled.
+func stackbarConfigFor(cfg *config.Config, accessibilityGranted bool) config.StackbarConfig {
+	barCfg := cfg.Tiling.Stackbar
+	if !accessibilityGranted || !cfg.Tiling.Enabled {
+		barCfg.Enabled = false
+	}
+
+	return barCfg
 }
 
 // tilingConfigFor is the [tiling] section as the engine gets it: as written,

--- a/internal/daemon/reloader.go
+++ b/internal/daemon/reloader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/y3owk1n/mimi/internal/native"
 	"github.com/y3owk1n/mimi/internal/observe"
 	"github.com/y3owk1n/mimi/internal/permissions"
+	"github.com/y3owk1n/mimi/internal/stackbar"
 	"github.com/y3owk1n/mimi/internal/tiling"
 )
 
@@ -48,6 +49,7 @@ type reloader struct {
 	tiler     *tiling.Engine
 	borders   *border.Engine
 	zone      *dropzone.Tracker
+	bars      *stackbar.Tracker
 	logger    *zap.SugaredLogger
 }
 
@@ -69,6 +71,7 @@ func newReloader(
 	tiler *tiling.Engine,
 	borders *border.Engine,
 	zone *dropzone.Tracker,
+	bars *stackbar.Tracker,
 	logger *zap.SugaredLogger,
 ) *reloader {
 	if logger == nil {
@@ -84,6 +87,7 @@ func newReloader(
 		tiler:     tiler,
 		borders:   borders,
 		zone:      zone,
+		bars:      bars,
 		logger:    logger,
 	}
 }
@@ -144,6 +148,10 @@ func (rl *reloader) Apply(cfg *config.Config) (reloadChanges, error) {
 
 	if rl.zone != nil {
 		rl.zone.Update(dropzoneConfigFor(cfg, perm.Accessibility))
+	}
+
+	if rl.bars != nil {
+		rl.bars.Update(stackbarConfigFor(cfg, perm.Accessibility))
 	}
 
 	return reloadChanges{

--- a/internal/daemon/reloader_test.go
+++ b/internal/daemon/reloader_test.go
@@ -54,7 +54,18 @@ func newTestReloader(
 	)
 	executor := hooks.NewExecutor(reg, &initialCfg.Settings, logger)
 
-	cfgReloader := newReloader(initialCfg, reg, executor, axTracker, router, nil, nil, nil, nil)
+	cfgReloader := newReloader(
+		initialCfg,
+		reg,
+		executor,
+		axTracker,
+		router,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
 
 	return cfgReloader, reg
 }

--- a/internal/native/stackbar.go
+++ b/internal/native/stackbar.go
@@ -1,0 +1,69 @@
+package native
+
+/*
+#include <stdlib.h>
+#include "stackbar.h"
+*/
+import "C"
+
+// StackbarStyle is how a stack indicator is drawn: the color of a member
+// that is not the active one, the color of the active one, the height of the
+// bar and the corner radius of each segment, in points.
+type StackbarStyle struct {
+	Color       Color
+	ActiveColor Color
+	Height      float64
+	Radius      float64
+}
+
+// Stackbar is one stack to mark: the frame its windows share, in window
+// coordinates, how many windows are in it, and which of them, counting from
+// 0, the layout means to be seen.
+type Stackbar struct {
+	Left   float64
+	Top    float64
+	Width  float64
+	Height float64
+	Count  int
+	Active int
+}
+
+// SyncStackbars draws exactly these stacks and no others. Passing none takes
+// every indicator off screen.
+func SyncStackbars(bars []Stackbar, style StackbarStyle) {
+	cStyle := C.MimiStackbarStyle{
+		color:       cColor(style.Color),
+		activeColor: cColor(style.ActiveColor),
+		height:      C.double(style.Height),
+		radius:      C.double(style.Radius),
+	}
+
+	if len(bars) == 0 {
+		C.MimiStackbarsSync(nil, 0, &cStyle)
+
+		return
+	}
+
+	// A MimiStackbar holds only numbers, so this array carries no Go
+	// pointer and may cross into C as it is. The native side copies every
+	// bar before it hands the work to the main thread, so nothing of Go's
+	// is held past the call.
+	cBars := make([]C.MimiStackbar, len(bars))
+	for index, bar := range bars {
+		cBars[index] = C.MimiStackbar{
+			x:      C.double(bar.Left),
+			y:      C.double(bar.Top),
+			width:  C.double(bar.Width),
+			height: C.double(bar.Height),
+			count:  C.int(bar.Count),
+			active: C.int(bar.Active),
+		}
+	}
+
+	C.MimiStackbarsSync(&cBars[0], C.int(len(cBars)), &cStyle)
+}
+
+// ClearStackbars takes every indicator off screen.
+func ClearStackbars() {
+	C.MimiStackbarsClear()
+}

--- a/internal/native/stackbar.h
+++ b/internal/native/stackbar.h
@@ -1,0 +1,37 @@
+#ifndef MIMI_STACKBAR_H
+#define MIMI_STACKBAR_H
+
+#import "border.h"
+
+#include <stdint.h>
+
+/// How a stack indicator is drawn: the color of a member that is not the
+/// active one, the color of the active one, the height of the bar and the
+/// corner radius of each segment, in points.
+typedef struct {
+	MimiColor color;
+	MimiColor activeColor;
+	double height;
+	double radius;
+} MimiStackbarStyle;
+
+/// One stack to mark: the frame its windows share, in window coordinates (y
+/// down from the top of the main display), how many windows are in it, and
+/// which of them, counting from 0, the layout means to be seen.
+typedef struct {
+	double x;
+	double y;
+	double width;
+	double height;
+	int count;
+	int active;
+} MimiStackbar;
+
+/// Draw exactly these stacks and no others, replacing whatever was drawn
+/// before. Passing none takes every indicator off screen.
+void MimiStackbarsSync(const MimiStackbar *bars, int count, const MimiStackbarStyle *style);
+
+/// Take every indicator off screen and release the windows behind them.
+void MimiStackbarsClear(void);
+
+#endif  // MIMI_STACKBAR_H

--- a/internal/native/stackbar.m
+++ b/internal/native/stackbar.m
@@ -1,0 +1,134 @@
+#import "stackbar.h"
+
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
+
+// A stack indicator is one transparent window sitting on the top edge of the
+// frame a stack's windows share, holding one segment per window with the
+// active one in its own colour. It says how many windows are in that place
+// and which one is meant to be seen, which is the only thing about a stack
+// that is otherwise invisible.
+//
+// One window per stack, kept in a pool: a sync shows as many as it was given
+// and orders the rest out rather than releasing them, since a desktop settles
+// on a stack count and a released window would be rebuilt on the next pass.
+// Every call goes to the main thread, where the daemon runs its application
+// loop.
+
+static NSMutableArray<NSWindow *> *gBars;
+
+/// Gap between one segment and the next, in points.
+static const double kMimiStackbarGap = 2.0;
+
+/// Inset of the whole bar from the sides of the frame it marks, in points.
+static const double kMimiStackbarInset = 4.0;
+
+static NSRect mimiStackbarCocoaRect(CGRect rect) {
+	double primaryHeight = CGDisplayBounds(CGMainDisplayID()).size.height;
+	return NSMakeRect(
+	    rect.origin.x, primaryHeight - rect.origin.y - rect.size.height, rect.size.width, rect.size.height);
+}
+
+static NSWindow *mimiStackbarWindow(void) {
+	NSWindow *bar = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 1, 1)
+	                                            styleMask:NSWindowStyleMaskBorderless
+	                                              backing:NSBackingStoreBuffered
+	                                                defer:NO];
+	bar.level = NSFloatingWindowLevel;
+	bar.opaque = NO;
+	bar.backgroundColor = [NSColor clearColor];
+	bar.hasShadow = NO;
+	bar.ignoresMouseEvents = YES;
+	bar.releasedWhenClosed = NO;
+	bar.animationBehavior = NSWindowAnimationBehaviorNone;
+	bar.collectionBehavior = NSWindowCollectionBehaviorStationary | NSWindowCollectionBehaviorIgnoresCycle |
+	                         NSWindowCollectionBehaviorCanJoinAllSpaces;
+	bar.contentView.wantsLayer = YES;
+	return bar;
+}
+
+/// Lay one bar's segments out across its width, the active one coloured apart.
+static void mimiStackbarDraw(NSWindow *bar, MimiStackbar spec, MimiStackbarStyle style) {
+	CALayer *root = bar.contentView.layer;
+	root.sublayers = nil;
+
+	if (spec.count <= 0) {
+		return;
+	}
+
+	double width = bar.frame.size.width;
+	double each = (width - kMimiStackbarGap * (spec.count - 1)) / spec.count;
+	if (each <= 0) {
+		return;
+	}
+
+	CGColorRef plain = CGColorCreateSRGB(style.color.red, style.color.green, style.color.blue, style.color.alpha);
+	CGColorRef active = CGColorCreateSRGB(
+	    style.activeColor.red, style.activeColor.green, style.activeColor.blue, style.activeColor.alpha);
+
+	for (int index = 0; index < spec.count; index++) {
+		CALayer *segment = [CALayer layer];
+		segment.anchorPoint = CGPointZero;
+		segment.frame = CGRectMake(index * (each + kMimiStackbarGap), 0, each, style.height);
+		segment.cornerRadius = style.radius;
+		segment.backgroundColor = index == spec.active ? active : plain;
+		[root addSublayer:segment];
+	}
+
+	CGColorRelease(plain);
+	CGColorRelease(active);
+}
+
+void MimiStackbarsSync(const MimiStackbar *bars, int count, const MimiStackbarStyle *style) {
+	if (count < 0) {
+		count = 0;
+	}
+
+	MimiStackbarStyle styleCopy = *style;
+	NSMutableArray *specs = [NSMutableArray arrayWithCapacity:(NSUInteger)count];
+	for (int index = 0; index < count; index++) {
+		[specs addObject:[NSValue valueWithBytes:&bars[index] objCType:@encode(MimiStackbar)]];
+	}
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (!gBars) {
+			gBars = [NSMutableArray array];
+		}
+
+		while (gBars.count < specs.count) {
+			[gBars addObject:mimiStackbarWindow()];
+		}
+
+		for (NSUInteger index = 0; index < specs.count; index++) {
+			MimiStackbar spec;
+			[specs[index] getValue:&spec size:sizeof(spec)];
+
+			NSWindow *bar = gBars[index];
+			CGRect frame =
+			    CGRectMake(spec.x + kMimiStackbarInset, spec.y, spec.width - 2 * kMimiStackbarInset, styleCopy.height);
+			if (frame.size.width <= 0) {
+				[bar orderOut:nil];
+				continue;
+			}
+
+			[bar setFrame:mimiStackbarCocoaRect(frame) display:NO];
+			mimiStackbarDraw(bar, spec, styleCopy);
+			[bar orderFrontRegardless];
+		}
+
+		// The windows past the ones just drawn belong to stacks that are
+		// gone. They are kept for the next sync rather than released.
+		for (NSUInteger index = specs.count; index < gBars.count; index++) {
+			[gBars[index] orderOut:nil];
+		}
+	});
+}
+
+void MimiStackbarsClear(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		for (NSWindow *bar in gBars) {
+			[bar orderOut:nil];
+		}
+		[gBars removeAllObjects];
+	});
+}

--- a/internal/stackbar/native.go
+++ b/internal/stackbar/native.go
@@ -1,0 +1,43 @@
+package stackbar
+
+import (
+	"github.com/y3owk1n/mimi/internal/native"
+)
+
+// nativeDrawer draws the indicators with the window server.
+type nativeDrawer struct{}
+
+// NativeDrawer draws the indicators on the desktop mimi runs on.
+func NativeDrawer() Drawer {
+	return nativeDrawer{}
+}
+
+func (nativeDrawer) Sync(bars []Bar, style Style) {
+	native.SyncStackbars(barsOf(bars), native.StackbarStyle{
+		Color:       native.Color(style.Color),
+		ActiveColor: native.Color(style.ActiveColor),
+		Height:      style.Height,
+		Radius:      style.Radius,
+	})
+}
+
+func (nativeDrawer) Clear() {
+	native.ClearStackbars()
+}
+
+// barsOf is the bars in the shape the window server takes them.
+func barsOf(bars []Bar) []native.Stackbar {
+	drawn := make([]native.Stackbar, len(bars))
+	for index, bar := range bars {
+		drawn[index] = native.Stackbar{
+			Left:   bar.Frame.X,
+			Top:    bar.Frame.Y,
+			Width:  bar.Frame.Width,
+			Height: bar.Frame.Height,
+			Count:  bar.Count,
+			Active: bar.Active,
+		}
+	}
+
+	return drawn
+}

--- a/internal/stackbar/stackbar.go
+++ b/internal/stackbar/stackbar.go
@@ -1,0 +1,170 @@
+// Package stackbar marks the places where a layout put several windows in
+// one frame, so the ones behind the top one can be seen to be there.
+//
+// A stack is the layout's idea, not mimi's: the engine gives every member the
+// frame the layout returned and changes no z-order, because macOS offers no
+// way to raise one application's window above another's without also focusing
+// it. What is left invisible is that there is more than one window in that
+// place at all, and this is what says so.
+package stackbar
+
+import (
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/tiling"
+)
+
+// Bar is one stack as it is drawn: the frame its windows share, how many
+// there are, and which of them, counting from 0, is the one to mark.
+type Bar struct {
+	Frame  action.Frame
+	Count  int
+	Active int
+}
+
+// Drawer puts the indicators on screen. The real one is the native overlay;
+// the tests use a fake.
+type Drawer interface {
+	Sync(bars []Bar, style Style)
+	Clear()
+}
+
+// Style is how an indicator is drawn, with its colors already parsed.
+type Style struct {
+	Color       Color
+	ActiveColor Color
+	Height      float64
+	Radius      float64
+}
+
+// Color is one parsed color, each part from 0 to 1.
+type Color struct {
+	Red, Green, Blue, Alpha float64
+}
+
+// Tracker draws the stacks the engine reports. It is safe to use from several
+// goroutines: the engine reports from a pass, and a reload replaces the style
+// from the signal loop.
+type Tracker struct {
+	draw   Drawer
+	logger *zap.SugaredLogger
+
+	mu      sync.Mutex
+	enabled bool
+	style   Style
+	// shown is how many bars are on screen, so a report of none after none
+	// draws nothing rather than calling into the window server again.
+	shown int
+}
+
+// New returns a tracker that draws nothing until Update enables it.
+func New(draw Drawer, logger *zap.SugaredLogger) *Tracker {
+	if logger == nil {
+		logger = zap.NewNop().Sugar()
+	}
+
+	return &Tracker{draw: draw, logger: logger}
+}
+
+// Update applies the [tiling.stackbar] section. Switching it off takes every
+// indicator off screen at once rather than waiting for the next pass, since
+// there may not be one.
+func (t *Tracker) Update(cfg config.StackbarConfig) {
+	t.mu.Lock()
+
+	style, err := styleOf(cfg)
+	if err != nil {
+		t.mu.Unlock()
+		// The config was validated before it got here, so this is a
+		// build that let an unparseable color through rather than
+		// anything the user can fix.
+		t.logger.Warnw("stack indicator disabled: its colors do not parse", "err", err)
+
+		return
+	}
+
+	wasEnabled := t.enabled
+	t.enabled, t.style = cfg.Enabled, style
+
+	switchedOff := wasEnabled && !cfg.Enabled && t.shown > 0
+	if switchedOff {
+		t.shown = 0
+	}
+
+	t.mu.Unlock()
+
+	if switchedOff {
+		t.draw.Clear()
+	}
+}
+
+// Sync draws exactly these stacks and no others. It is what the engine calls
+// at the end of every pass, with every display's stacks at once.
+func (t *Tracker) Sync(stacks []tiling.PlacedStack) {
+	t.mu.Lock()
+
+	if !t.enabled {
+		t.mu.Unlock()
+
+		return
+	}
+
+	bars := make([]Bar, 0, len(stacks))
+
+	for _, stack := range stacks {
+		bars = append(bars, Bar{
+			Frame:  stack.Frame,
+			Count:  len(stack.Windows),
+			Active: activeIndex(stack.Stack),
+		})
+	}
+
+	if len(bars) == 0 && t.shown == 0 {
+		t.mu.Unlock()
+
+		return
+	}
+
+	style := t.style
+	t.shown = len(bars)
+
+	t.mu.Unlock()
+
+	t.draw.Sync(bars, style)
+}
+
+// activeIndex is where the member the layout means to be seen sits among the
+// stack's windows, or 0 when it names one that is not in the stack.
+func activeIndex(stack tiling.Stack) int {
+	for index, number := range stack.Windows {
+		if number == stack.Active {
+			return index
+		}
+	}
+
+	return 0
+}
+
+// styleOf parses the colors in the config once, so a pass never parses one.
+func styleOf(cfg config.StackbarConfig) (Style, error) {
+	color, err := config.ParseColor(cfg.Color)
+	if err != nil {
+		return Style{}, err
+	}
+
+	active, err := config.ParseColor(cfg.ActiveColor)
+	if err != nil {
+		return Style{}, err
+	}
+
+	return Style{
+		Color:       Color(color),
+		ActiveColor: Color(active),
+		Height:      cfg.Height,
+		Radius:      cfg.Radius,
+	}, nil
+}

--- a/internal/stackbar/stackbar_test.go
+++ b/internal/stackbar/stackbar_test.go
@@ -1,0 +1,180 @@
+package stackbar_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/config"
+	"github.com/y3owk1n/mimi/internal/stackbar"
+	"github.com/y3owk1n/mimi/internal/tiling"
+)
+
+// fakeDrawer records what it was asked to draw.
+type fakeDrawer struct {
+	mu     sync.Mutex
+	syncs  [][]stackbar.Bar
+	clears int
+}
+
+func (d *fakeDrawer) Sync(bars []stackbar.Bar, _ stackbar.Style) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.syncs = append(d.syncs, bars)
+}
+
+func (d *fakeDrawer) Clear() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.clears++
+}
+
+func (d *fakeDrawer) last() []stackbar.Bar {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if len(d.syncs) == 0 {
+		return nil
+	}
+
+	return d.syncs[len(d.syncs)-1]
+}
+
+func (d *fakeDrawer) counts() (int, int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return len(d.syncs), d.clears
+}
+
+func enabled() config.StackbarConfig {
+	return config.StackbarConfig{
+		Enabled:     true,
+		Color:       "#60e2e2e3",
+		ActiveColor: "#e2e2e3",
+		Height:      4,
+		Radius:      2,
+	}
+}
+
+func stackOf(active uint32, windows ...uint32) tiling.PlacedStack {
+	return tiling.PlacedStack{
+		Stack: tiling.Stack{Windows: windows, Active: active},
+		Frame: action.Frame{X: 10, Y: 20, Width: 300, Height: 400},
+	}
+}
+
+// TestTracker_Sync_DrawsOneBarPerStack pins what reaches the drawer: the frame
+// the stack's windows share, how many there are, and where the active one sits
+// among them, since that last is what the mark points at.
+func TestTracker_Sync_DrawsOneBarPerStack(t *testing.T) {
+	t.Parallel()
+
+	draw := &fakeDrawer{}
+	tracker := stackbar.New(draw, nil)
+	tracker.Update(enabled())
+
+	tracker.Sync([]tiling.PlacedStack{stackOf(4243, 4242, 4243, 4244)})
+
+	bars := draw.last()
+	if len(bars) != 1 {
+		t.Fatalf("drew %d bars, want 1", len(bars))
+	}
+
+	if bars[0].Count != 3 || bars[0].Active != 1 {
+		t.Fatalf("bar = %+v, want 3 windows with the second active", bars[0])
+	}
+
+	if bars[0].Frame.Width != 300 {
+		t.Fatalf("bar frame = %+v, want the frame the stack shares", bars[0].Frame)
+	}
+}
+
+// TestTracker_Sync_MarksTheFirstWhenActiveIsNotAMember pins that a layout
+// naming an active window that is not in the stack marks the first member
+// rather than nothing, since a bar with no mark reads as a bug.
+func TestTracker_Sync_MarksTheFirstWhenActiveIsNotAMember(t *testing.T) {
+	t.Parallel()
+
+	draw := &fakeDrawer{}
+	tracker := stackbar.New(draw, nil)
+	tracker.Update(enabled())
+
+	tracker.Sync([]tiling.PlacedStack{stackOf(9999, 4242, 4243)})
+
+	if bars := draw.last(); len(bars) != 1 || bars[0].Active != 0 {
+		t.Fatalf("bars = %+v, want the first member marked", bars)
+	}
+}
+
+// TestTracker_Sync_DrawsNothingWhileDisabled pins that the indicator is off by
+// default and costs a pass nothing when it is.
+func TestTracker_Sync_DrawsNothingWhileDisabled(t *testing.T) {
+	t.Parallel()
+
+	draw := &fakeDrawer{}
+	tracker := stackbar.New(draw, nil)
+
+	tracker.Sync([]tiling.PlacedStack{stackOf(4242, 4242, 4243)})
+
+	if syncs, clears := draw.counts(); syncs != 0 || clears != 0 {
+		t.Fatalf("drew %d times and cleared %d while disabled, want neither", syncs, clears)
+	}
+}
+
+// TestTracker_Update_ClearsWhatIsDrawnWhenSwitchedOff pins that switching the
+// indicator off takes it off screen at once, rather than leaving it until a
+// pass that may never come.
+func TestTracker_Update_ClearsWhatIsDrawnWhenSwitchedOff(t *testing.T) {
+	t.Parallel()
+
+	draw := &fakeDrawer{}
+	tracker := stackbar.New(draw, nil)
+	tracker.Update(enabled())
+	tracker.Sync([]tiling.PlacedStack{stackOf(4242, 4242, 4243)})
+
+	off := enabled()
+	off.Enabled = false
+	tracker.Update(off)
+
+	if _, clears := draw.counts(); clears != 1 {
+		t.Fatalf("cleared %d times, want 1", clears)
+	}
+
+	// And again is not another call into the window server.
+	tracker.Update(off)
+
+	if _, clears := draw.counts(); clears != 1 {
+		t.Fatalf("cleared %d times after a second off, want 1", clears)
+	}
+}
+
+// TestTracker_Sync_StopsDrawingWhenTheStacksGo pins that a pass with no stack
+// takes the last one off screen, and that the pass after it calls nothing.
+func TestTracker_Sync_StopsDrawingWhenTheStacksGo(t *testing.T) {
+	t.Parallel()
+
+	draw := &fakeDrawer{}
+	tracker := stackbar.New(draw, nil)
+	tracker.Update(enabled())
+
+	tracker.Sync([]tiling.PlacedStack{stackOf(4242, 4242, 4243)})
+	tracker.Sync(nil)
+
+	syncs, _ := draw.counts()
+	if syncs != 2 {
+		t.Fatalf("drew %d times, want the stack and then nothing", syncs)
+	}
+
+	if bars := draw.last(); len(bars) != 0 {
+		t.Fatalf("last draw = %+v, want no bars", bars)
+	}
+
+	tracker.Sync(nil)
+
+	if syncs, _ := draw.counts(); syncs != 2 {
+		t.Fatalf("drew %d times, want no call for a second pass with no stack", syncs)
+	}
+}

--- a/internal/tiling/contract.go
+++ b/internal/tiling/contract.go
@@ -51,6 +51,9 @@ type Input struct {
 	Focused  int                   `json:"focused"`
 	Windows  []action.WindowEntry  `json:"windows"`
 	State    json.RawMessage       `json:"state"`
+	// Stacks is the stacks the layout last named on this display, handed
+	// back for the same reason Unmanaged is.
+	Stacks []Stack `json:"stacks,omitempty"`
 	// Unmanaged is the windows on this display the layout last said it is
 	// not managing, by number. The engine hands the set back so that a
 	// layout restarted mid-session, or one that keeps its floats somewhere
@@ -90,6 +93,16 @@ type Output struct {
 	// layout uses it to act on the frames it returned, warping the cursor
 	// to the focused window say, once they are known to be applied.
 	After []string `json:"after,omitempty"`
+	// Stacks is the sets of windows this run put in one place, so that only
+	// one of each set is seen at a time. mimi draws an indicator over each,
+	// and hands them back on the next input.
+	//
+	// The engine gives every member the frame the layout returned for it and
+	// changes no z-order of its own, because macOS gives no way to raise one
+	// application's window above another's without also focusing it. So the
+	// member on top is the one with keyboard focus, and a layout moves
+	// between members with the Focus key.
+	Stacks []Stack `json:"stacks,omitempty"`
 	// Unmanaged is the windows this run was given that the layout is
 	// leaving alone, by number, such as the ones it floats.
 	//
@@ -101,6 +114,27 @@ type Output struct {
 	// run stays unmanaged until a later run for the same display leaves it
 	// out of this list.
 	Unmanaged []uint32 `json:"unmanaged,omitempty"`
+}
+
+// Stack is windows the layout put in one place, with the one it means to be
+// seen. Every member has the same frame, so the one in front hides the rest.
+//
+// Active is the member the layout wants seen. It is what the indicator marks,
+// and it is the layout's own reckoning rather than a reading of the desktop:
+// the member actually in front is the one with focus, which the input reports
+// as Focused and orders by each window's Order.
+type Stack struct {
+	Windows []uint32 `json:"windows"`
+	Active  uint32   `json:"active"`
+}
+
+// PlacedStack is a stack together with the frame its windows share, which is
+// what something drawing a mark over it needs and what the layout never has
+// to repeat: the engine already has every frame the layout returned.
+type PlacedStack struct {
+	Stack
+
+	Frame action.Frame `json:"frame"`
 }
 
 // Event kinds the engine reports beyond the hookable ones it forwards from

--- a/internal/tiling/engine.go
+++ b/internal/tiling/engine.go
@@ -88,6 +88,15 @@ type Engine struct {
 	// nothing else, because the window server counts window numbers up and
 	// does not hand one out twice.
 	unmanaged map[uint32]bool
+	// stacks is the stacks the layout last named, by display, so a run for
+	// one display never speaks for another's, each with the frame its
+	// windows share. The indicator is drawn from these and they are handed
+	// back on the next input.
+	stacks map[uint32][]PlacedStack
+	// onStacks is told every time the stacks change, so whatever draws them
+	// can follow. nil draws nothing, which is the CLI's engine and any
+	// build with the indicator switched off.
+	onStacks func([]PlacedStack)
 	// seen is every window number the last pass read, nil before the
 	// first, so a window_created pass can tell whether the window it was
 	// raised for has reached the window server's on-screen list yet.
@@ -143,6 +152,7 @@ func New(desktop Desktop, serialize Serializer, logger *zap.SugaredLogger) *Engi
 		logger:      logger,
 		states:      map[string]json.RawMessage{},
 		unmanaged:   map[uint32]bool{},
+		stacks:      map[uint32][]PlacedStack{},
 		writtenAt:   map[string]uint64{},
 		pending:     map[string]bool{},
 		applied:     map[uint32]action.Frame{},
@@ -238,6 +248,16 @@ func (e *Engine) SetMouse(down func() bool) {
 	defer e.mu.Unlock()
 
 	e.mouseDown = down
+}
+
+// SetStacks names what to tell when the stacks a layout named change. The
+// daemon hands in the indicator. A CLI engine hands in nothing, because
+// nothing it drew would outlive the process.
+func (e *Engine) SetStacks(onStacks func([]PlacedStack)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.onStacks = onStacks
 }
 
 // Enabled reports whether a pass would run anything.
@@ -551,7 +571,10 @@ func (e *Engine) passLocked(ctx context.Context, event Event) error {
 		after = append(after, out.After...)
 
 		e.keepUnmanaged(input, out.Unmanaged)
+		e.keepStacks(input, out.Frames, out.Stacks)
 	}
+
+	e.tellStacks()
 
 	if len(frames) == 0 && focus == 0 && len(before) == 0 && len(after) == 0 {
 		return nil
@@ -749,6 +772,85 @@ func (e *Engine) keepUnmanaged(input Input, unmanaged []uint32) {
 	for _, number := range unmanaged {
 		e.unmanaged[number] = true
 	}
+}
+
+// stackNeeds is how many windows make a stack. One window in a place of its
+// own is what every layout does with every window, and marking that would
+// mark the whole desktop.
+const stackNeeds = 2
+
+// keepStacks records the stacks this run named, for the display it was for.
+//
+// A stack is dropped rather than kept when it names fewer than two windows, or
+// names one this run returned no frame for, because an indicator drawn over a
+// window that is not where the layout said would point at nothing. A dropped
+// stack costs the pass nothing else: the frames still apply. The caller holds
+// the lock.
+func (e *Engine) keepStacks(input Input, frames []action.WindowFrame, stacks []Stack) {
+	placed := make(map[uint32]action.Frame, len(frames))
+	for _, frame := range frames {
+		placed[frame.Number] = frame.Frame
+	}
+
+	kept := make([]PlacedStack, 0, len(stacks))
+
+	for _, stack := range stacks {
+		if len(stack.Windows) < stackNeeds {
+			e.logger.Debugw("stack ignored: fewer than two windows", "windows", len(stack.Windows))
+
+			continue
+		}
+
+		unplaced := uint32(0)
+
+		for _, number := range stack.Windows {
+			if _, ok := placed[number]; !ok {
+				unplaced = number
+
+				break
+			}
+		}
+
+		if unplaced != 0 {
+			e.logger.Debugw("stack ignored: a member has no frame", "window", unplaced)
+
+			continue
+		}
+
+		kept = append(kept, PlacedStack{Stack: stack, Frame: placed[stack.Windows[0]]})
+	}
+
+	if len(kept) == 0 {
+		delete(e.stacks, input.Display.ID)
+
+		return
+	}
+
+	e.stacks[input.Display.ID] = kept
+}
+
+// tellStacks hands every display's stacks to whatever draws them, in one
+// call, so the indicator is a picture of the whole desktop rather than of
+// whichever display ran last. The caller holds the lock.
+func (e *Engine) tellStacks() {
+	if e.onStacks == nil {
+		return
+	}
+
+	var all []PlacedStack
+
+	displays := make([]uint32, 0, len(e.stacks))
+	for display := range e.stacks {
+		displays = append(displays, display)
+	}
+
+	slices.Sort(displays)
+
+	for _, display := range displays {
+		all = append(all, e.stacks[display]...)
+	}
+
+	e.onStacks(all)
 }
 
 // stillPlaced is where the engine last put every window it is still watching,
@@ -1026,6 +1128,10 @@ func (e *Engine) buildInputsLocked(event Event, read desktopRead) []Input {
 			if e.unmanaged[win.Number] {
 				input.Unmanaged = append(input.Unmanaged, win.Number)
 			}
+		}
+
+		for _, stack := range e.stacks[display.ID] {
+			input.Stacks = append(input.Stacks, stack.Stack)
 		}
 
 		if key, named := stateKey(input); named {

--- a/internal/tiling/stacks_test.go
+++ b/internal/tiling/stacks_test.go
@@ -1,0 +1,171 @@
+package tiling_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/tiling"
+)
+
+// twoWindowDesktop is newDesktop with a second window, which is the fewest a
+// stack can be made of.
+func twoWindowDesktop() *fakeDesktop {
+	desktop := newDesktop()
+	desktop.windows = action.WindowsInfo{Focused: 0, Windows: []action.WindowEntry{
+		{Number: 1, PID: 10, App: "A", Frame: action.Frame{Width: 500, Height: 500}},
+		{Number: 2, PID: 11, App: "B", Frame: action.Frame{X: 500, Width: 500, Height: 500}},
+	}}
+
+	return desktop
+}
+
+// heard collects what the engine tells about stacks.
+type heard struct {
+	mu     sync.Mutex
+	stacks [][]tiling.PlacedStack
+}
+
+func (h *heard) note(stacks []tiling.PlacedStack) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.stacks = append(h.stacks, stacks)
+}
+
+func (h *heard) last() []tiling.PlacedStack {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if len(h.stacks) == 0 {
+		return nil
+	}
+
+	return h.stacks[len(h.stacks)-1]
+}
+
+// stacking is a layout that puts both windows in one place and names that a
+// stack, which is what a stacking layout does.
+const stacking = `jq -c '{frames: [` +
+	`{number: 1, frame: {x: 0, y: 0, width: 500, height: 500}},` +
+	`{number: 2, frame: {x: 0, y: 0, width: 500, height: 500}}], ` +
+	`stacks: [{windows: [1, 2], active: 2}], state: {stacked: true}}'`
+
+// TestEngine_Pass_TellsTheStacksALayoutNamed pins that a stack reaches
+// whatever draws it, with the frame its windows share, since that frame is
+// the one thing the layout does not repeat in the stack itself.
+func TestEngine_Pass_TellsTheStacksALayoutNamed(t *testing.T) {
+	t.Parallel()
+
+	desktop := twoWindowDesktop()
+	told := &heard{}
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.SetStacks(told.note)
+	engine.Update(enabled(stacking), shell)
+
+	err := engine.Pass(context.Background(), tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	stacks := told.last()
+	if len(stacks) != 1 {
+		t.Fatalf("told %d stacks, want 1: %+v", len(stacks), stacks)
+	}
+
+	stack := stacks[0]
+	if len(stack.Windows) != 2 || stack.Active != 2 {
+		t.Fatalf("stack = %+v, want windows [1 2] active 2", stack.Stack)
+	}
+
+	want := action.Frame{Width: 500, Height: 500}
+	if stack.Frame != want {
+		t.Fatalf("stack frame = %+v, want %+v", stack.Frame, want)
+	}
+}
+
+// TestEngine_Pass_HandsTheStacksBack pins that a layout is told the stacks it
+// named last time, so one that lost its own state can pick them up again.
+func TestEngine_Pass_HandsTheStacksBack(t *testing.T) {
+	t.Parallel()
+
+	desktop := twoWindowDesktop()
+
+	engine := tiling.New(desktop, nil, nil)
+	engine.Update(enabled(stacking), shell)
+
+	ctx := context.Background()
+
+	err := engine.Pass(ctx, tiling.Event{Kind: created})
+	if err != nil {
+		t.Fatalf("Pass() error = %v", err)
+	}
+
+	inputs, _, err := engine.Preview(ctx, tiling.Event{Kind: tiling.EventPreview})
+	if err != nil {
+		t.Fatalf("Preview() error = %v", err)
+	}
+
+	if len(inputs[0].Stacks) != 1 {
+		t.Fatalf("input carried %d stacks, want 1", len(inputs[0].Stacks))
+	}
+
+	if got := inputs[0].Stacks[0]; len(got.Windows) != 2 || got.Active != 2 {
+		t.Fatalf("input stack = %+v, want windows [1 2] active 2", got)
+	}
+}
+
+// TestEngine_Pass_DropsAStackItCannotDraw pins the two a stack is refused
+// for: a member with no frame, whose mark would sit where nothing is, and a
+// stack of one, which is every window in every layout.
+func TestEngine_Pass_DropsAStackItCannotDraw(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		layout string
+	}{
+		{
+			name: "a member with no frame",
+			layout: `jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 500, height: 500}}], ` +
+				`stacks: [{windows: [1, 2], active: 1}], state: {}}'`,
+		},
+		{
+			name: "a stack of one",
+			layout: `jq -c '{frames: [{number: 1, frame: {x: 0, y: 0, width: 500, height: 500}}], ` +
+				`stacks: [{windows: [1], active: 1}], state: {}}'`,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			desktop := twoWindowDesktop()
+			told := &heard{}
+
+			engine := tiling.New(desktop, nil, nil)
+			engine.SetStacks(told.note)
+			engine.Update(enabled(testCase.layout), shell)
+
+			// The frames still apply; only the stack is refused.
+			err := engine.Pass(context.Background(), tiling.Event{Kind: created})
+			if err != nil {
+				t.Fatalf("Pass() error = %v", err)
+			}
+
+			if stacks := told.last(); len(stacks) != 0 {
+				t.Fatalf("told %+v, want no stack", stacks)
+			}
+
+			if len(desktop.applied) != 1 {
+				t.Fatalf(
+					"applied %d times, want the frames to have been written",
+					len(desktop.applied),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR lets a layout put several windows in one place and have mimi say so.

Giving two windows the same frame was always possible, and always invisible.
Only the window in front is seen, and nothing on screen says the others are
there, so a column of four windows looks exactly like a column of one. That is
why no shipped layout has ever done it.

A layout now names its stacks in its output, and mimi draws a small bar along
the top of the frame they share, one segment per window with the active one in
its own colour. The mark is the feature. Everything else was already there.

## Related Issues

None.

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

Not attached. The mark is a 4pt bar along the top edge of a stacked column,
which a screenshot conveys poorly at this size. What I checked live is under
Additional Context, and `[tiling.stackbar]` is off by default so the change is
invisible until switched on.

## Config changes

One new table. It is off by default, so nothing changes for anyone who does
not switch it on.

```toml
[tiling.stackbar]
enabled = true
color = "#60e2e2e3"
active_color = "#e2e2e3"
height = 4
radius = 2
```

| Key | Default | Meaning |
| --- | --- | --- |
| `enabled` | `false` | Mark the stacks a layout names |
| `color` | `#60e2e2e3` | The colour of a window in the stack |
| `active_color` | `#e2e2e3` | The colour of the one the layout means to be seen |
| `height` | `4` | How tall the bar is, in points, up to 40 |
| `radius` | `2` | The corner radius of each segment, in points |

Colours are `#rrggbb` or `#aarrggbb`, alpha first, as everywhere else. The
table sits inside `[tiling]`, which is reloadable as a whole, so every key is.
Like the drop zone, it switches itself off without Accessibility or with
tiling disabled.

## Layout contract changes

One optional key each way, both additive. A layout that names no stack behaves
exactly as it did, and the input version does not move.

**Output**: `"stacks": [{"windows": [4242, 4244], "active": 4242}]`

**Input**: the same stacks it last named on that display, handed back.

Every member needs its own frame in the same `frames`. A stack naming fewer
than two windows, or one with no frame, is dropped with a debug line and the
frames still apply.

`rules.py` gains the `stacks` argument to `write_output`, and
`examples/tiling/stacked.py` is a new example: equal columns where a column
holds one window or several, answering `stack`, `unstack`, `next` and `prev`.

`monocle.py` also names one now, which costs it five lines. Every window in
monocle already fills the display, so they were always one stack, and a
display with six windows on it looked exactly like a display with one. It can
finally say how many there are.

`configs/default-config.toml` documents the new table alongside the others.

No command, flag, or `mimi_*` variable changes.

## Why the engine changes no z-order

This is the part worth reviewing. The obvious design is for the engine to
raise the member the layout names and leave focus alone. It cannot, and I
measured rather than assumed. Run against a window belonging to another
application, from mimi's own connection:

| Call | Result |
| --- | --- |
| `SLSOrderWindow` front below second | `kCGErrorFailure` (1000), no change |
| `SLSOrderWindow` second above front | `kCGErrorFailure` (1000), no change |
| `SLSOrderWindow` either relative to 0 | `kCGErrorFailure` (1000), no change |
| `SLSSetWindowLevel` on a foreign window | returned 0, no change |

The window server takes these only from a connection with the scripting
addition, which needs SIP disabled. And the only raise mimi has,
`MimiRaiseWindowNumber`, goes through `MimiActivateWindow`, which activates
the app and sets `kAXMain` and `kAXFocused` before it raises.

So the window seen in a stack is the one with keyboard focus, and a layout
moves between members with the `focus` key it already had.
`docs/adr/0006-a-stack-is-windows-sharing-a-frame-with-focus-on-top.md`
records this along with the three alternatives it rules out (minimising the
others, moving them off screen, raising them).

One consequence: `active` is the layout's own reckoning, not a reading of the
desktop, and Cmd-Tab can surface a buried member without telling the layout.
The input reports what is really in front through `focused` and each window's
`order`, so a layout that cares can reconcile. mimi does not reconcile for it.

## Additional Context

Checked live with three real windows and `stacked.py`. `stack` put Safari and
Ghostty in one column at the same frame and width with Notes beside them, the
engine's own state showed the columns, the bar drew two segments, and `next`
alternated the front window between the two across three presses. The
indicator switches its lit segment with them.

Five unit tests cover the indicator (what reaches the drawer, an `active` that
names no member, staying quiet while disabled, clearing when switched off,
and stopping when the stacks go) and four cover the engine (what it reports,
what it hands back, and the two shapes of stack it refuses).

Deliberately not in this PR: `strip.py` and `bsp.py`. A tabbed column in
`strip.py` is the natural next step, and a small change to `frames_for`, but
it is the layout most people actually run and deserves its own PR now the
primitive is proven. `bsp.py` wants a leaf that holds several windows, which
is a real change to its tree and a larger piece of work. `columns.py` is
deliberately the one with no state and no commands, so stacking does not
belong there at all.
