### PR TITLE
fix(cli): show a layout's input when the layout is resident

### DIFF
--- a/cmd/mimi/cmd/tiling.go
+++ b/cmd/mimi/cmd/tiling.go
@@ -328,9 +328,7 @@ func previewLayout(cobraCmd *cobra.Command, cfg *config.Config, inputOnly bool) 
 	engine := tiling.New(tiling.LiveDesktop{}, nil, nil)
 
 	if inputOnly {
-		layout := cfg.Tiling
-		layout.Layout = "cat >/dev/null"
-		engine.Update(layout, cfg.Settings.HookShell)
+		engine.Update(inputOnlyLayout(cfg.Tiling), cfg.Settings.HookShell)
 	} else {
 		if cfg.Tiling.Layout == "" {
 			return nil, derrors.New(derrors.CodeInvalidConfig, "tiling.layout is not set")
@@ -371,6 +369,23 @@ func previewLayout(cobraCmd *cobra.Command, cfg *config.Config, inputOnly bool) 
 	}
 
 	return previews, nil
+}
+
+// inputOnlyLayout is the [tiling] section with the layout swapped for one
+// that reads its input and answers nothing, which is what --input runs: the
+// inputs are what is wanted and the layout is not to be run at all.
+//
+// The mode is forced to oneshot along with it. A layout that answers nothing
+// is read as an empty output when it is a process per pass and simply exits,
+// but a resident one is read a line at a time and is expected to print one
+// per input. Left resident, the substitute never answers, the pass fails, and
+// --input reports that the layout exited without answering rather than
+// printing the inputs.
+func inputOnlyLayout(cfg config.TilingConfig) config.TilingConfig {
+	cfg.Layout = "cat >/dev/null"
+	cfg.LayoutMode = config.LayoutModeOneshot
+
+	return cfg
 }
 
 // previewOutput is one display's Output printed the way the layout printed

--- a/cmd/mimi/cmd/tiling_test.go
+++ b/cmd/mimi/cmd/tiling_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/y3owk1n/mimi/internal/action"
+	"github.com/y3owk1n/mimi/internal/config"
 	derrors "github.com/y3owk1n/mimi/internal/errors"
 	"github.com/y3owk1n/mimi/internal/ipc"
 )
@@ -163,4 +164,35 @@ func waitForSocket(t *testing.T, socketPath string) {
 	}
 
 	t.Fatalf("socket %s never came up", socketPath)
+}
+
+// TestInputOnlyLayout_RunsOnceWhateverTheConfigSays pins the fix for a preview
+// that would not answer: --input swaps the layout for one that prints nothing,
+// which reads as an empty output from a process that exits and never answers
+// at all from a resident one. The substitute is run as a one-shot whatever
+// mode the user's own layout is named with.
+func TestInputOnlyLayout_RunsOnceWhateverTheConfigSays(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{config.LayoutModeOneshot, config.LayoutModeResident, ""}
+
+	for _, mode := range tests {
+		t.Run("named as "+mode, func(t *testing.T) {
+			t.Parallel()
+
+			got := inputOnlyLayout(config.TilingConfig{
+				Enabled:    true,
+				Layout:     "my-layout",
+				LayoutMode: mode,
+			})
+
+			if got.LayoutMode != config.LayoutModeOneshot {
+				t.Fatalf("layout_mode = %q, want %q", got.LayoutMode, config.LayoutModeOneshot)
+			}
+
+			if got.Layout == "my-layout" {
+				t.Fatal("the user's layout would be run, and --input runs none")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

This PR fixes `mimi tiling preview --input` printing nothing when
`layout_mode = "resident"`.

That command shows the JSON a layout would be given without running it, and it
arranges that by swapping the layout for a command that reads its input and
prints nothing. It left `layout_mode` alone, though. A substitute that prints
nothing exits cleanly as a one-shot and its silence reads as an empty output,
so the inputs come back. As a resident layout it is read a line at a time and
expected to answer every input, never does, and the pass fails before the
inputs are returned.

So with a resident layout the command failed with `layout exited without
answering` and printed nothing. The substitute now runs as a one-shot whatever
the config names, since it is a one-shot by nature.

## Related Issues

None.

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] Linters pass (`just lint`)
- [x] Tests pass (`just test`)
- [x] Build succeeds (`just build`)
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, the documented behaviour was already what this now does
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Recordings

N/A, one command prints where it printed nothing.

## Additional Context

Reproduced against a real config naming a resident layout:

```
$ mimi tiling preview --input
Error: [ACTION_FAILED] layout exited without answering

$ mimi tiling preview --input | jq -c '.[0] | {display: .display.id, windows: (.windows|length)}'
{"display":3,"windows":3}
```

The same config with `layout_mode = "oneshot"` always worked, which is what
narrowed it down. A plain `mimi tiling preview` was never affected and still
runs the real layout in the mode the config asks for; I checked that too.

Nothing a user types or writes changes, and the documented behaviour of
`--input` is already what it now does.

The substitution moved into a small function so the rule can be pinned
directly: the mode it produces is one-shot whether the config names oneshot,
resident, or nothing at all.
